### PR TITLE
Add playback speed modifier

### DIFF
--- a/Main/Game.hpp
+++ b/Main/Game.hpp
@@ -63,6 +63,7 @@ public:
 	// Song was manually ended
 	virtual bool GetManualExit() = 0;
 	virtual float GetPlaybackSpeed() = 0;
+	virtual bool GetPlaybackSpeedChanged() = 0;
 	// Set demo mode
 	virtual void SetDemoMode(bool value) = 0; 
 	// Set song db so a random song can be selected

--- a/Main/ScoreScreen.cpp
+++ b/Main/ScoreScreen.cpp
@@ -117,9 +117,10 @@ public:
 			m_simpleHitStats.Add(shs);
 		}
 
-		// Don't save the score if autoplay was on or if the song was launched using command line
-		// also don't save the score if the song was manually exited
-		if (!m_autoplay && !m_autoButtons && game->GetDifficultyIndex().mapId != -1 && !game->GetManualExit())
+		// Don't save the score if autoplay was on or if the song was launched using command line,
+		// song was manually exited, or playback speed was changed
+		if (!m_autoplay && !m_autoButtons && game->GetDifficultyIndex().mapId != -1 
+			&& !game->GetManualExit() && !game->GetPlaybackSpeedChanged())
 		{
 			m_mapDatabase.AddScore(game->GetDifficultyIndex(),
 				m_score,

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ If something breaks in the song database, delete "maps.db". **Please note this w
 - Press \[FX-L\] + \[FX-R\] to open up game settings (Hard gauge, Random, Mirror, etc.)
 - Press \[TAB\] to open the Search bar on the top to search for songs
 
+### During a song:
+- Hold \[Start\] and press \[FX-L\] to adjust hispeed modifier
+- Press \[-\] or \[+\] to adjust the playback speed of the song. (High scores won't be saved)
+
 ## How to run:
 Just run 'usc-game' or 'usc-game_Debug' from within the 'bin' folder. Or, to play a chart immediately:  
 #### `{Download Location}/bin> usc-game {path to *.ksh chart} [flags]`

--- a/bin/skins/Default/scripts/gameplay.lua
+++ b/bin/skins/Default/scripts/gameplay.lua
@@ -556,6 +556,10 @@ function draw_song_info(deltaTime)
         gfx.Text(string.format("HiSpeed: %.0f x %.1f = %.0f",
                 gameplay.bpm, gameplay.hispeed, gameplay.bpm * gameplay.hispeed),
                 textX, 115)
+        gfx.Text(string.format("Playback Speed: %.0f",
+                100*gameplay.playbackSpeed),
+                textX, 130)
+
     end
 
     -- aaaand, scene!


### PR DESCRIPTION
Saw https://github.com/Drewol/unnamed-sdvx-clone/issues/99 and wanted to see if I could do some of the work..

This adds controls for the audio playback speed. Press + or - on the keyboard during a song to adjust the playback rate by 5%.
Right now it's limited to a playback rate of 0.5 - 1.0. I want to update this to allow playback speeds higher than 1, but I ran into a bug. Occasionally if you increase the playback rate, in AudioStreamBase.cpp, m_remainingBufferData is -1. I think this means, we played through the entire buffer and didn't have any samples available, which causes the song to end. That would happen since we're playing the samples faster than expected. This doesn't happen every time, but if I set the max playback to something like 2 and mash "+", it usually happens.

I was looking for a way to re-fill the buffer based on the new playback speed. I tried calling playback.Advance(0) and I tried calling playback.TogglePause() twice but these didn't work. I saw there was a function AudioStreamBase::RestartTiming() but not sure if that would do it and not sure how to call it from playback::SetPlaybackSpeed(). Any ideas would be appreciated!

Adjusting the playback speed disables high scores for the song.