### PR TITLE
Remove non-ascii characters

### DIFF
--- a/Graphics/src/ImageLoader.cpp
+++ b/Graphics/src/ImageLoader.cpp
@@ -142,7 +142,7 @@ namespace Graphics
 		bool Load(ImageRes* pImage, Buffer& b)
 		{
 			// Check for PNG based on first 4 bytes
-			if (*(uint32*)b.data() == (uint32&)"‰PNG")
+			if (*(uint32*)b.data() == (uint32&)"\x89PNG")
 				return LoadPNG(pImage, b);
 			else // jay-PEG ?
 				return LoadJPEG(pImage, b);


### PR DESCRIPTION
Non ascii characters can be badly encoded if file is open thinking that it is encoded in UTF8