### PR TITLE
Bindable back button

### DIFF
--- a/Main/Application.cpp
+++ b/Main/Application.cpp
@@ -1328,6 +1328,7 @@ void Application::m_SetNvgLuaBindings(lua_State * state)
 		pushIntToTable("BUTTON_FXL", (int)Input::Button::FX_0);
 		pushIntToTable("BUTTON_FXR", (int)Input::Button::FX_1);
 		pushIntToTable("BUTTON_STA", (int)Input::Button::BT_S);
+		pushIntToTable("BUTTON_BCK", (int)Input::Button::BT_B);
 
 		lua_setglobal(state, "game");
 	}

--- a/Main/Game.cpp
+++ b/Main/Game.cpp
@@ -1503,6 +1503,14 @@ public:
 				FinishGame();
 			}
 		}
+		else if (buttonCode == Input::Button::BT_B)
+		{
+			ObjectState *const* lastObj = &m_beatmap->GetLinearObjects().back();
+			MapTime timePastEnd = m_lastMapTime - m_endTime;
+			if (timePastEnd < 0)
+				m_manualExit = true;
+			FinishGame();
+		}
 	}
 	int m_getClearState()
 	{

--- a/Main/GameConfig.cpp
+++ b/Main/GameConfig.cpp
@@ -71,6 +71,7 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::Key_Laser1Pos, SDLK_p);
 	Set(GameConfigKeys::Key_Sensitivity, 3.0f);
 	Set(GameConfigKeys::Key_LaserReleaseTime, 0.0f);
+	Set(GameConfigKeys::Key_BTB, SDLK_ESCAPE);
 
 	// Default controller settings
 	Set(GameConfigKeys::Controller_DeviceID, 0); // First device
@@ -85,6 +86,7 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::Controller_Laser1Axis, 1);
 	Set(GameConfigKeys::Controller_Sensitivity, 1.0f);
 	Set(GameConfigKeys::Controller_Deadzone, 0.f);
+	Set(GameConfigKeys::Controller_BTB, 7);
 
 	// Default mouse settings
 	Set(GameConfigKeys::Mouse_Laser0Axis, 0);

--- a/Main/GameConfig.hpp
+++ b/Main/GameConfig.hpp
@@ -62,6 +62,7 @@ DefineEnum(GameConfigKeys,
 	Key_Laser1Neg,
 	Key_Sensitivity,
 	Key_LaserReleaseTime,
+	Key_BTB,
 
 	// Controller bindings
 	Controller_DeviceID,
@@ -77,6 +78,7 @@ DefineEnum(GameConfigKeys,
 	Controller_Deadzone,
 	Controller_Sensitivity,
 	InputBounceGuard,
+	Controller_BTB,
 
 	LastSelected,
 	LevelFilter,

--- a/Main/Input.cpp
+++ b/Main/Input.cpp
@@ -229,6 +229,7 @@ void Input::m_InitKeyboardMapping()
 		m_buttonMap.Add(g_gameConfig.GetInt(GameConfigKeys::Key_BT1), Button::BT_1);
 		m_buttonMap.Add(g_gameConfig.GetInt(GameConfigKeys::Key_BT2), Button::BT_2);
 		m_buttonMap.Add(g_gameConfig.GetInt(GameConfigKeys::Key_BT3), Button::BT_3);
+		m_buttonMap.Add(g_gameConfig.GetInt(GameConfigKeys::Key_BTB), Button::BT_B);
 		// Alternate button mappings
 		m_buttonMap.Add(g_gameConfig.GetInt(GameConfigKeys::Key_BT0Alt), Button::BT_0);
 		m_buttonMap.Add(g_gameConfig.GetInt(GameConfigKeys::Key_BT1Alt), Button::BT_1);
@@ -264,6 +265,7 @@ void Input::m_InitControllerMapping()
 		m_controllerMap.Add(g_gameConfig.GetInt(GameConfigKeys::Controller_BT3), Button::BT_3);
 		m_controllerMap.Add(g_gameConfig.GetInt(GameConfigKeys::Controller_FX0), Button::FX_0);
 		m_controllerMap.Add(g_gameConfig.GetInt(GameConfigKeys::Controller_FX1), Button::FX_1);
+		m_controllerMap.Add(g_gameConfig.GetInt(GameConfigKeys::Controller_BTB), Button::BT_B);
 	}
 }
 

--- a/Main/Input.hpp
+++ b/Main/Input.hpp
@@ -26,8 +26,8 @@ public:
 		LS_0Pos, // Left laser+		(|---->)
 		LS_1Neg, // Right laser-	(<----|)
 		LS_1Pos, // Right laser+
-		Length,
-		BT_B); // Back Button
+		BT_B,	// Back Button
+		Length)
 
 	~Input();
 	void Init(Graphics::Window& wnd);

--- a/Main/Input.hpp
+++ b/Main/Input.hpp
@@ -26,7 +26,8 @@ public:
 		LS_0Pos, // Left laser+		(|---->)
 		LS_1Neg, // Right laser-	(<----|)
 		LS_1Pos, // Right laser+
-		Length);
+		Length,
+		BT_B); // Back Button
 
 	~Input();
 	void Init(Graphics::Window& wnd);

--- a/Main/ScoreScreen.cpp
+++ b/Main/ScoreScreen.cpp
@@ -315,10 +315,10 @@ public:
 	{
 		// Check for button pressed here instead of adding to onbuttonpressed for stability reasons
 		//TODO: Change to onbuttonpressed
-		if(m_startPressed && !g_input.GetButton(Input::Button::BT_S))
+		if(m_startPressed && (!g_input.GetButton(Input::Button::BT_S) || !g_input.GetButton(Input::Button::BT_B)))
 			g_application->RemoveTickable(this);
 
-		m_startPressed = g_input.GetButton(Input::Button::BT_S);
+		m_startPressed = g_input.GetButton(Input::Button::BT_S) || g_input.GetButton(Input::Button::BT_B);
 
 		if (g_input.GetButton(Input::Button::FX_0))
 			m_showStats = true;

--- a/Main/SettingsScreen.cpp
+++ b/Main/SettingsScreen.cpp
@@ -59,7 +59,8 @@ private:
 		GameConfigKeys::Key_BT2,
 		GameConfigKeys::Key_BT3,
 		GameConfigKeys::Key_FX0,
-		GameConfigKeys::Key_FX1
+		GameConfigKeys::Key_FX1,
+		GameConfigKeys::Key_BTB
 	};
 
 	Vector<GameConfigKeys> m_keyboardLaserKeys = {
@@ -76,7 +77,8 @@ private:
 		GameConfigKeys::Controller_BT2,
 		GameConfigKeys::Controller_BT3,
 		GameConfigKeys::Controller_FX0,
-		GameConfigKeys::Controller_FX1
+		GameConfigKeys::Controller_FX1,
+		GameConfigKeys::Controller_BTB
 	};
 
 	Vector<GameConfigKeys> m_controllerLaserKeys = {
@@ -105,7 +107,7 @@ private:
 	float m_laserSens = 1.0f;
 	float m_masterVolume = 1.0f;
 	float m_laserColors[2] = { 0.25f, 0.75f };
-	String m_controllerButtonNames[7];
+	String m_controllerButtonNames[8];
 	String m_controllerLaserNames[2];
 	char m_songsPath[1024];
 	int m_pathlen = 0;
@@ -178,6 +180,14 @@ private:
 	void SetRL()
 	{
 		g_application->AddTickable(ButtonBindingScreen::Create(GameConfigKeys::Controller_Laser1Axis, m_laserMode == 2, m_selectedGamepad));
+	}
+
+	void SetKey_BK()
+	{
+		if (m_buttonMode == 1)
+			g_application->AddTickable(ButtonBindingScreen::Create(GameConfigKeys::Controller_BTB, true, m_selectedGamepad));
+		else
+			g_application->AddTickable(ButtonBindingScreen::Create(GameConfigKeys::Key_BTB));
 	}
 
 	void CalibrateSens()
@@ -368,7 +378,7 @@ public:
 		}
 		nk_input_end(m_nctx);
 
-		for (size_t i = 0; i < 7; i++)
+		for (size_t i = 0; i < 8; i++)
 		{
 			if (m_buttonMode == 1)
 			{
@@ -442,6 +452,9 @@ public:
 
 			nk_layout_row_dynamic(m_nctx, buttonheight, 1);
 			if (nk_button_label(m_nctx, "Calibrate Laser Sensitivity")) CalibrateSens();
+
+			nk_layout_row_dynamic(m_nctx, buttonheight, 1);
+			if (nk_button_label(m_nctx, m_controllerButtonNames[7].c_str())) SetKey_BK();
 
 			nk_labelf(m_nctx, nk_text_alignment::NK_TEXT_LEFT, "Laser sensitivity (%f):", m_laserSens);
 			nk_slider_float(m_nctx, 0, &m_laserSens, 20, 0.001);
@@ -778,6 +791,8 @@ public:
 				m_firstStart = true;
 			}
 		}
+		else if (button == Input::Button::BT_B)
+			g_application->RemoveTickable(this);
 	}
 
 	virtual void OnKeyPressed(int32 key)

--- a/Main/SettingsScreen.cpp
+++ b/Main/SettingsScreen.cpp
@@ -451,10 +451,10 @@ public:
 			if (nk_button_label(m_nctx, m_controllerButtonNames[6].c_str())) SetKey_FXR();
 
 			nk_layout_row_dynamic(m_nctx, buttonheight, 1);
-			if (nk_button_label(m_nctx, "Calibrate Laser Sensitivity")) CalibrateSens();
-
-			nk_layout_row_dynamic(m_nctx, buttonheight, 1);
 			if (nk_button_label(m_nctx, m_controllerButtonNames[7].c_str())) SetKey_BK();
+			
+			nk_layout_row_dynamic(m_nctx, buttonheight, 1);
+			if (nk_button_label(m_nctx, "Calibrate Laser Sensitivity")) CalibrateSens();
 
 			nk_labelf(m_nctx, nk_text_alignment::NK_TEXT_LEFT, "Laser sensitivity (%f):", m_laserSens);
 			nk_slider_float(m_nctx, 0, &m_laserSens, 20, 0.001);

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -1197,6 +1197,21 @@ public:
 					m_settingsWheel->Active = false;
 				}
 				break;
+			case Input::Button::BT_B:
+				if (m_settingsWheel->Active)
+				{
+					m_settingsWheel->Active = false;
+				}
+				else if (m_filterSelection->Active)
+				{
+					m_filterSelection->Active = !m_filterSelection->Active;
+				}
+				else
+				{
+					m_suspended = true;
+					g_application->RemoveTickable(this);
+				}
+
 			default:
 				break;
 			}


### PR DESCRIPTION
Pretty self explanatory. Defaults to ESC, but should be able to work with any other key.
Added on the Settings screen under the FX buttons.
I left the ESC hardcodes just in case. 

This partially solves #96 although not all of it.

This is a very common request for users of the Yuancon SDVX controller, as the back button is hardcoded in firmware to H.

I was not able to test the controller bindings with my setup.

It's worth nothing perhaps that since I added it to the Score Results screen, but due to how buttons are handled on that screen, if you have the bindable back button held when you enter it (such as pressing the bindable back button during gameplay to end a song), odds are good you'll skip past the score result screen unless you tap and release the button as fast as you can. I'm not sure how much this is a problem, but we can just remove that binding and force the user to use the start button to progress past the score results.