### PR TITLE
Fix grade string display on linux

### DIFF
--- a/Main/GUI/SongSelectItem.cpp
+++ b/Main/GUI/SongSelectItem.cpp
@@ -288,7 +288,7 @@ void SongSelectItem::SetSelectedDifficulty(int32 selectedIndex)
 				L"D",
 			};
 
-			m_score->SetText(Utility::WSprintf(L"%08d\n%d%%\n%s", score, gaugeDisplay, gradeStrings[grade]));
+			m_score->SetText(Utility::WSprintf(L"%08d\n%d%%\n%ls", score, gaugeDisplay, gradeStrings[grade]));
 		}
 		else
 		{


### PR DESCRIPTION
Now displays full string instead of first char. Should also still work on Windows.