### PR TITLE
Add support for SwitchAudio effect

### DIFF
--- a/Beatmap/include/Beatmap/AudioEffects.hpp
+++ b/Beatmap/include/Beatmap/AudioEffects.hpp
@@ -22,6 +22,7 @@ DefineEnum(EffectType,
 	LowPassFilter,
 	HighPassFilter,
 	PeakingFilter,
+	SwitchAudio, // Not a real effect
 	UserDefined0 = 0x40, // This ID or higher is user for user defined effects inside map objects
 	UserDefined1,	// Keep this ID at least a few ID's away from the normal effect so more native effects can be added later
 	UserDefined2,
@@ -226,5 +227,10 @@ struct AudioEffect
 			// Cuttoff frequency (Hz)
 			EffectParam<float> freq;
 		} peaking;
+		struct
+		{
+			// Audio Index
+			EffectParam<int32> index;
+		} switchaudio;
 	};
 };

--- a/Beatmap/include/Beatmap/Beatmap.hpp
+++ b/Beatmap/include/Beatmap/Beatmap.hpp
@@ -86,6 +86,8 @@ public:
 
 	const Vector<String>& GetSamplePaths() const;
 
+	const Vector<String>& GetSwitchablePaths() const;
+
 	// Retrieves audio effect settings for a given button id
 	AudioEffect GetEffect(EffectType type) const;
 	// Retrieves audio effect settings for a given filter effect id
@@ -104,6 +106,7 @@ private:
 	Vector<ObjectState*> m_objectStates;
 	Vector<ZoomControlPoint*> m_zoomControlPoints;
 	Vector<String> m_samplePaths;
+	Vector<String> m_switchablePaths;
 	BeatmapSettings m_settings;
 	
 };

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -106,6 +106,9 @@ static AudioEffect CreateDefault(EffectType type)
 		ret.flanger.offset = IntRange(10);
 		ret.flanger.depth = IntRange(40);
 		break;
+	case EffectType::SwitchAudio:
+		ret.switchaudio.index = -1;
+		break;
 	}
 
 	return ret;

--- a/Beatmap/src/Beatmap.cpp
+++ b/Beatmap/src/Beatmap.cpp
@@ -92,6 +92,11 @@ const Vector<String>& Beatmap::GetSamplePaths() const
 	return m_samplePaths;
 }
 
+const Vector<String>& Beatmap::GetSwitchablePaths() const
+{
+	return m_switchablePaths;
+}
+
 AudioEffect Beatmap::GetEffect(EffectType type) const
 {
 	if(type >= EffectType::UserDefined0)

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -181,6 +181,13 @@ static MultiParam ParseParam(const String& in)
 		ret.type = MultiParam::Samples;
 		sscanf(*in, "%i", &ret.ival);
 	}
+	else if (in.find("%") != -1)
+	{
+		ret.type = MultiParam::Float;
+		int percentage = 0;
+		sscanf(*in, "%i", &percentage);
+		ret.fval = percentage / 100.0;
+	}
 	else
 	{
 		ret.type = MultiParam::Int;
@@ -212,24 +219,32 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition& def)
 		}
 		else
 		{
-			size_t split = s.second.find('-', 1);
+			size_t splitArrow = s.second.find('>', 1);
+			String param;
+			if (splitArrow != -1)
+			{
+				param = s.second.substr(splitArrow + 1);
+			} else {
+				param = s.second;
+			}
+			size_t split = param.find('-', 1);
 			if (split != -1)
 			{
 				String a, b;
-				a = s.second.substr(0, split);
-				b = s.second.substr(split + 1);
+				a = param.substr(0, split);
+				b = param.substr(split + 1);
 
 				MultiParamRange pr = { ParseParam(a), ParseParam(b) };
 				if (pr.params[0].type != pr.params[1].type)
 				{
-					Logf("Non matching parameters types \"[%s, %s]\" for key: %s", Logger::Warning, s.first, s.second, s.first);
+					Logf("Non matching parameters types \"[%s, %s]\" for key: %s", Logger::Warning, s.first, param, s.first);
 					continue;
 				}
 				params.Add(s.first, pr);
 			}
 			else
 			{
-				params.Add(s.first, ParseParam(s.second));
+				params.Add(s.first, ParseParam(param));
 			}
 		}
 	}

--- a/Main/Audio/AudioPlayback.hpp
+++ b/Main/Audio/AudioPlayback.hpp
@@ -19,6 +19,11 @@ public:
 	void SetParams(DSP* dsp, AudioPlayback& playback, HoldObjectState* object);
 };
 
+struct SwitchableAudio {
+	bool m_enabled;
+	AudioStream m_audio;
+};
+
 /* 
 	Handles playback of map audio
 	keeps track of the state of sound effects
@@ -66,6 +71,10 @@ public:
 	// Toggle FX track or normal track
 	// this is just to support maps that do actually have an FX track
 	void SetFXTrackEnabled(bool enabled);
+	
+	// Switch audio track
+	void SetSwitchableTrackEnabled(int index, bool enabled);
+	void ResetSwitchableTracks();
 
 	BeatmapPlayback& GetBeatmapPlayback();
 	const Beatmap& GetBeatmap() const;
@@ -88,6 +97,13 @@ private:
 
 	AudioStream m_music;
 	AudioStream m_fxtrack;
+	Vector<SwitchableAudio> m_switchables;
+	Vector<int32> m_enabledSwitchables;
+	int32 m_laserSwitchable = -1;
+	
+
+	float m_musicVolume = 1.0f;
+
 	bool m_paused = false;
 	bool m_fxtrackEnabled = true;
 


### PR DESCRIPTION
Since there's already a fxtrack, the audio tracks for SwitchAudio effect are referred as switchables in code.

Notes:
- Beatmap is changed.
- SwitchAudio is treated as a AudioEffect, yet it is being handle by special cases to avoid using DSP.
- Added a m_musicVolume member to ensure the volume stay consistent when switching between tracks (including fxtrack)
- Switchable tracks does not load if fxtrack exists. Just like other effects.
- [Here](https://1drv.ms/u/s!AhmEP92g-Ak5gqEqumZH62lnYttbzg) is a example ksh map.

Other:
- Stop Gate effect from updating its gate in every frame, when the effect is activated by laser. (Updating gate reset the timer so the effect can not be heard).



