### PR TITLE
Fix a precision error when calculating TimingPoints

### DIFF
--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -522,6 +522,7 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream& input, bool metadataOnly)
 	// Process initial timing point
 	TimingPoint* lastTimingPoint = new TimingPoint();
 	lastTimingPoint->time = atol(*kshootMap.settings["o"]);
+	double realMapTime = (double)lastTimingPoint->time;
 	double bpm = atof(*kshootMap.settings["t"]);
 	lastTimingPoint->beatDuration = 60000.0 / bpm;
 	lastTimingPoint->numerator = 4;
@@ -593,7 +594,8 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream& input, bool metadataOnly)
 		// Sub-Block offset by adding ticks together
 		double blockPercent = (double)tickFromStartOfTimingPoint / (double)block.ticks.size();
 		double tickOffset = blockPercent * blockDuration;
-		MapTime mapTime = lastTimingPoint->time + MapTime(blockDurationOffset + tickOffset);
+		double currentMapTime = realMapTime + blockDurationOffset + tickOffset;
+		MapTime mapTime = MapTime(currentMapTime);
 
 		bool lastTick = &block == &kshootMap.blocks.back() &&
 			&tick == &block.ticks.back();
@@ -614,6 +616,7 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream& input, bool metadataOnly)
 				{
 					lastTimingPoint = new TimingPoint(*lastTimingPoint);
 					lastTimingPoint->time = mapTime;
+					realMapTime = currentMapTime;
 					m_timingPoints.Add(lastTimingPoint);
 					timingPointMap.Add(mapTime, lastTimingPoint);
 					timingPointBlockOffset = time.block;


### PR DESCRIPTION
MapTime is integer. If there are a lot of BPM and beat changes, the `time` in each TimingPoint is shifting 
 a little bit due to lack of precision. (And the `time` in these TimingPoints are being passed to DSP's lastTimingPoint, which is used to determine the repeating pattern of the Retrigger effect.)

timingPoints in USC:
![image](https://user-images.githubusercontent.com/3797859/58366588-0e203080-7f07-11e9-967e-c28725add8d8.png)

the counterparts in KSM editor:
![image](https://user-images.githubusercontent.com/3797859/58366613-8686f180-7f07-11e9-8d6e-eed8c8427775.png)

At the end of the map they are already 4ms apart, I'd imagine it'll only get worse if more timingPoints is created.

This PR fixed this issue by temporary storing a double precision time and using it instead of MapTime.