### PR TITLE
Fix getting size of wrong texture

### DIFF
--- a/Main/LaserTrackBuilder.cpp
+++ b/Main/LaserTrackBuilder.cpp
@@ -18,7 +18,7 @@ LaserTrackBuilder::LaserTrackBuilder(class OpenGL* gl, class Track* track, uint3
 	m_laserWidth = track->laserWidth;
 	laserTextureSize = track->laserTextures[0]->GetSize(); // NOTE: expects left/right textures to be the same size!
 	laserEntryTextureSize = track->laserTailTextures[0]->GetSize();
-	laserExitTextureSize = track->laserTailTextures[1]->GetSize();
+	laserExitTextureSize = track->laserTailTextures[2]->GetSize();
 }
 Mesh LaserTrackBuilder::GenerateTrackMesh(class BeatmapPlayback& playback, LaserObjectState* laser)
 {


### PR DESCRIPTION
It's currently getting the size for the second entry texture instead of an exit texture.