### PR TITLE
Fix issue with skins having `.` in their file path

### DIFF
--- a/Main/Application.cpp
+++ b/Main/Application.cpp
@@ -764,11 +764,12 @@ Sample Application::LoadSample(const String& name, const bool& external)
     else
         path = String("skins/") + m_skin + String("/audio/") + name;
 
+	path = Path::Normalize(path);
 	String ext = Path::GetExtension(path);
 	if (ext.empty())
 		path += ".wav";
 
-	Sample ret = g_audio->CreateSample(Path::Normalize(path));
+	Sample ret = g_audio->CreateSample(path);
 	assert(ret);
 	return ret;
 }

--- a/Shared/src/Path.cpp
+++ b/Shared/src/Path.cpp
@@ -59,29 +59,13 @@ String Path::RemoveBase(String path, String base)
 }
 String Path::GetExtension(const String& path)
 {
-	size_t dotPos = path.find(".");
-	if(dotPos == -1)
-		return String();
-	return path.substr(dotPos + 1);
-}
-String Path::ReplaceExtension(String path, String newExt)
-{
-	newExt.TrimFront('.');
-
-	// Remove everything in the extension and the dot
 	size_t dotPos = path.find_last_of(".");
-	if(dotPos != -1)
-	{
-		path.erase(path.begin() + dotPos, path.end());
-	}
-
-	if(newExt.empty())
-		return path;
-
-	path.push_back('.');
-	path += newExt;
-
-	return path;
+	if (dotPos == std::string::npos)
+		return String();
+	size_t sepPos = path.find_last_of(Path::sep);
+	if(sepPos == std::string::npos || dotPos > sepPos)
+		return path.substr(dotPos + 1);
+	return String();
 }
 String Path::ExtractPathFromCmdLine(String& input)
 {


### PR DESCRIPTION
Removed an unused extension related function while I was at it, didn't want to update it for no reason.