### PR TITLE
config for song select laser speed

### DIFF
--- a/Main/GameConfig.cpp
+++ b/Main/GameConfig.cpp
@@ -34,7 +34,7 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::UseCMod, false);
 	Set(GameConfigKeys::ModSpeed, 300.0f);
 	Set(GameConfigKeys::SongFolder, "songs");
-
+	Set(GameConfigKeys::SongSelectLaserSpeed, 3.0f);
 
 	// Input settings
 	SetEnum<Enum_InputDevice>(GameConfigKeys::ButtonInputDevice, InputDevice::Keyboard);

--- a/Main/GameConfig.hpp
+++ b/Main/GameConfig.hpp
@@ -21,6 +21,7 @@ DefineEnum(GameConfigKeys,
 	SongFolder,
 	FPSTarget,
 	LaserAssistLevel,
+	SongSelectLaserSpeed,
 
 	// Input device setting per element
 	LaserInputDevice,

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -675,8 +675,9 @@ public:
 		
 		
         // Song navigation using laser inputs
-        float diff_input = g_input.GetInputLaserDir(0);
-        float song_input = g_input.GetInputLaserDir(1);
+        float songSelectLaserSpeed = g_gameConfig.GetFloat(GameConfigKeys::SongSelectLaserSpeed);
+        float diff_input = g_input.GetInputLaserDir(0) * songSelectLaserSpeed;
+        float song_input = g_input.GetInputLaserDir(1) * songSelectLaserSpeed;
         
         m_advanceDiff += diff_input;
         m_advanceSong += song_input;


### PR DESCRIPTION
Adds config option for how fast song/difficulty select with lasers is. Fixes #26. 