### PR TITLE
Add option to specify path for shaded mesh

### DIFF
--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -64,6 +64,7 @@ public:
 	Texture LoadTexture(const String& name);
 	Texture LoadTexture(const String & name, const bool& external);
 	Material LoadMaterial(const String& name);
+	Material LoadMaterial(const String& name, const String& path);
 	Sample LoadSample(const String& name, const bool& external = false);
 	Graphics::Font LoadFont(const String& name, const bool& external = false);
 	int LoadImageJob(const String& path, Vector2i size, int placeholder, const bool& web = false);

--- a/Main/include/ShadedMesh.hpp
+++ b/Main/include/ShadedMesh.hpp
@@ -4,6 +4,7 @@
 class ShadedMesh {
 public:
 	ShadedMesh(const String& name);
+	ShadedMesh(const String& name, const String& path);
 	ShadedMesh();
 
 	void Draw();

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1135,11 +1135,11 @@ Texture Application::LoadTexture(const String& name, const bool& external)
 		return ret;
 	}
 }
-Material Application::LoadMaterial(const String& name)
+Material Application::LoadMaterial(const String& name, const String& path)
 {
-	String pathV = String("skins/") + m_skin + String("/shaders/") + name + ".vs";
-	String pathF = String("skins/") + m_skin + String("/shaders/") + name + ".fs";
-	String pathG = String("skins/") + m_skin + String("/shaders/") + name + ".gs";
+	String pathV = path + name + ".vs";
+	String pathF = path + name + ".fs";
+	String pathG = path + name + ".gs";
 	pathV = Path::Absolute(pathV);
 	pathF = Path::Absolute(pathF);
 	pathG = Path::Absolute(pathG);
@@ -1153,6 +1153,10 @@ Material Application::LoadMaterial(const String& name)
 	}
 	assert(ret);
 	return ret;
+}
+Material Application::LoadMaterial(const String& name)
+{
+	return LoadMaterial(name, String("skins/") + m_skin + String("/shaders/"));
 }
 Sample Application::LoadSample(const String& name, const bool& external)
 {

--- a/Main/src/ShadedMesh.cpp
+++ b/Main/src/ShadedMesh.cpp
@@ -21,6 +21,13 @@ ShadedMesh::ShadedMesh(const String& name) {
 	m_mesh->SetPrimitiveType(Graphics::PrimitiveType::TriangleList);
 }
 
+ShadedMesh::ShadedMesh(const String& name, const String& path) {
+	m_material = g_application->LoadMaterial(name, path);
+	m_material->opaque = false;
+	m_mesh = MeshRes::Create(g_gl);
+	m_mesh->SetPrimitiveType(Graphics::PrimitiveType::TriangleList);
+}
+
 void ShadedMesh::Draw() {
 	auto rq = g_application->GetRenderQueueBase();
 	rq->DrawScissored(g_application->GetCurrentGUIScissor() ,g_application->GetCurrentGUITransform(), m_mesh, m_material, m_params);
@@ -281,7 +288,12 @@ int __gc(lua_State* L) {
 
 int ShadedMesh::lNew(lua_State* L)
 {
-	if (lua_gettop(L) == 1)
+	if (lua_gettop(L) == 2)
+	{
+		ShadedMesh** place = (ShadedMesh**)lua_newuserdata(L, sizeof(ShadedMesh*));
+		*place = new ShadedMesh(luaL_checkstring(L, 1), luaL_checkstring(L, 2));
+	}
+	else if (lua_gettop(L) == 1)
 	{
 		ShadedMesh** place = (ShadedMesh**)lua_newuserdata(L, sizeof(ShadedMesh*));
 		*place = new ShadedMesh(luaL_checkstring(L, 1));

--- a/docs/source/shadedmesh.rst
+++ b/docs/source/shadedmesh.rst
@@ -28,6 +28,11 @@ gfx.CreateShadedMesh(String material = "guiTex")
 Creates a new ShadedMesh object, the material is loaded from the skin shaders folder where
 ``material.fs`` and ``material.vs`` need to exist.
 
+gfx.CreateShadedMesh(String material, String path)
+************************************************
+Creates a new ShadedMesh object, the material is loaded from the given path where
+``material.fs`` and ``material.vs`` need to exist.
+
 ShadedMesh:Draw()
 *****************
 Renders the ShadedMesh object.


### PR DESCRIPTION
When using shaded mesh with chart provided backgrounds, materials can only be loaded from the skin directory. This patch adds an option to specify the path that the materials should be loaded from.