### PR TITLE
Add preview support for nautica

### DIFF
--- a/Main/include/DownloadScreen.hpp
+++ b/Main/include/DownloadScreen.hpp
@@ -4,6 +4,7 @@
 #include "Input.hpp"
 #include "Shared/Thread.hpp"
 #include "cpr/cpr.h"
+#include "PreviewPlayer.hpp"
 #include <queue>
 
 struct ArchiveRequest
@@ -50,8 +51,12 @@ private:
 	void m_ProcessArchiveResponses();
 	int m_Exit(struct lua_State* L);
 	int m_DownloadArchive(struct lua_State* L);
+	int m_PlayPreview(struct lua_State* L);
 	int m_GetSongsPath(struct lua_State* L);
 	bool m_extractFile(struct archive* a, String path);
 	Map<String, String> m_mapFromLuaTable(int index);
+
+	PreviewPlayer m_previewPlayer;
+	PreviewParams m_previewParams;
 
 };

--- a/Main/include/MultiplayerScreen.hpp
+++ b/Main/include/MultiplayerScreen.hpp
@@ -234,15 +234,5 @@ private:
 	DBUpdateScreen* m_dbUpdateScreen = nullptr;
 
 	PreviewPlayer m_previewPlayer;
-	struct PreviewParams
-	{
-		String filepath;
-		uint32 offset;
-		uint32 duration;
-
-		bool operator!=(const PreviewParams &rhs)
-		{
-			return filepath != rhs.filepath || offset != rhs.offset || duration != rhs.duration;
-		}
-	} m_previewParams;
+	PreviewParams m_previewParams;
 };

--- a/bin/skins/Default/scripts/downloadscreen.lua
+++ b/bin/skins/Default/scripts/downloadscreen.lua
@@ -22,6 +22,7 @@ local downloaded = {}
 local songs = {}
 local selectedLevels = {}
 local selectedSorting = "Uploaded"
+local lastPlaying = nil
 for i = 1, 20 do
     selectedLevels[i] = false
 end
@@ -130,6 +131,15 @@ function render_song(song, x,y)
         gfx.FontSize(60)
         gfx.FillColor(255,255,255)
         gfx.Text(downloaded[song.id], 375, 150)
+    elseif song.status then
+        gfx.BeginPath()
+        gfx.Rect(0,0,750,300)
+        gfx.FillColor(0,0,0,127)
+        gfx.Fill()
+        gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
+        gfx.FontSize(60)
+        gfx.FillColor(255,255,255)
+        gfx.Text(song.status, 375, 150)
     end
     gfx.ResetScissor()
     gfx.Restore()
@@ -312,6 +322,18 @@ function button_pressed(button)
         elseif screenState == 2 then
             selectedSorting = sortingOptions[sortingcursor + 1]
             reload_songs()
+        end
+
+    elseif button == game.BUTTON_BTA then
+        if screenState == 0 then
+            local song = songs[cursorPos + 1]
+            if song == nil then return end
+            dlScreen.PlayPreview(encodeURI(song.preview_url), header, song.id)
+            song.status = "Playing"
+            if lastPlaying ~=nil then
+                lastPlaying.status = nil
+            end
+            lastPlaying = song
         end
         
     elseif button == game.BUTTON_FXL then


### PR DESCRIPTION
This changeset adds a lua function to DownloadScreen which takes a url to a preview audio file, downloads it to the `preview` directory and then plays it.

I've also updated the default skin to have support for nautica's previews.