### PR TITLE
Fixed a crash and a resource leak in DownloadScreen.

### DIFF
--- a/Main/src/DownloadScreen.cpp
+++ b/Main/src/DownloadScreen.cpp
@@ -218,18 +218,30 @@ void DownloadScreen::m_ProcessArchiveResponses()
 		lua_rawgeti(m_lua, LUA_REGISTRYINDEX, ar.callback);
 		struct archive_entry *entry;
 		int numEntries = 1;
+		bool readError = false;
 		lua_newtable(m_lua);
 		while (archive_read_next_header(ar.a, &entry) == ARCHIVE_OK) {
-			//Logf("%s", Logger::Info, archive_entry_pathname(entry));
+			const wchar_t* pathname_w = archive_entry_pathname_w(entry);
+			if (pathname_w == nullptr)
+			{
+				readError = true;
+				break;
+			}
+
+			const String pathname = Utility::ConvertToUTF8(pathname_w);
 			lua_pushinteger(m_lua, numEntries++);
-			lua_pushstring(m_lua, archive_entry_pathname(entry));
+			lua_pushstring(m_lua, pathname.c_str());
 			lua_settable(m_lua, -3);
 			archive_read_data_skip(ar.a);
 		}
 		archive_read_free(ar.a);
 		lua_pushstring(m_lua, ar.id.c_str());
 		
-		if (lua_pcall(m_lua, 2, 1, 0) != 0)
+		if (readError)
+		{
+			Log("Error reading archive response", Logger::Error);
+		}
+		else if (lua_pcall(m_lua, 2, 1, 0) != 0)
 		{
 			Logf("Lua error on calling archive callback: %s", Logger::Error, lua_tostring(m_lua, -1));
 		}
@@ -256,7 +268,8 @@ void DownloadScreen::m_ProcessArchiveResponses()
 			archive_read_support_format_all(ar.a);
 			archive_read_open_memory(ar.a, ar.data.data(), ar.data.size());
 			while (archive_read_next_header(ar.a, &entry) == ARCHIVE_OK) {
-				String entryName = archive_entry_pathname(entry);
+				const wchar_t* entryName_w = archive_entry_pathname_w(entry);
+				String entryName = Utility::ConvertToUTF8(entryName_w);
 				if (entryPathMap.Contains(entryName))
 				{
 					if (!m_extractFile(ar.a, entryPathMap.at(entryName)))
@@ -266,10 +279,13 @@ void DownloadScreen::m_ProcessArchiveResponses()
 					}
 				}
 			}
+
+			archive_read_free(ar.a);
 		}
+		
 		lua_settop(m_lua, 0);
 		luaL_unref(m_lua, LUA_REGISTRYINDEX, ar.callback);
-		
+
 		//pop response
 		m_archiveLock.lock();
 		m_archiveResps.pop();


### PR DESCRIPTION
The download screen for Nautica, in specific `DownloadScreen::m_ProcessArchiveResponses`, had two problems.

1. After extracting a chart archive, it didn't free the archive handle properly.
2. For certain chart archives with non-ASCII pathnames, the program could crash.

A bug still exists where certain archives with non-ASCII pathnames are not extracted properly.