### PR TITLE
Feature/songselect handy hotkeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ maps.db
 bin/Main.cfg
 bin/screenshots
 bin/log*
+bin/skins/*/skin.cfg
 
 # Intermediate Files
 x64

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -220,7 +220,7 @@ class SelectionWheel
 	uint32 m_currentlySelectedLuaMapIndex = 0;
 
 	// previous lua map index 
-	int32 m_previousRandomMapId = -1;
+	std::stack<int32> m_previousRandomMapIds;
 
 	// Style to use for everything song select related
 	lua_State* m_lua = nullptr;
@@ -331,7 +331,9 @@ public:
 		auto& srcCollection = m_SourceCollection();
 		if (srcCollection.empty())
 			return;
-		m_previousRandomMapId = m_currentlySelectedId;
+		if (m_previousRandomMapIds.size() == 0 || (m_previousRandomMapIds.size() > 0 && m_previousRandomMapIds.top() != m_currentlySelectedId))
+			m_previousRandomMapIds.push(m_currentlySelectedId);
+
 		uint32 selection = Random::IntRange(0, (int32)srcCollection.size() - 1);
 		auto it = srcCollection.begin();
 		std::advance(it, selection);
@@ -339,10 +341,11 @@ public:
 	}
 	void SelectPreviousRandom()
 	{
-		if (m_SourceCollection().empty() || m_previousRandomMapId < 0)
+		if (m_SourceCollection().empty() || m_previousRandomMapIds.size() < 1 )
 			return;
 
-		SelectMap(m_previousRandomMapId);
+		SelectMap(m_previousRandomMapIds.top());
+		m_previousRandomMapIds.pop();
 	}
 	void SelectByMapId(uint32 id)
 	{

--- a/Main/SongSelect.cpp
+++ b/Main/SongSelect.cpp
@@ -95,6 +95,7 @@ public:
 	{
 		backspaceCount = 0;
 		input.clear();
+		OnTextChanged.Call(input);
 	}
 	void Tick()
 	{
@@ -1495,8 +1496,16 @@ public:
 			}
 			else if (key == SDLK_ESCAPE)
 			{
-				m_suspended = true;
-				g_application->RemoveTickable(this);
+				if (m_searchInput->active)
+				{
+					m_searchInput->Reset();
+					m_searchInput->SetActive(false);
+				}
+				else
+				{
+					m_suspended = true;
+					g_application->RemoveTickable(this);
+				}
 			}
 			else if (key == SDLK_TAB)
 			{


### PR DESCRIPTION
This PR adds two hotkey functionalities in song select:
- Shift+F2 to go back to the previous randomly selected song (same as in osu!). This is useful because when F2'ing through songs, you sometimes go too quickly and want to go back to a song thumbnail that caught your attention before you accidentally pressed F2 again.
- Escape key will cancel out of an active search box and reset its contents. I added this as it seems intuitive/useful to not have to hold backspace, but also because this way you can clear the search box while the currently selected song stays the same. (With backspace it will usually jump to other songs that are more relevant every time a character is removed...)