### PR TITLE
Changed most usage of SDL_Keycode into SDL_Scancode.

### DIFF
--- a/Graphics/include/Graphics/Window.hpp
+++ b/Graphics/include/Graphics/Window.hpp
@@ -75,7 +75,7 @@ namespace Graphics
 		int GetDisplayIndex() const;
 		
 		// Checks if a key is pressed
-		bool IsKeyPressed(int32 key) const;
+		bool IsKeyPressed(SDL_Scancode key) const;
 
 		ModifierKeys GetModifierKeys() const;
 
@@ -103,8 +103,8 @@ namespace Graphics
 		// Open a gamepad within the range of the number of gamepads
 		Ref<Gamepad> OpenGamepad(int32 deviceIndex);
 
-		Delegate<int32> OnKeyPressed;
-		Delegate<int32> OnKeyReleased;
+		Delegate<SDL_Scancode> OnKeyPressed;
+		Delegate<SDL_Scancode> OnKeyReleased;
 		Delegate<MouseButton> OnMousePressed;
 		Delegate<MouseButton> OnMouseReleased;
 		Delegate<int32, int32> OnMouseMotion;
@@ -114,7 +114,7 @@ namespace Graphics
 		//	Negative for scroll up
 		Delegate<int32> OnMouseScroll;
 		// Called for the initial an repeating presses of a key
-		Delegate<int32> OnKeyRepeat;
+		Delegate<SDL_Scancode> OnKeyRepeat;
 		Delegate<const WString&> OnTextInput;
 		Delegate<const TextComposition&> OnTextComposition;
 		Delegate<const Vector2i&> OnResized;

--- a/Graphics/src/Window.cpp
+++ b/Graphics/src/Window.cpp
@@ -170,30 +170,20 @@ namespace Graphics
 		{
 		}
 
-
-
 		/* input handling */
-		void HandleKeyEvent(SDL_Keycode code, uint8 newState, int32 repeat)
+		void HandleKeyEvent(const SDL_Keysym& keySym, uint8 newState, int32 repeat)
 		{
-			SDL_Keymod m = SDL_GetModState();
-			m_modKeys = ModifierKeys::None;
-			if((m & KMOD_ALT) != 0)
-			{
-				(uint8&)m_modKeys |= (uint8)ModifierKeys::Alt;
-			}
-			if((m & KMOD_CTRL) != 0)
-			{
-				(uint8&)m_modKeys |= (uint8)ModifierKeys::Ctrl;
-			}
-			if((m & KMOD_SHIFT) != 0)
-			{
-				(uint8&)m_modKeys |= (uint8)ModifierKeys::Shift;
-			}
+			const SDL_Scancode code = keySym.scancode;
+			SDL_Keymod m = static_cast<SDL_Keymod>(keySym.mod);
 
-			
-		
+			m_modKeys = ModifierKeys::None;
+
+			if((m & KMOD_ALT) != 0) (uint8&) m_modKeys |= (uint8) ModifierKeys::Alt;
+			if((m & KMOD_CTRL) != 0) (uint8&) m_modKeys |= (uint8) ModifierKeys::Ctrl;
+			if((m & KMOD_SHIFT) != 0) (uint8&) m_modKeys |= (uint8) ModifierKeys::Shift;
 
 			uint8& currentState = m_keyStates[code];
+
 			if(currentState != newState)
 			{
 				currentState = newState;
@@ -264,12 +254,12 @@ namespace Graphics
 					if(m_textComposition.composition.empty())
 					{
 						// Ignore key input when composition is being typed
-						HandleKeyEvent(evt.key.keysym.sym, 1, evt.key.repeat);
+						HandleKeyEvent(evt.key.keysym, 1, evt.key.repeat);
 					}
 				}
 				else if(evt.type == SDL_EventType::SDL_KEYUP)
 				{
-					HandleKeyEvent(evt.key.keysym.sym, 0, 0);
+					HandleKeyEvent(evt.key.keysym, 0, 0);
 				}
 				else if(evt.type == SDL_EventType::SDL_JOYBUTTONDOWN)
 				{
@@ -444,7 +434,7 @@ namespace Graphics
 		SDL_Cursor* currentCursor = nullptr;
 
 		// Window Input State
-		Map<SDL_Keycode, uint8> m_keyStates;
+		Map<SDL_Scancode, uint8> m_keyStates;
 		KeyMap m_keyMapping;
 		ModifierKeys m_modKeys = ModifierKeys::None;
 
@@ -551,7 +541,7 @@ namespace Graphics
 		return SDL_GetWindowDisplayIndex(m_impl->m_window);
 	}
 
-	bool Window::IsKeyPressed(SDL_Keycode key) const
+	bool Window::IsKeyPressed(SDL_Scancode key) const
 	{
 		return m_impl->m_keyStates[key] > 0;
 	}
@@ -664,9 +654,6 @@ namespace Graphics
 	{
 		return SDL_GetRelativeMouseMode() == SDL_TRUE;
 	}
-
-
-
 }
 
 namespace Graphics

--- a/Graphics/src/Window.cpp
+++ b/Graphics/src/Window.cpp
@@ -251,11 +251,7 @@ namespace Graphics
 			{
 				if(evt.type == SDL_EventType::SDL_KEYDOWN)
 				{
-					if(m_textComposition.composition.empty())
-					{
-						// Ignore key input when composition is being typed
-						HandleKeyEvent(evt.key.keysym, 1, evt.key.repeat);
-					}
+					HandleKeyEvent(evt.key.keysym, 1, evt.key.repeat);
 				}
 				else if(evt.type == SDL_EventType::SDL_KEYUP)
 				{

--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -112,8 +112,8 @@ private:
 	void m_MainLoop();
 	void m_Tick();
 	void m_Cleanup();
-	void m_OnKeyPressed(int32 key);
-	void m_OnKeyReleased(int32 key);
+	void m_OnKeyPressed(SDL_Scancode code);
+	void m_OnKeyReleased(SDL_Scancode code);
 	void m_OnWindowResized(const Vector2i& newSize);
 	void m_OnFocusChanged(bool focused);
 	void m_unpackSkins();

--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -106,6 +106,7 @@ public:
 
 private:
 	bool m_LoadConfig();
+	void m_UpdateConfigVersion();
 	void m_SaveConfig();
 	void m_InitDiscord();
 	bool m_Init();

--- a/Main/include/ApplicationTickable.hpp
+++ b/Main/include/ApplicationTickable.hpp
@@ -12,8 +12,8 @@ public:
 	virtual void Tick(float deltaTime) {};
 	virtual void Render(float deltaTime) {};
 	virtual void ForceRender(float deltaTime) { Render(deltaTime); };
-	virtual void OnKeyPressed(int32 key) {};
-	virtual void OnKeyReleased(int32 key) {};
+	virtual void OnKeyPressed(SDL_Scancode code) {};
+	virtual void OnKeyReleased(SDL_Scancode code) {};
 	// Called when focus of this item is lost
 	virtual void OnSuspend() {};
 	// Called when focus to this item is restored

--- a/Main/include/CollectionDialog.hpp
+++ b/Main/include/CollectionDialog.hpp
@@ -32,7 +32,7 @@ private:
 	void m_ChangeState();
 	void m_AdvanceSelection(int steps);
 	void m_OnButtonPressed(Input::Button button);
-	void m_OnKeyPressed(int32 key);
+	void m_OnKeyPressed(SDL_Scancode code);
 	void m_OnEntryReturn(const WString& name);
 
 	//Call when closing has been completed

--- a/Main/include/DownloadScreen.hpp
+++ b/Main/include/DownloadScreen.hpp
@@ -31,8 +31,8 @@ public:
 	void Tick(float deltaTime) override;
 	void Render(float deltaTime) override;
 
-	void OnKeyPressed(int32 key) override;
-	void OnKeyReleased(int32 key) override;
+	void OnKeyPressed(SDL_Scancode code) override;
+	void OnKeyReleased(SDL_Scancode code) override;
 private:
 	struct lua_State* m_lua;
 	LuaBindable* m_bindable;

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -3,6 +3,9 @@
 #include "Input.hpp"
 
 DefineEnum(GameConfigKeys,
+		   // Version of the config
+	       ConfigVersion,
+
 		   // Screen settings
 		   ScreenWidth,
 		   ScreenHeight,
@@ -160,6 +163,14 @@ DefineEnum(ButtonComboModeSettings,
 public:
 	GameConfig();
 	void SetKeyBinding(GameConfigKeys key, Key value);
+
+
+	// When this should change, the UpdateVersion MUST be updated to update the old config files.
+	// If there's no need to update the UpdateVersion, there's no need to touch this too.
+	constexpr static int32 VERSION = 1;
+
+	// Update the version of the config file to VERSION.
+	void UpdateVersion();
 
 protected:
 	virtual void InitDefaults() override;

--- a/Main/include/GameplaySettingsDialog.hpp
+++ b/Main/include/GameplaySettingsDialog.hpp
@@ -84,7 +84,7 @@ private:
     void m_ChangeStepSetting(int steps); //int, enum, toggle, are all advanced in distinct steps
     void m_OnButtonPressed(Input::Button button);
     void m_OnButtonReleased(Input::Button button);
-    void m_OnKeyPressed(int32 key);
+    void m_OnKeyPressed(SDL_Scancode code);
     Setting m_CreateToggleSetting(GameConfigKeys key, String name);
     Setting m_CreateIntSetting(GameConfigKeys key, String name, Vector2i range);
     Setting m_CreateFloatSetting(GameConfigKeys key, String name, Vector2 range, float mult = 1.0f);

--- a/Main/include/Input.hpp
+++ b/Main/include/Input.hpp
@@ -48,8 +48,8 @@ public:
 	MouseLockHandle LockMouse();
 
 	// Event handlers
-	virtual void OnKeyPressed(int32 key);
-	virtual void OnKeyReleased(int32 key);
+	virtual void OnKeyPressed(SDL_Scancode code);
+	virtual void OnKeyReleased(SDL_Scancode code);
 	virtual void OnMouseMotion(int32 x, int32 y);
 
 	// Request laser input state

--- a/Main/include/MultiplayerScreen.hpp
+++ b/Main/include/MultiplayerScreen.hpp
@@ -47,8 +47,8 @@ public:
 	void Render(float deltaTime) override;
 	void ForceRender(float deltaTime) override;
 
-	void OnKeyPressed(int32 key) override;
-	void OnKeyReleased(int32 key) override;
+	void OnKeyPressed(SDL_Scancode code) override;
+	void OnKeyReleased(SDL_Scancode code) override;
 	void MousePressed(MouseButton button);
 
 	virtual void OnSuspend();

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -640,14 +640,7 @@ bool Application::m_Init()
 	}
 
 	// Load config
-	if (m_LoadConfig())
-	{
-		m_UpdateConfigVersion();
-	}
-	else
-	{
-		Log("Failed to load config file", Logger::Warning);
-	}
+	if (!m_LoadConfig()) Log("Failed to load config file", Logger::Warning);
 
 	// Job sheduler
 	g_jobSheduler = new JobSheduler();
@@ -699,10 +692,17 @@ bool Application::m_Init()
 		g_gameConfig.GetInt(GameConfigKeys::ScreenWidth),
 		g_gameConfig.GetInt(GameConfigKeys::ScreenHeight));
 	g_aspectRatio = (float)g_resolution.x / (float)g_resolution.y;
+
 	int samplecount = g_gameConfig.GetInt(GameConfigKeys::AntiAliasing);
-	if (samplecount > 0)
-		samplecount = 1 << samplecount;
+	if (samplecount > 0) samplecount = 1 << samplecount;
+
 	g_gameWindow = new Graphics::Window(g_resolution, samplecount);
+
+	// Versioning up config uses some SDL util functions, so it must be called after SDL is initialized.
+	// SDL is initialized in the constructor of Graphics::Window.
+	// The awkward placement of this call may be avoided by initializing SDL earlier, but to avoid unwanted side-effects I'll put this here for now.
+	this->m_UpdateConfigVersion();
+
 	g_gameWindow->Show();
 
 	g_gameWindow->OnKeyPressed.Add(this, &Application::m_OnKeyPressed);

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -22,7 +22,6 @@
 #include "json.hpp"
 #include "SkinConfig.hpp"
 #include "SkinHttp.hpp"
-#include "SDL2/SDL_keycode.h"
 #include "ShadedMesh.hpp"
 #ifdef EMBEDDED
 #define NANOVG_GLES2_IMPLEMENTATION
@@ -1624,10 +1623,10 @@ int Application::IsNamedSamplePlaying(String name)
 		return -1;
 	}
 }
-void Application::m_OnKeyPressed(int32 key)
+void Application::m_OnKeyPressed(SDL_Scancode code)
 {
 	// Fullscreen toggle
-	if (key == SDLK_RETURN)
+	if (code == SDL_SCANCODE_ESCAPE)
 	{
 		if ((g_gameWindow->GetModifierKeys() & ModifierKeys::Alt) == ModifierKeys::Alt)
 		{
@@ -1644,15 +1643,15 @@ void Application::m_OnKeyPressed(int32 key)
 	// Pass key to application
 	for (auto it = g_tickables.rbegin(); it != g_tickables.rend();)
 	{
-		(*it)->OnKeyPressed(key);
+		(*it)->OnKeyPressed(code);
 		break;
 	}
 }
-void Application::m_OnKeyReleased(int32 key)
+void Application::m_OnKeyReleased(SDL_Scancode code)
 {
 	for (auto it = g_tickables.rbegin(); it != g_tickables.rend();)
 	{
-		(*it)->OnKeyReleased(key);
+		(*it)->OnKeyReleased(code);
 		break;
 	}
 }

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -428,8 +428,16 @@ bool Application::m_LoadConfig()
 		if (g_gameConfig.Load(reader))
 			return true;
 	}
+
+	g_gameConfig.Set(GameConfigKeys::ConfigVersion, GameConfig::VERSION);
 	return false;
 }
+
+void Application::m_UpdateConfigVersion()
+{
+	g_gameConfig.UpdateVersion();
+}
+
 void Application::m_SaveConfig()
 {
 	if (!g_gameConfig.IsDirty())
@@ -632,7 +640,11 @@ bool Application::m_Init()
 	}
 
 	// Load config
-	if (!m_LoadConfig())
+	if (m_LoadConfig())
+	{
+		m_UpdateConfigVersion();
+	}
+	else
 	{
 		Log("Failed to load config file", Logger::Warning);
 	}

--- a/Main/src/CalibrationScreen.cpp
+++ b/Main/src/CalibrationScreen.cpp
@@ -2,7 +2,6 @@
 #include "Application.hpp"
 #include "CalibrationScreen.hpp"
 #include "Audio/Audio.hpp"
-#include "SDL2/SDL_keycode.h"
 #include "SettingsScreen.hpp"
 #include "../third_party/nuklear/nuklear.h"
 #include <unordered_set>

--- a/Main/src/CollectionDialog.cpp
+++ b/Main/src/CollectionDialog.cpp
@@ -36,9 +36,9 @@ public:
 	{
 		composition = comp.composition;
 	}
-	void OnKeyRepeat(int32 key)
+	void OnKeyRepeat(SDL_Scancode key)
 	{
-		if (key == SDLK_BACKSPACE)
+		if (key == SDL_SCANCODE_BACKSPACE)
 		{
 			if (input.empty())
 				backspaceCount++; // Send backspace
@@ -51,8 +51,9 @@ public:
 			}
 		}
 	}
-	void OnKeyPressed(int32 key)
+	void OnKeyPressed(SDL_Scancode code)
 	{
+		SDL_Keycode key = SDL_GetKeyFromScancode(code);
 		if (key == SDLK_v)
 		{
 			if (g_gameWindow->GetModifierKeys() == ModifierKeys::Ctrl)
@@ -64,7 +65,7 @@ public:
 				}
 			}
 		}
-		else if (key == SDLK_RETURN)
+		else if (code == SDL_SCANCODE_RETURN)
 		{
 			OnReturn.Call(input);
 		}
@@ -370,7 +371,7 @@ void CollectionDialog::m_OnButtonPressed(Input::Button button)
 	lua_settop(m_lua, 0);
 }
 
-void CollectionDialog::m_OnKeyPressed(int32 key)
+void CollectionDialog::m_OnKeyPressed(SDL_Scancode code)
 {
 	if (!m_active || m_closing)
 	{
@@ -379,16 +380,16 @@ void CollectionDialog::m_OnKeyPressed(int32 key)
 
 	if (m_nameEntry->active)
 	{
-		if (key == SDLK_ESCAPE)
+		if (code == SDL_SCANCODE_ESCAPE)
 			m_shouldChangeState = true;
 		return;
 	}
 
-	if (key == SDLK_DOWN)
+	if (code == SDL_SCANCODE_DOWN)
 	{
 		m_AdvanceSelection(1);
 	}
-	else if (key == SDLK_UP)
+	else if (code == SDL_SCANCODE_UP)
 	{
 		m_AdvanceSelection(-1);
 	}

--- a/Main/src/DownloadScreen.cpp
+++ b/Main/src/DownloadScreen.cpp
@@ -81,12 +81,12 @@ void DownloadScreen::Render(float deltaTime)
 	}
 }
 
-void DownloadScreen::OnKeyPressed(int32 key)
+void DownloadScreen::OnKeyPressed(SDL_Scancode code)
 {
 	lua_getglobal(m_lua, "key_pressed");
 	if (lua_isfunction(m_lua, -1))
 	{	
-		lua_pushnumber(m_lua, key);
+		lua_pushnumber(m_lua, static_cast<lua_Number>(SDL_GetKeyFromScancode(code)));
 		if (lua_pcall(m_lua, 1, 0, 0) != 0)
 		{
 			Logf("Lua error on key_pressed: %s", Logger::Error, lua_tostring(m_lua, -1));
@@ -96,12 +96,12 @@ void DownloadScreen::OnKeyPressed(int32 key)
 	lua_settop(m_lua, 0);
 }
 
-void DownloadScreen::OnKeyReleased(int32 key)
+void DownloadScreen::OnKeyReleased(SDL_Scancode code)
 {
 	lua_getglobal(m_lua, "key_released");
 	if (lua_isfunction(m_lua, -1))
 	{
-		lua_pushnumber(m_lua, key);
+		lua_pushnumber(m_lua, static_cast<lua_Number>(SDL_GetKeyFromScancode(code)));
 		if (lua_pcall(m_lua, 1, 0, 0) != 0)
 		{
 			Logf("Lua error on key_released: %s", Logger::Error, lua_tostring(m_lua, -1));

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -21,7 +21,6 @@
 #include "MultiplayerScreen.hpp"
 #include "GameConfig.hpp"
 #include <Shared/Time.hpp>
-#include "SDL2/SDL_keycode.h"
 
 extern "C"
 {
@@ -1702,38 +1701,38 @@ public:
 		}
 	}
 
-	virtual void OnKeyPressed(int32 key) override
+	virtual void OnKeyPressed(SDL_Scancode code) override
 	{
-		if(key == SDLK_PAUSE && m_multiplayer == nullptr)
+		if(code == SDL_SCANCODE_PAUSE && m_multiplayer == nullptr)
 		{
 			m_audioPlayback.TogglePause();
 			m_paused = m_audioPlayback.IsPaused();
 		}
-		else if(key == SDLK_RETURN) // Skip intro
+		else if(code == SDL_SCANCODE_RETURN) // Skip intro
 		{
 			if(!SkipIntro())
 				SkipOutro();
 		}
-		else if(key == SDLK_PAGEUP && m_multiplayer == nullptr)
+		else if(code == SDL_SCANCODE_PAGEUP && m_multiplayer == nullptr)
 		{
 			m_audioPlayback.Advance(5000);
 		}
-		else if(key == SDLK_F5 && m_multiplayer == nullptr) // Restart map
+		else if(code == SDL_SCANCODE_F5 && m_multiplayer == nullptr) // Restart map
 		{
 			// Restart
 			Restart();
 		}
-		else if(key == SDLK_F8)
+		else if(code == SDL_SCANCODE_F8)
 		{
 			m_renderDebugHUD = !m_renderDebugHUD;
 			//m_psi->visibility = m_renderDebugHUD ? Visibility::Collapsed : Visibility::Visible;
 		}
-		else if(key == SDLK_TAB)
+		else if(code == SDL_SCANCODE_TAB)
 		{
 			//g_gameWindow->SetCursorVisible(!m_settingsBar->IsShown());
 			//m_settingsBar->SetShow(!m_settingsBar->IsShown());
 		}
-		else if(key == SDLK_F9)
+		else if(code == SDL_SCANCODE_F9)
 		{
 			g_application->ReloadScript("gameplay", m_lua);
 		}

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -3,7 +3,7 @@
 
 #include "Shared/Log.hpp"
 
-static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigKeys> keys)
+inline static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigKeys> keys)
 {
 	// To use SDL_GetScancodeFromKey, SDL must be initialized before.
 	assert(SDL_WasInit(SDL_INIT_EVENTS) != 0);
@@ -25,7 +25,10 @@ static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigK
 			const char* keyName = SDL_GetKeyName(keycode);
 			if (keyName == nullptr) keyName = "unknown";
 
-			Logf("Unable to convert key \"%s\" (%d) into scancode", Logger::Error, keyName, keycode);
+			const String& fieldName = Enum_GameConfigKeys::ToString(key);
+
+			Logf("Unable to convert key \"%s\" (%d) into scancode, for config field \"%s\".", Logger::Error, keyName, keycode, fieldName.c_str());
+			config.Set(key, -1);
 		}
 	}
 }

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -3,8 +3,11 @@
 
 #include "Shared/Log.hpp"
 
-inline static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigKeys> keys)
+static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigKeys> keys)
 {
+	// To use SDL_GetScancodeFromKey, SDL must be initialized before.
+	assert(SDL_WasInit(SDL_INIT_EVENTS) != 0);
+
 	for (const GameConfigKeys key : keys)
 	{
 		const int32 keycodeInt = config.GetInt(key);
@@ -12,7 +15,18 @@ inline static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<Game
 
 		const SDL_Keycode keycode = static_cast<SDL_Keycode>(keycodeInt);
 		const SDL_Scancode scancode = SDL_GetScancodeFromKey(keycode);
-		config.Set(key, static_cast<int32>(scancode));
+
+		if (scancode != SDL_SCANCODE_UNKNOWN)
+		{
+			config.Set(key, static_cast<int32>(scancode));
+		}
+		else
+		{
+			const char* keyName = SDL_GetKeyName(keycode);
+			if (keyName == nullptr) keyName = "unknown";
+
+			Logf("Unable to convert key \"%s\" (%d) into scancode", Logger::Error, keyName, keycode);
+		}
 	}
 }
 

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "GameConfig.hpp"
-#include "SDL2/SDL_keycode.h"
 
 GameConfig::GameConfig()
 {
@@ -65,24 +64,24 @@ void GameConfig::InitDefaults()
 	SetEnum<Enum_ButtonComboModeSettings>(GameConfigKeys::UseBackCombo, ButtonComboModeSettings::Hold);
 
 	// Default keyboard bindings
-	Set(GameConfigKeys::Key_BTS, SDLK_1); // Start button on Dao controllers
-	Set(GameConfigKeys::Key_BT0, SDLK_d);
-	Set(GameConfigKeys::Key_BT1, SDLK_f);
-	Set(GameConfigKeys::Key_BT2, SDLK_j);
-	Set(GameConfigKeys::Key_BT3, SDLK_k);
+	Set(GameConfigKeys::Key_BTS, SDL_SCANCODE_1); // Start button on Dao controllers
+	Set(GameConfigKeys::Key_BT0, SDL_SCANCODE_D);
+	Set(GameConfigKeys::Key_BT1, SDL_SCANCODE_F);
+	Set(GameConfigKeys::Key_BT2, SDL_SCANCODE_J);
+	Set(GameConfigKeys::Key_BT3, SDL_SCANCODE_K);
 	Set(GameConfigKeys::Key_BT0Alt, -1);
 	Set(GameConfigKeys::Key_BT1Alt, -1);
 	Set(GameConfigKeys::Key_BT2Alt, -1);
 	Set(GameConfigKeys::Key_BT3Alt, -1);
-	Set(GameConfigKeys::Key_FX0, SDLK_c);
-	Set(GameConfigKeys::Key_FX1, SDLK_m);
+	Set(GameConfigKeys::Key_FX0, SDL_SCANCODE_C);
+	Set(GameConfigKeys::Key_FX1, SDL_SCANCODE_M);
 	Set(GameConfigKeys::Key_FX0Alt, -1);
 	Set(GameConfigKeys::Key_FX1Alt, -1);
-	Set(GameConfigKeys::Key_Laser0Neg, SDLK_w);
-	Set(GameConfigKeys::Key_Laser0Pos, SDLK_e);
-	Set(GameConfigKeys::Key_Laser1Neg, SDLK_o);
-	Set(GameConfigKeys::Key_Laser1Pos, SDLK_p);
-	Set(GameConfigKeys::Key_Back, SDLK_ESCAPE);
+	Set(GameConfigKeys::Key_Laser0Neg, SDL_SCANCODE_W);
+	Set(GameConfigKeys::Key_Laser0Pos, SDL_SCANCODE_E);
+	Set(GameConfigKeys::Key_Laser1Neg, SDL_SCANCODE_O);
+	Set(GameConfigKeys::Key_Laser1Pos, SDL_SCANCODE_P);
+	Set(GameConfigKeys::Key_Back, SDL_SCANCODE_ESCAPE);
 	Set(GameConfigKeys::Key_Sensitivity, 3.0f);
 	Set(GameConfigKeys::Key_LaserReleaseTime, 0.0f);
 

--- a/Main/src/GameplaySettingsDialog.cpp
+++ b/Main/src/GameplaySettingsDialog.cpp
@@ -469,26 +469,26 @@ void GameplaySettingsDialog::m_ChangeStepSetting(int steps)
     }
 }
 
-void GameplaySettingsDialog::m_OnKeyPressed(int32 key)
+void GameplaySettingsDialog::m_OnKeyPressed(SDL_Scancode code)
 {
     if (!m_active || m_closing)
         return;
 
-    switch (key)
+    switch (code)
     {
-    case SDLK_LEFT:
+    case SDL_SCANCODE_LEFT:
         m_ChangeStepSetting(-1);
         break;
-    case SDLK_RIGHT:
+    case SDL_SCANCODE_RIGHT:
         m_ChangeStepSetting(1);
         break;
-    case SDLK_TAB:
+    case SDL_SCANCODE_TAB:
         m_AdvanceTab(1);
         break;
-    case SDLK_UP:
+    case SDL_SCANCODE_UP:
         m_AdvanceSelection(-1);
         break;
-    case SDLK_DOWN:
+    case SDL_SCANCODE_DOWN:
         m_AdvanceSelection(1);
         break;
     }

--- a/Main/src/Input.cpp
+++ b/Main/src/Input.cpp
@@ -363,17 +363,17 @@ void Input::m_OnGamepadButtonReleased(uint8 button)
 		m_OnButtonInput(it1->second, false);
 }
 
-void Input::OnKeyPressed(int32 key)
+void Input::OnKeyPressed(SDL_Scancode code)
 {
 	// Handle button mappings
-	auto it = m_buttonMap.equal_range(key);
+	auto it = m_buttonMap.equal_range(static_cast<int32>(code));
 	for(auto it1 = it.first; it1 != it.second; it1++)
 		m_OnButtonInput(it1->second, true);
 }
-void Input::OnKeyReleased(int32 key)
+void Input::OnKeyReleased(SDL_Scancode code)
 {
 	// Handle button mappings
-	auto it = m_buttonMap.equal_range(key);
+	auto it = m_buttonMap.equal_range(static_cast<int32>(code));
 	for(auto it1 = it.first; it1 != it.second; it1++)
 		m_OnButtonInput(it1->second, false);
 }

--- a/Main/src/MultiplayerScreen.cpp
+++ b/Main/src/MultiplayerScreen.cpp
@@ -48,9 +48,9 @@ public:
 	{
 		composition = comp.composition;
 	}
-	void OnKeyRepeat(int32 key)
+	void OnKeyRepeat(SDL_Scancode key)
 	{
-		if (key == SDLK_BACKSPACE)
+		if (key == SDL_SCANCODE_BACKSPACE)
 		{
 			if (input.empty())
 				backspaceCount++; // Send backspace
@@ -63,8 +63,9 @@ public:
 			}
 		}
 	}
-	void OnKeyPressed(int32 key)
+	void OnKeyPressed(SDL_Scancode code)
 	{
+		SDL_Keycode key = SDL_GetKeyFromScancode(code);
 		if (key == SDLK_v)
 		{
 			if (g_gameWindow->GetModifierKeys() == ModifierKeys::Ctrl)
@@ -970,7 +971,7 @@ void MultiplayerScreen::OnSearchStatusUpdated(String status)
 	m_statusLock.unlock();
 }
 
-void MultiplayerScreen::OnKeyPressed(int32 key)
+void MultiplayerScreen::OnKeyPressed(SDL_Scancode code)
 {
 	if (IsSuspended())
 		return;
@@ -978,7 +979,7 @@ void MultiplayerScreen::OnKeyPressed(int32 key)
 	lua_getglobal(m_lua, "key_pressed");
 	if (lua_isfunction(m_lua, -1))
 	{
-		lua_pushnumber(m_lua, key);
+		lua_pushnumber(m_lua, static_cast<lua_Number>(SDL_GetKeyFromScancode(code)));
 		if (lua_pcall(m_lua, 1, 0, 0) != 0)
 		{
 			Logf("Lua error on key_pressed: %s", Logger::Error, lua_tostring(m_lua, -1));
@@ -987,23 +988,23 @@ void MultiplayerScreen::OnKeyPressed(int32 key)
 	}
 	lua_settop(m_lua, 0);
 
-	if (key == SDLK_LEFT && m_hasSelectedMap)
+	if (code == SDL_SCANCODE_LEFT && m_hasSelectedMap)
 	{
 		m_changeDifficulty(-1);
 	}
-	else if (key == SDLK_RIGHT && m_hasSelectedMap)
+	else if (code == SDL_SCANCODE_RIGHT && m_hasSelectedMap)
 	{
 		m_changeDifficulty(1);
 	}
-	else if (key == SDLK_UP && m_screenState == MultiplayerScreenState::ROOM_LIST)
+	else if (code == SDL_SCANCODE_UP && m_screenState == MultiplayerScreenState::ROOM_LIST)
 	{
 		m_changeSelectedRoom(-1);
 	}
-	else if (key == SDLK_DOWN && m_screenState == MultiplayerScreenState::ROOM_LIST)
+	else if (code == SDL_SCANCODE_DOWN && m_screenState == MultiplayerScreenState::ROOM_LIST)
 	{
 		m_changeSelectedRoom(1);
 	}
-	else if (key == SDLK_ESCAPE)
+	else if (code == SDL_SCANCODE_ESCAPE)
 	{
 		if (m_screenState != MultiplayerScreenState::ROOM_LIST)
 		{
@@ -1040,7 +1041,7 @@ void MultiplayerScreen::OnKeyPressed(int32 key)
 			m_hasSelectedMap = false;
 		}
 	}
-	else if (key == SDLK_RETURN)
+	else if (code == SDL_SCANCODE_RETURN)
 	{
 		if (m_screenState == MultiplayerScreenState::JOIN_PASSWORD) 
 		{
@@ -1060,7 +1061,7 @@ void MultiplayerScreen::OnKeyPressed(int32 key)
 
 
 
-void MultiplayerScreen::OnKeyReleased(int32 key)
+void MultiplayerScreen::OnKeyReleased(SDL_Scancode code)
 {
 	if (IsSuspended())
 		return;
@@ -1068,7 +1069,7 @@ void MultiplayerScreen::OnKeyReleased(int32 key)
 	lua_getglobal(m_lua, "key_released");
 	if (lua_isfunction(m_lua, -1))
 	{
-		lua_pushnumber(m_lua, key);
+		lua_pushnumber(m_lua, static_cast<lua_Number>(SDL_GetKeyFromScancode(code)));
 		if (lua_pcall(m_lua, 1, 0, 0) != 0)
 		{
 			Logf("Lua error on key_released: %s", Logger::Error, lua_tostring(m_lua, -1));

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -501,21 +501,21 @@ public:
 	}
 
 
-	virtual void OnKeyPressed(int32 key) override
+	virtual void OnKeyPressed(SDL_Scancode code) override
 	{
 		if (m_collDiag.IsActive())
 			return;
 
-		if(key == SDLK_RETURN && !m_removed)
+		if(code == SDL_SCANCODE_RETURN && !m_removed)
 		{
 			g_application->RemoveTickable(this);
 			m_removed = true;
 		}
-		if (key == SDLK_F12)
+		if (code == SDL_SCANCODE_F12)
 		{
 			Capture();
 		}
-		if (key == SDLK_F9)
+		if (code == SDL_SCANCODE_F9)
 		{
 			g_application->ReloadScript("result", m_lua);
 			lua_getglobal(m_lua, "result_set");
@@ -530,7 +530,7 @@ public:
 			lua_settop(m_lua, 0);
 		}
 	}
-	virtual void OnKeyReleased(int32 key) override
+	virtual void OnKeyReleased(SDL_Scancode code) override
 	{
 	}
 	virtual void Render(float deltaTime) override

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -890,11 +890,11 @@ public:
 		}
 	}
 
-	virtual void OnKeyPressed(int32 key)
+	virtual void OnKeyPressed(SDL_Scancode code)
 	{
 		if (!m_isGamepad && !m_knobs)
 		{
-			g_gameConfig.Set(m_key, key);
+			g_gameConfig.Set(m_key, code);
 			m_completed = true; // Needs to be set because pressing right alt triggers two keypresses on the same frame.
 		}
 		else if (!m_isGamepad && m_knobs)
@@ -904,10 +904,10 @@ public:
 				switch (m_key)
 				{
 				case GameConfigKeys::Controller_Laser0Axis:
-					g_gameConfig.Set(GameConfigKeys::Key_Laser0Neg, key);
+					g_gameConfig.Set(GameConfigKeys::Key_Laser0Neg, code);
 					break;
 				case GameConfigKeys::Controller_Laser1Axis:
-					g_gameConfig.Set(GameConfigKeys::Key_Laser1Neg, key);
+					g_gameConfig.Set(GameConfigKeys::Key_Laser1Neg, code);
 					break;
 				default:
 					break;
@@ -919,10 +919,10 @@ public:
 				switch (m_key)
 				{
 				case GameConfigKeys::Controller_Laser0Axis:
-					g_gameConfig.Set(GameConfigKeys::Key_Laser0Pos, key);
+					g_gameConfig.Set(GameConfigKeys::Key_Laser0Pos, code);
 					break;
 				case GameConfigKeys::Controller_Laser1Axis:
-					g_gameConfig.Set(GameConfigKeys::Key_Laser1Pos, key);
+					g_gameConfig.Set(GameConfigKeys::Key_Laser1Pos, code);
 					break;
 				default:
 					break;
@@ -1031,9 +1031,9 @@ public:
 		}
 	}
 
-	virtual void OnKeyPressed(int32 key)
+	virtual void OnKeyPressed(SDL_Scancode code)
 	{
-		if (key == SDLK_ESCAPE)
+		if (code == SDL_SCANCODE_ESCAPE)
 			g_application->RemoveTickable(this);
 	}
 

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -103,6 +103,11 @@ float nk_propertyf_sdl_text(struct nk_context *ctx, const char *name, float min,
 	return value;
 }
 
+static inline const char* GetKeyNameFromScancodeConfig(int scancode)
+{
+	return SDL_GetKeyName(SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(scancode)));
+}
+
 class SettingsScreen_Impl : public SettingsScreen
 {
 private:
@@ -505,7 +510,7 @@ public:
 			}
 			else
 			{
-				m_controllerButtonNames[i] = SDL_GetKeyName(g_gameConfig.GetInt((*m_activeBTKeys)[i]));
+				m_controllerButtonNames[i] = GetKeyNameFromScancodeConfig(g_gameConfig.GetInt((*m_activeBTKeys)[i]));
 			}
 		}
 		for (size_t i = 0; i < 2; i++)
@@ -516,10 +521,10 @@ public:
 			}
 			else
 			{
-				m_controllerLaserNames[i] = Utility::ConvertToUTF8(Utility::WSprintf( //wstring->string because regular Sprintf messes up(?????)
+				m_controllerLaserNames[i] = Utility::ConvertToUTF8(Utility::WSprintf( // wstring->string because regular Sprintf messes up(?????)
 					L"%ls / %ls",
-					Utility::ConvertToWString(SDL_GetKeyName(g_gameConfig.GetInt(m_keyboardLaserKeys[i * 2]))),
-					Utility::ConvertToWString(SDL_GetKeyName(g_gameConfig.GetInt(m_keyboardLaserKeys[i * 2 + 1])))
+					Utility::ConvertToWString(GetKeyNameFromScancodeConfig(g_gameConfig.GetInt(m_keyboardLaserKeys[i * 2]))),
+					Utility::ConvertToWString(GetKeyNameFromScancodeConfig(g_gameConfig.GetInt(m_keyboardLaserKeys[i * 2 + 1])))
 				));
 			}
 		}

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -46,9 +46,9 @@ public:
 	{
 		composition = comp.composition;
 	}
-	void OnKeyRepeat(int32 key)
+	void OnKeyRepeat(SDL_Scancode key)
 	{
-		if (key == SDLK_BACKSPACE)
+		if (key == SDL_SCANCODE_BACKSPACE)
 		{
 			if (input.empty())
 				backspaceCount++; // Send backspace
@@ -61,8 +61,9 @@ public:
 			}
 		}
 	}
-	void OnKeyPressed(int32 key)
+	void OnKeyPressed(SDL_Scancode code)
 	{
+		SDL_Keycode key = SDL_GetKeyFromScancode(code);
 		if (key == SDLK_v)
 		{
 			if (g_gameWindow->GetModifierKeys() == ModifierKeys::Ctrl)
@@ -1762,73 +1763,73 @@ public:
 			m_selectionWheel->AdvanceSelection(steps);
 		}
 	}
-	virtual void OnKeyPressed(int32 key)
+	virtual void OnKeyPressed(SDL_Scancode code)
 	{
 		if (m_collDiag.IsActive() || m_settDiag.IsActive())
 			return;
 
 		if (m_filterSelection->Active)
 		{
-			if (key == SDLK_DOWN)
+			if (code == SDL_SCANCODE_DOWN)
 			{
 				m_filterSelection->AdvanceSelection(1);
 			}
-			else if (key == SDLK_UP)
+			else if (code == SDL_SCANCODE_DOWN)
 			{
 				m_filterSelection->AdvanceSelection(-1);
 			}
 		}
 		else if (m_sortSelection->Active)
 		{
-			if (key == SDLK_DOWN)
+			if (code == SDL_SCANCODE_DOWN)
 			{
 				m_sortSelection->AdvanceSelection(1);
 			}
-			else if (key == SDLK_UP)
+			else if (code == SDL_SCANCODE_UP)
 			{
 				m_sortSelection->AdvanceSelection(-1);
 			}
 		}
 		else
 		{
-			if (key == SDLK_DOWN)
+			if (code == SDL_SCANCODE_DOWN)
 			{
 				m_selectionWheel->AdvanceSelection(1);
 			}
-			else if (key == SDLK_UP)
+			else if (code == SDL_SCANCODE_UP)
 			{
 				m_selectionWheel->AdvanceSelection(-1);
 			}
-			else if (key == SDLK_PAGEDOWN)
+			else if (code == SDL_SCANCODE_PAGEDOWN)
 			{
 				m_selectionWheel->AdvancePage(1);
 			}
-			else if (key == SDLK_PAGEUP)
+			else if (code == SDL_SCANCODE_PAGEUP)
 			{
 				m_selectionWheel->AdvancePage(-1);
 			}
-			else if (key == SDLK_LEFT)
+			else if (code == SDL_SCANCODE_LEFT)
 			{
 				m_selectionWheel->AdvanceDifficultySelection(-1);
 			}
-			else if (key == SDLK_RIGHT)
+			else if (code == SDL_SCANCODE_RIGHT)
 			{
 				m_selectionWheel->AdvanceDifficultySelection(1);
 			}
-			else if (key == SDLK_F5)
+			else if (code == SDL_SCANCODE_F5)
 			{
 				m_mapDatabase->StartSearching();
 				OnSearchTermChanged(m_searchInput->input);
 			}
-			else if (key == SDLK_F1 && m_hasCollDiag)
+			else if (code == SDL_SCANCODE_F1 && m_hasCollDiag)
 			{
 				m_collDiag.Open(*m_selectionWheel->GetSelectedChart());
 			}
-			else if (key == SDLK_F2)
+			else if (code == SDL_SCANCODE_F2)
 			{
 				m_selectionWheel->SelectRandom();
 			}
-			else if (key == SDLK_F8) // start demo mode
+			else if (code == SDL_SCANCODE_F8) // start demo mode
 			{
 				ChartIndex *chart = m_mapDatabase->GetRandomChart();
 
@@ -1846,13 +1847,13 @@ public:
 				// Transition to game
 				g_transition->TransitionTo(game);
 			}
-			else if (key == SDLK_F9)
+			else if (code == SDL_SCANCODE_F9)
 			{
 				m_selectionWheel->ReloadScript();
 				m_filterSelection->ReloadScript();
 				g_application->ReloadScript("songselect/background", m_lua);
 			}
-			else if (key == SDLK_F11)
+			else if (code == SDL_SCANCODE_F11)
 			{
 				String paramFormat = g_gameConfig.GetString(GameConfigKeys::EditorParamsFormat);
 				String path = Path::Normalize(g_gameConfig.GetString(GameConfigKeys::EditorPath));
@@ -1860,21 +1861,21 @@ public:
 												Utility::Sprintf("\"%s\"", Path::Absolute(m_selectionWheel->GetSelectedChart()->path)));
 				Path::Run(path, param.GetData());
 			}
-			else if (key == SDLK_F12)
+			else if (code == SDL_SCANCODE_F12)
 			{
 				Path::ShowInFileBrowser(m_selectionWheel->GetSelection()->path);
 			}
-			else if (key == SDLK_TAB)
+			else if (code == SDL_SCANCODE_TAB)
 			{
 				m_searchInput->SetActive(!m_searchInput->active);
 			}
-			else if (key == SDLK_RETURN && m_searchInput->active)
+			else if (code == SDL_SCANCODE_RETURN && m_searchInput->active)
 			{
 				m_searchInput->SetActive(false);
 			}
 		}
 	}
-	virtual void OnKeyReleased(int32 key)
+	virtual void OnKeyReleased(SDL_Scancode code)
 	{
 	}
 	virtual void Tick(float deltaTime) override

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -1774,7 +1774,7 @@ public:
 			{
 				m_filterSelection->AdvanceSelection(1);
 			}
-			else if (code == SDL_SCANCODE_DOWN)
+			else if (code == SDL_SCANCODE_UP)
 			{
 				m_filterSelection->AdvanceSelection(-1);
 			}

--- a/Main/src/Test.cpp
+++ b/Main/src/Test.cpp
@@ -45,14 +45,14 @@ public:
 	~Test_Impl()
 	{
 	}
-	virtual void OnKeyPressed(int32 key) override
+	virtual void OnKeyPressed(SDL_Scancode code) override
 	{
-		if(key == SDLK_TAB)
+		if(code == SDL_SCANCODE_TAB)
 		{
 			//m_settings->SetShow(!m_settings->IsShown());
 		}
 	}
-	virtual void OnKeyReleased(int32 key) override
+	virtual void OnKeyReleased(SDL_Scancode code) override
 	{
 	}
 	virtual void Render(float deltaTime) override

--- a/Main/src/TransitionScreen.cpp
+++ b/Main/src/TransitionScreen.cpp
@@ -394,9 +394,9 @@ public:
 		return true;
 	}
 
-	void OnKeyPressed(int32 key)
+	void OnKeyPressed(SDL_Scancode code)
 	{
-		if (key == SDLK_ESCAPE && !m_stopped && m_canCancel)
+		if (code == SDL_SCANCODE_ESCAPE && !m_stopped && m_canCancel)
 		{
 			m_stopped = true;
 			if (m_loadingJob->IsQueued())


### PR DESCRIPTION
This fixes #135, which is _extremely_ annoying for people using two or more key layouts. (Most non-latin-alphabet-using people use a keyboard layout for their native language and QWERTY for latin alphabet.)

- Since only the physical locations of keys matter for button inputs, I changed delegates to receive scancodes instead of keycodes.
- Except `Ctrl+V`, skin's `key_pressed` and `key_released`, all inputs (sort wheel, ...) are now handled on scancodes. This should have no visible effect.
- Since old configs using keycodes must be converted into new configs using scancodes, I created `ConfigVersion` field to `GameConfig`.
  - The version should increase only if there's an incompatible change.
  - The config file is updated with `GameConfig::UpdateVersion`, called by `Application::m_UpdateConfigVersion`.