### PR TITLE
Possibly improve input offset when grading if a note was missed

### DIFF
--- a/Main/Game.cpp
+++ b/Main/Game.cpp
@@ -1032,7 +1032,7 @@ public:
 		m_scoring.OnObjectReleased.Add(this, &Game_Impl::OnObjectReleased);
 		m_scoring.OnScoreChanged.Add(this, &Game_Impl::OnScoreChanged);
 
-		m_playback.hittableObjectEnter = Scoring::missHitTime;
+		m_playback.hittableObjectEnter = Scoring::missHitTime + g_gameConfig.GetInt(GameConfigKeys::InputOffset);
 		m_playback.hittableObjectLeave = Scoring::goodHitTime;
 
 		if(g_application->GetAppCommandLine().Contains("-autobuttons"))

--- a/Main/Scoring.cpp
+++ b/Main/Scoring.cpp
@@ -650,7 +650,7 @@ void Scoring::m_UpdateTicks()
 		for(uint32 i = 0; i < ticks.size(); i++)
 		{
 			ScoreTick* tick = ticks[i];
-			MapTime delta = currentTime - ticks[i]->time;
+			MapTime delta = currentTime - ticks[i]->time + m_inputOffset;
 			bool shouldMiss = abs(delta) > tick->GetHitWindow();
 			bool processed = false;
 			if(delta >= 0)


### PR DESCRIPTION
Some people noticed that they stopped getting earlys and lates when having large magnitude input offsets. I looked at where the input offset was applied and found it was correctly applied when a tick has  been consumed by a button press:
https://github.com/Drewol/unnamed-sdvx-clone/blob/41d9c670e95c9033b80010ce2dbfa67d6cdf7874/Main/Scoring.cpp#L776

However when the game judges if a tick has been missed without a button hit, there is no input offset applied:
https://github.com/Drewol/unnamed-sdvx-clone/blob/41d9c670e95c9033b80010ce2dbfa67d6cdf7874/Main/Scoring.cpp#L653

This seems incorrect, since it would mean that the tick could be removed before the actual good or crit window starts (with the input offset applied)

As a potential fix I added the input offset second delta calculation. However this is hard to test as it requires large offsets, so I want to double check that this makes sense.