### PR TITLE
Ensure detected MixFormat is supported, and use the returned closestFormat if not

### DIFF
--- a/Audio/src/Windows/AudioOutput_WASAPI.cpp
+++ b/Audio/src/Windows/AudioOutput_WASAPI.cpp
@@ -186,7 +186,14 @@ public:
 			throw _com_error(res);
 
 		WAVEFORMATEX* mixFormat = nullptr;
+		WAVEFORMATEX* closestFormat = nullptr;
 		res = m_audioClient->GetMixFormat(&mixFormat);
+		res = m_audioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, mixFormat, &closestFormat);
+		if (res != S_OK)
+		{
+			CoTaskMemFree(mixFormat);
+			mixFormat = closestFormat;
+		}
 		if (m_exclusive)
 		{
 			// Aquire format and initialize device for exclusive mode

--- a/Audio/src/Windows/AudioOutput_WASAPI.cpp
+++ b/Audio/src/Windows/AudioOutput_WASAPI.cpp
@@ -188,12 +188,6 @@ public:
 		WAVEFORMATEX* mixFormat = nullptr;
 		WAVEFORMATEX* closestFormat = nullptr;
 		res = m_audioClient->GetMixFormat(&mixFormat);
-		res = m_audioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, mixFormat, &closestFormat);
-		if (res != S_OK)
-		{
-			CoTaskMemFree(mixFormat);
-			mixFormat = closestFormat;
-		}
 		if (m_exclusive)
 		{
 			// Aquire format and initialize device for exclusive mode
@@ -264,6 +258,12 @@ public:
 		}
 		else
 		{
+			res = m_audioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, mixFormat, &closestFormat);
+			if (res != S_OK)
+			{
+				CoTaskMemFree(mixFormat);
+				mixFormat = closestFormat;
+			}
 			// Init client
 			res = m_audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0,
 				bufferDuration, 0, mixFormat, nullptr);


### PR DESCRIPTION
Ensure detected MixFormat is supported, and use the returned closestFormat if not