### PR TITLE
 Add offset to offbeat retrigger effect

### DIFF
--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -305,6 +305,11 @@ void RetriggerDSP::Process(float* out, uint32 numSamples)
 	int32 pcmStartSample = (double)lastTimingPoint * ((double)audioBase->GetSampleRate() / 1000.0);
 	int32 baseStartRepeat = (double)lastTimingPoint * ((double)audio->GetSampleRate() / 1000.0);
 
+	// Offset between the start of the effect hold and the nearest subdivision of this retrigger's updatePeriod.
+	int32 startResetOffset = (m_resetDuration > 0) ?
+		startSample - (startSample / (int)m_resetDuration) * m_resetDuration :
+		0;
+
 	for(uint32 i = 0; i < numSamples; i++)
 	{
 		if(nowSample + i < startSample)
@@ -316,7 +321,7 @@ void RetriggerDSP::Process(float* out, uint32 numSamples)
 		if (m_resetDuration > 0)
 		{
 			startOffset = (nowSample + i - baseStartRepeat) / (int)m_resetDuration;
-			startOffset = startOffset * m_resetDuration * rateMult;
+			startOffset = (startOffset * m_resetDuration + startResetOffset) * rateMult;
 		}
 		else
 		{


### PR DESCRIPTION
 The old behavior resulted in the retriggered sample to be that of the nearest division of `updatePeriod`. We now add samples to the start of that such that the retriggered sample will always be the sample on which the FX hold starts.

Old incorrect behavior: https://cdn.discordapp.com/attachments/384032012249464832/708104951318183975/fx_wrong.mp4

New correct behavior: https://cdn.discordapp.com/attachments/384032012249464832/708105005101744179/usc_fx_fixed.mp4

This time around the fix doesn't break other retriggers: https://cdn.discordapp.com/attachments/384032012249464832/708105235842727946/usc_fx_same.mp4