### PR TITLE
export include paths from Graphics target

### DIFF
--- a/Graphics/CMakeLists.txt
+++ b/Graphics/CMakeLists.txt
@@ -59,6 +59,7 @@ else(WIN32)
 		include_directories(${X11_INCLUDE_DIR})
 	endif(APPLE)
 
-	include_directories(${FREETYPE_INCLUDE_DIRS})
-	find_package(Freetype REQUIRED)
+	get_target_property(gfx_includes Graphics INCLUDE_DIRECTORIES)
+	set_property(TARGET Graphics PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${gfx_includes})
+
 endif(WIN32)


### PR DESCRIPTION
Without this, all SDL2 includes (and probably a fair few others) in targets that depend on Graphics don't work.

Also, the two lines I removed are present in FindLibraries.cmake, which is included a few lines earlier.

With this change, building under macOS (High Sierra) works without a hitch 