### PR TITLE
Fixes and improvements to preview handling

### DIFF
--- a/Beatmap/include/Beatmap/Beatmap.hpp
+++ b/Beatmap/include/Beatmap/Beatmap.hpp
@@ -39,6 +39,8 @@ struct BeatmapSettings
 	MapTime previewOffset;
 	// Preview duration
 	MapTime previewDuration;
+	// Preview file (optional)
+	String previewFile;
 
 	// Initial audio settings
 	float slamVolume = 1.0f;

--- a/Beatmap/src/Beatmap.cpp
+++ b/Beatmap/src/Beatmap.cpp
@@ -207,6 +207,7 @@ BinaryStream& operator<<(BinaryStream& stream, BeatmapSettings& settings)
 
 	stream << settings.previewOffset;
 	stream << settings.previewDuration;
+	stream << settings.previewFile;
 
 	stream << settings.slamVolume;
 	stream << settings.laserEffectMix;

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -506,6 +506,10 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream& input, bool metadataOnly)
 		{
 			m_settings.previewDuration = atoi(*s.second);
 		}
+		else if (s.first == "previewfile")
+		{
+			m_settings.previewFile = s.second;
+		}
 		else if (s.first == "total")
 		{
 			m_settings.total = atoi(*s.second);

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -1108,8 +1108,12 @@ public:
 
 	void m_updatePreview(DifficultyIndex *diff, bool mapChanged)
 	{
+		String mapRootPath = diff->path.substr(0, diff->path.find_last_of(Path::sep));
+
 		// Set current preview audio
-		String audioPath = diff->path.substr(0, diff->path.find_last_of(Path::sep)) + Path::sep + diff->settings.audioNoFX;
+		String audioPath = diff->settings.previewFile.length() > 0 ?
+			mapRootPath + Path::sep + diff->settings.previewFile :
+			mapRootPath + Path::sep + diff->settings.audioNoFX;
 
 		AudioStream previewAudio = g_audio->CreateStream(audioPath);
 		if (previewAudio)
@@ -1121,10 +1125,14 @@ public:
 			 * same. So, if the audio file is different but offset and duration equal the previously
 			 * playing preview, we know that it was just a change to a different difficulty of the
 			 * same chart. To avoid restarting the preview when changing difficulty, we say that
-			 * charts with this setup all have the same preview. */
-			bool newPreview = mapChanged 
-				? m_previewParams != params 
-				: (m_previewParams.duration != params.duration || m_previewParams.offset != params.offset);
+			 * charts with this setup all have the same preview. 
+			 *
+			 * Note that if the chart is using the `previewfile` field, then all this is ignored. */
+			bool newPreview = diff->settings.previewFile.length() > 0 ?
+				m_previewParams.filepath != audioPath :
+			    mapChanged ?
+				   m_previewParams != params :
+			      (m_previewParams.duration != params.duration || m_previewParams.offset != params.offset);
 
 			if (newPreview) {
 				previewAudio->SetPosition(diff->settings.previewOffset);


### PR DESCRIPTION
There were a few issues with the preview system. I got rid of the delay hack and replaced it with a nicer implementation handled by the `PreviewPlayer` struct. 

In cases where different difficulties of a song have differing previews, the correct one will now be played when its difficulty is selected.

The final commit adds support for a new KSH metadata field, `previewfile`. This allows charts to define a specific file in the song directory to be played as a preview in lieu of setting an offset and duration. If a `previewfile` is present, the preview offset and duration fields are ignored; if there is no `previewfile` then they retain their previous behavior.