### PR TITLE
Check for extension before loading SFX sample

### DIFF
--- a/Main/Game.cpp
+++ b/Main/Game.cpp
@@ -873,7 +873,7 @@ public:
 		m_fxSamples = new Sample[samples.size()];
 		for (int i = 0; i < samples.size(); i++)
 		{
-			String ext = samples[i].substr(samples[i].length() - 4, 4);
+			String ext = samples[i].length() > 4 ? samples[i].substr(samples[i].length() - 4, 4) : "";
 			ext.ToUpper();
 			if (ext == ".WAV")
 			{


### PR DESCRIPTION
Some charts don't specify an extension for their samples ("2" instead of "2.wav"), this crashes the game since it causes an underflow when extracting the extension, trying to substract 4 from the string length (1).

This commit fixes that by checking the string is long enough before attempting to extract an extension from it.

I'm not exactly sure if this would be the optimal approach, so i'm open to feedback.