### PR TITLE
(Mostly) fix event changes not behaving correctly at low frame rates

### DIFF
--- a/Beatmap/src/BeatmapPlayback.cpp
+++ b/Beatmap/src/BeatmapPlayback.cpp
@@ -222,7 +222,7 @@ void BeatmapPlayback::Update(MapTime newTime)
 		else if (obj->type == ObjectType::Event)
 		{
 			EventObjectState* evt = (EventObjectState*)obj;
-			if (obj->time < (m_playbackTime + 2)) // Tiny offset to make sure events are triggered before they are needed
+			if (obj->time < (m_playbackTime + Math::Max(delta, 2))) // Tiny offset to make sure events are triggered before they are needed
 			{
 				// Trigger event
 				OnEventChanged.Call(evt->key, evt->data);


### PR DESCRIPTION
This PR makes it so that event changes (most prominently roll keep changes) work as expected at lower frame rates like 60 or 165 FPS.

This probably won't fix situations where the frame times are wildly erratic i.e. during stutters.