### PR TITLE
Resize all cover art > 150x150 to 150x150

### DIFF
--- a/Graphics/include/Graphics/Image.hpp
+++ b/Graphics/include/Graphics/Image.hpp
@@ -15,6 +15,7 @@ namespace Graphics
 		static Ref<ImageRes> Create(Vector2i size = Vector2i());
 	public:
 		virtual void SetSize(Vector2i size) = 0;
+		virtual void ReSize(Vector2i size) = 0;
 		virtual Vector2i GetSize() const = 0;
 		virtual Colori* GetBits() = 0;
 		virtual const Colori* GetBits() const = 0;

--- a/Graphics/src/Image.cpp
+++ b/Graphics/src/Image.cpp
@@ -39,6 +39,27 @@ namespace Graphics
 			Clear();
 			Allocate();
 		}
+		void ReSize(Vector2i size)
+		{
+			size_t new_DataLength = size.x * size.y;
+			if (new_DataLength == 0){
+				return;
+			}
+			Colori* new_pData = new Colori[new_DataLength];
+
+			for (int32 ix = 0; ix < size.x; ++ix){
+				for (int32 iy = 0; iy < size.y; ++iy){
+					int32 sampledX = ix * ((double)m_size.x / (double)size.x);
+					int32 sampledY = iy * ((double)m_size.y / (double)size.y);
+					new_pData[size.x * iy + ix] = m_pData[m_size.x * sampledY + sampledX];
+				}
+			}
+
+			delete[] m_pData;
+			m_pData = new_pData;
+			m_size = size;
+			m_nDataLength = m_size.x * m_size.y;
+		}
 		Vector2i GetSize() const
 		{
 			return m_size;


### PR DESCRIPTION
With  a sample database of several hundred songs, this drops memory usage from 3gb  down to below 1gb.

Also added a commented out section for evicting artwork from the cache based on last use time.