### PR TITLE
Fixed: charts with high offset value ends as soon as the play starts

### DIFF
--- a/Audio/src/AudioStreamBase.cpp
+++ b/Audio/src/AudioStreamBase.cpp
@@ -183,9 +183,13 @@ void AudioStreamBase::Process(float* out, uint32 numSamples)
 	}
 
 	// Store timing info
-	if(m_samplePos > 0)
+	if (m_samplePos > 0)
 	{
 		m_samplePos = GetStreamPosition_Internal() - (int64)m_remainingBufferData;
+	}
+
+	if(m_samplePos > 0)
+	{
 		if(m_samplePos >= m_samplesTotal)
 		{
 			if(!m_ended)


### PR DESCRIPTION
When `m_samplePos` is negative, `m_samplePos >= m_samplesTotal` returns true since `m_samplePos` is converted to unsigned integer.

Some of charts on Nautica had this problem. Example: https://ksm.dev/songs/bca80f60-d3e2-11e9-98db-77b73288e072