### PR TITLE
Fix uninitialized spin type in camera

### DIFF
--- a/Main/Camera.cpp
+++ b/Main/Camera.cpp
@@ -8,7 +8,7 @@ const float ZOOM_POW = 1.65f;
 
 Camera::Camera()
 {
-
+	m_spinType = SpinStruct::SpinType::None;
 }
 Camera::~Camera()
 {


### PR DESCRIPTION
m_spinType was not initialized, so there was a chance that it would be set to one of the spin enum values. When this happened it would cause a roll as soon as the first tick is calculated. This results in m_spinRoll being miscalculated and set to NaN. This will prevent the track from rendering at the start of a song.

The fix simply sets m_spinType  to None in the constructor.