### PR TITLE
Fix crash by exiting before transition end

### DIFF
--- a/Main/Game.cpp
+++ b/Main/Game.cpp
@@ -1740,7 +1740,7 @@ public:
 	{
 		if (buttonCode == Input::Button::BT_S)
 		{
-			if (g_input.Are3BTsHeld())
+			if (g_input.Are3BTsHeld() && IsSuccessfullyInitialized())
 			{
 				ObjectState *const* lastObj = &m_beatmap->GetLinearObjects().back();
 				MapTime timePastEnd = m_lastMapTime - (*lastObj)->time;


### PR DESCRIPTION
Able to reproduce consistently by holding down the BT buttons and spamming Start during the transition screen from song select to chart. 

What happens is at some point at the end of the transition screen from song select to play `Game.cpp` will accept input and when pressing the manual exit keys it will change screens before `TransitionScreen.cpp` finishes and cleans up causing an Access Violation at `m_tickableToLoad->Tick(deltaTime);` in `TransitionScreen.cpp`