### PR TITLE
Set the locale to `.UTF-8` to force C lib functions such as fopen use UTF-8

### DIFF
--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -644,6 +644,14 @@ bool Application::m_Init()
 		}
 	}
 
+	// Set the locale so that functions such as `fopen` use UTF-8.
+	{
+		String prevLocale = setlocale(LC_CTYPE, nullptr);
+		setlocale(LC_CTYPE, ".UTF-8");
+
+		Logf("The locale was changed from %s to %s", Logger::Severity::Info, prevLocale.c_str(), setlocale(LC_CTYPE, nullptr));
+	}
+
 	// Load config
 	if (!m_LoadConfig()) Log("Failed to load config file", Logger::Severity::Warning);
 	Logger::Get().SetLogLevel(g_gameConfig.GetEnum<Logger::Enum_Severity>(GameConfigKeys::LogLevel));

--- a/Main/src/DownloadScreen.cpp
+++ b/Main/src/DownloadScreen.cpp
@@ -329,11 +329,11 @@ void DownloadScreen::m_ProcessArchiveResponses()
 		lua_settop(m_lua, 0);
 		luaL_unref(m_lua, LUA_REGISTRYINDEX, ar.callback);
 
-		setlocale(LC_CTYPE, defaultLocale.c_str());
-
 		// Pop response
 		m_archiveLock.lock();
 		m_archiveResps.pop();
+
+		setlocale(LC_CTYPE, defaultLocale.c_str());
 	}
 	m_archiveLock.unlock();
 }


### PR DESCRIPTION
This is a fix for #351 
