### PR TITLE
Re-work how some of the song select internals work

### DIFF
--- a/Beatmap/src/MapDatabase.cpp
+++ b/Beatmap/src/MapDatabase.cpp
@@ -183,7 +183,11 @@ public:
 		m_pendingChangesLock.unlock();
 		return std::move(changes);
 	}
-	
+
+	Map<int32, MapIndex*> GetMaps()
+	{
+		return m_maps;
+	}
 	Map<int32, MapIndex*> FindMaps(const String& searchString)
 	{
 		WString test = Utility::ConvertToWString(searchString);
@@ -717,6 +721,10 @@ void MapDatabase::StartSearching()
 void MapDatabase::StopSearching()
 {
 	m_impl->StopSearching();
+}
+Map<int32, MapIndex*> MapDatabase::GetMaps()
+{
+	return m_impl->GetMaps();
 }
 Map<int32, MapIndex*> MapDatabase::FindMaps(const String& search)
 {

--- a/Main/SongFilter.cpp
+++ b/Main/SongFilter.cpp
@@ -30,15 +30,20 @@ bool LevelFilter::IsAll()
 
 Map<int32, SongSelectIndex> FolderFilter::GetFiltered(const Map<int32, SongSelectIndex>& source)
 {
-	Map<int32, MapIndex*> maps = m_mapDatabase->FindMapsByFolder(m_folder);
-
 	Map<int32, SongSelectIndex> filtered;
-	for (auto m : maps)
+	String folder = "\\" + m_folder + "\\";
+	for (auto kvp : source)
 	{
-		SongSelectIndex index(m.second);
-		filtered.Add(index.id, index);
+		MapIndex* map = kvp.second.GetMap();
+		if (map->path.find(folder) != -1)
+		{
+			SongSelectIndex index(map);
+			filtered.Add(index.id, index);
+		}
 	}
+	Logf("%d items in filter for %s", Logger::Info, filtered.size(), m_folder);
 	return filtered;
+//	Map<int32, MapIndex*> maps = m_mapDatabase->FindMapsByFolder(m_folder);
 }
 
 String FolderFilter::GetName()

--- a/Main/SongFilter.hpp
+++ b/Main/SongFilter.hpp
@@ -33,13 +33,11 @@ private:
 class FolderFilter : public SongFilter
 {
 public:
-	FolderFilter(String folder, MapDatabase* database) : m_folder(folder), m_mapDatabase(database) {}
+	FolderFilter(String folder) : m_folder(folder) {}
 	virtual Map<int32, SongSelectIndex> GetFiltered(const Map<int32, SongSelectIndex>& source);
 	virtual String GetName() override;
 	virtual bool IsAll() override;
 
 private:
 	String m_folder;
-	MapDatabase* m_mapDatabase;
-
 };

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -282,8 +282,11 @@ public:
 	}
 	void m_SelectNearest(int32 id, MapIndex* map, DifficultyIndex* diff)
 	{
-		int32 resultId = 0;
 		Map<int32, SongSelectIndex> maps = m_SourceCollection();
+		int32 resultId = maps[0].id;
+		if (maps.empty())
+			resultId = 0;
+		else resultId = maps[0].id;
 
 		// attempt to get the exact id first, which is the pair of map/diff
 		auto exact = maps.Find(id);

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -790,9 +790,18 @@ public:
 				// m_previewPlayer.Restore();
 			}
 		} else{
-			// Wait at least 15 ticks before attempting to load song to prevent loading songs while scrolling very fast
-			m_previewDelayTicks = 15;
-			m_currentPreviewAudio = map;
+			// make sure that the map we got has difficulties, it's not garbage data
+			// TODO(local): This caused me problems when re-loading the game with different 
+			//  charts (one copied in directly to the bin/songs folder after changing the
+			//  settings from my ksm songs)
+			// Investigate where we need to guarantee that charts are loaded befure making
+			//  updates to audio and UI proper, then this can be removed again.
+			if (map->difficulties.size() > 0)
+			{
+				// Wait at least 15 ticks before attempting to load song to prevent loading songs while scrolling very fast
+				m_previewDelayTicks = 15;
+				m_currentPreviewAudio = map;
+			}
 			m_previewLoaded = false;
 		}
 	}

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -550,10 +550,18 @@ public:
 	void SetMapDB(MapDatabase* db)
 	{
 		m_mapDB = db;
+
+		Map<int32, SongSelectIndex> mapPool;
+		for (auto m : db->GetMaps())
+		{
+			SongSelectIndex index(m.second);
+			mapPool.Add(index.id, index);
+		}
+
 		for (String p : Path::GetSubDirs(g_gameConfig.GetString(GameConfigKeys::SongFolder)))
 		{
-			SongFilter* filter = new FolderFilter(p, m_mapDB);
-			if(filter->GetFiltered(Map<int32, SongSelectIndex>()).size() > 0)
+			SongFilter* filter = new FolderFilter(p);
+			if (filter->GetFiltered(mapPool).size() > 0)
 				AddFilter(filter);
 		}
 	}


### PR DESCRIPTION
This allows for the search bar to properly interact with the folder/level filters.

I commented out the database add/update/remove because I wasn't getting them to fire without seeing cleared as well. I hadn't tried to use those previous to any of my changes, so I'm not sure how or if they worked differently before, but it shouldn't be hard to look into the database code to see if they should fire separately and then make changes to this code again later. For now, song select just waits for a cleared event and refills the wheel.