### PR TITLE
Stop at the end of String Path::Normalize

### DIFF
--- a/Shared/src/Unix/Path.cpp
+++ b/Shared/src/Unix/Path.cpp
@@ -138,6 +138,8 @@ String Path::Normalize(const String& path)
 	{
 		if(out[i] == '\\')
 			out[i] = sep;
+		if (out[i] == '\0')
+			return out;
 	}
 	return out;
 }


### PR DESCRIPTION
Was causing Conditional jump or move depends on uninitialised value(s) under valgrind