### PR TITLE
Reworked how hold notes work.

### DIFF
--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -73,7 +73,7 @@ public:
 	void ReloadScript(const String& name, lua_State* L);
 	void LoadGauge(bool hard);
 	void DrawGauge(float rate, float x, float y, float w, float h, float deltaTime);
-	int FastText(String text, float x, float y, int size, int align);
+	int FastText(String text, float x, float y, int size, int align, const Color& color = Color::White);
 	float GetAppTime() const { return m_lastRenderTime; }
 	float GetRenderFPS() const;
 	Material GetFontMaterial() const;

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -248,6 +248,7 @@ private:
 	void m_SetHoldObject(ObjectState* obj, uint32 index);
 	void m_ReleaseHoldObject(ObjectState* obj);
 	void m_ReleaseHoldObject(uint32 index);
+	bool m_IsBeingHold(const ScoreTick* tick) const;
 
 	// Updates the target laser positions and currently tracked laser segments for those
 	//  also updates laser input and returns lasers back to idle position when not used
@@ -278,10 +279,13 @@ private:
 	float m_lastLaserInputDirection[2] = { 0.0f };
 	// Decides if the coming tick should be auto completed
 	float m_autoLaserTime[2] = { 0,0 };
+	
 	// Saves the time when a button was hit, used to decide if a button was held before a hold object was active
 	MapTime m_buttonHitTime[6] = { 0, 0, 0, 0, 0, 0 };
+	MapTime m_buttonReleaseTime[6] = { 0, 0, 0, 0, 0, 0 };
 	// Saves the time when a button was hit or released for bounce guarding
 	MapTime m_buttonGuardTime[6] = { 0, 0, 0, 0, 0, 0 };
+
 	// Max number of ticks to assist
 	float m_assistLevel = 1.5f;
 	float m_assistPunish = 1.5f;
@@ -305,9 +309,11 @@ private:
 
 	// Ticks for each BT[4] / FX[2] / Laser[2]
 	Vector<ScoreTick*> m_ticks[8];
+
 	// Hold objects
 	ObjectState* m_holdObjects[8];
 	Set<ObjectState*> m_heldObjects;
+	bool m_prevHoldHit[6];
 
 	GameFlags m_flags;
 };

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1739,7 +1739,7 @@ void Application::m_OnFocusChanged(bool focused)
 	}
 }
 
-int Application::FastText(String inputText, float x, float y, int size, int align)
+int Application::FastText(String inputText, float x, float y, int size, int align, const Color& color /* = Color::White */)
 {
 	WString text = Utility::ConvertToWString(inputText);
 	String fontpath = Path::Normalize(Path::Absolute("fonts/settings/NotoSans-Regular.ttf"));
@@ -1768,7 +1768,7 @@ int Application::FastText(String inputText, float x, float y, int size, int alig
 	}
 
 	MaterialParameterSet params;
-	params.SetParameter("color", Vector4(1.f, 1.f, 1.f, 1.f));
+	params.SetParameter("color", color);
 	g_application->GetRenderQueueBase()->Draw(textTransform, te, g_application->GetFontMaterial(), params);
 	return 0;
 }

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -1365,7 +1365,7 @@ public:
 		//RenderQueue& debugRq = g_guiRenderer->Begin();
 		auto RenderText = [&](const String& text, const Vector2& pos, const Color& color = Color::White)
 		{
-			g_application->FastText(text, pos.x, pos.y, 12, 0);
+			g_application->FastText(text, pos.x, pos.y, 12, 0, color);
 			return Vector2(0, 12);
 		};
 
@@ -1385,7 +1385,7 @@ public:
 
 		float currentBPM = (float)(60000.0 / tp.beatDuration);
 		textPos.y += RenderText(Utility::Sprintf("BPM: %.1f", currentBPM), textPos).y;
-		textPos.y += RenderText(Utility::Sprintf("Time Signature: %d/4", tp.numerator), textPos).y;
+		textPos.y += RenderText(Utility::Sprintf("Time Signature: %d/%d", tp.numerator, tp.denominator), textPos).y;
 		textPos.y += RenderText(Utility::Sprintf("Laser Effect Mix: %f", m_audioPlayback.GetLaserEffectMix()), textPos).y;
 		textPos.y += RenderText(Utility::Sprintf("Laser Filter Input: %f", m_scoring.GetLaserOutput()), textPos).y;
 
@@ -1416,7 +1416,6 @@ public:
 			if(hitsShown++ > 16) // Max of 16 entries to display
 				break;
 
-
 			static Color hitColors[] = {
 				Color::Red,
 				Color::Yellow,
@@ -1430,7 +1429,7 @@ public:
 			MultiObjectState* obj = *(*it)->object;
 			if(obj->type == ObjectType::Single)
 			{
-				text = Utility::Sprintf("[%d] %d", obj->button.index, (*it)->delta);
+				text = Utility::Sprintf("Button [%d] %d", obj->button.index, (*it)->delta);
 			}
 			else if(obj->type == ObjectType::Hold)
 			{

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -194,8 +194,15 @@ void Scoring::Reset()
 	}
 
 	m_heldObjects.clear();
+	
 	memset(m_holdObjects, 0, sizeof(m_holdObjects));
+	memset(m_prevHoldHit, 0, sizeof(m_prevHoldHit));
 	memset(m_currentLaserSegments, 0, sizeof(m_currentLaserSegments));
+
+	memset(m_buttonHitTime, 0, sizeof(m_buttonHitTime));
+	memset(m_buttonReleaseTime, 0, sizeof(m_buttonReleaseTime));
+	memset(m_buttonGuardTime, 0, sizeof(m_buttonGuardTime));
+
 	m_CleanupHitStats();
 	m_CleanupTicks();
 
@@ -216,7 +223,7 @@ void Scoring::Tick(float deltaTime)
 {
 	m_UpdateLasers(deltaTime);
 	m_UpdateTicks();
-	if (autoplay | autoplayButtons)
+	if (autoplay || autoplayButtons)
 	{
 		for (size_t i = 0; i < 6; i++)
 		{
@@ -643,12 +650,12 @@ void Scoring::m_OnObjectLeaved(ObjectState* obj)
 
 void Scoring::m_UpdateTicks()
 {
-	MapTime currentTime = m_playback->GetLastTime();
+	const MapTime currentTime = m_playback->GetLastTime();
 
 	// This loop checks for ticks that are missed
 	for (uint32 buttonCode = 0; buttonCode < 8; buttonCode++)
 	{
-		Input::Button button = (Input::Button)buttonCode;
+		Input::Button button = (Input::Button) buttonCode;
 
 		// List of ticks for the current button code
 		auto& ticks = m_ticks[buttonCode];
@@ -668,19 +675,24 @@ void Scoring::m_UpdateTicks()
 
 				if (tick->HasFlag(TickFlags::Hold))
 				{
-					HoldObjectState* hos = (HoldObjectState*)tick->object;
-					MapTime holdStart = hos->GetRoot()->time;
-
-					// Check buttons here for holds
-					if ((m_input && m_input->GetButton(button) && holdStart - holdHitTime < m_buttonHitTime[(uint8)button]) || autoplay || autoplayButtons)
+					assert(buttonCode < 6);
+					if (m_IsBeingHold(tick) || autoplay || autoplayButtons)
 					{
 						m_TickHit(tick, buttonCode);
 						HitStat* stat = new HitStat(tick->object);
 						stat->time = currentTime;
 						stat->rating = ScoreHitRating::Perfect;
 						hitStats.Add(stat);
-						processed = true;
+
+						m_prevHoldHit[buttonCode] = true;
 					}
+					else
+					{
+						m_TickMiss(tick, buttonCode, 0);
+
+						m_prevHoldHit[buttonCode] = false;
+					}
+					processed = true;
 				}
 				else if (tick->HasFlag(TickFlags::Laser))
 				{
@@ -768,14 +780,14 @@ void Scoring::m_UpdateTicks()
 }
 ObjectState* Scoring::m_ConsumeTick(uint32 buttonCode)
 {
-	MapTime currentTime = m_playback->GetLastTime();
-
+	const MapTime currentTime = m_playback->GetLastTime() + m_inputOffset;
 	assert(buttonCode < 8);
 
 	if (m_ticks[buttonCode].size() > 0)
 	{
 		ScoreTick* tick = m_ticks[buttonCode].front();
-		MapTime delta = currentTime - tick->time + m_inputOffset;
+
+		const MapTime delta = currentTime - tick->time;
 		ObjectState* hitObject = tick->object;
 		if (tick->HasFlag(TickFlags::Laser))
 		{
@@ -786,7 +798,7 @@ ObjectState* Scoring::m_ConsumeTick(uint32 buttonCode)
 		{
 			HoldObjectState* hos = (HoldObjectState*)hitObject;
 			hos = hos->GetRoot();
-			if (hos->time - Scoring::goodHitTime <= currentTime + m_inputOffset)
+			if (hos->time - Scoring::goodHitTime <= currentTime)
 				m_SetHoldObject(hitObject, buttonCode);
 			return nullptr;
 		}
@@ -973,9 +985,49 @@ void Scoring::m_ReleaseHoldObject(ObjectState* obj)
 		}
 	}
 }
+
 void Scoring::m_ReleaseHoldObject(uint32 index)
 {
 	m_ReleaseHoldObject(m_holdObjects[index]);
+}
+
+bool Scoring::m_IsBeingHold(const ScoreTick* tick) const
+{
+	// NOTE: all these are just heuristics. If there's a better heuristic, change this.
+	// See issue #355 for more detail.
+
+	const HoldObjectState* obj = (HoldObjectState*) tick->object;
+	const uint32 index = obj->index;
+	assert(0 <= index && index < 6);
+	
+	// Button needs to be hold at this moment.
+	// (Unless `tick` is the end of a long note; see below)
+	if (m_input && m_input->GetButton((Input::Button) index))
+	{
+		// The object currently being held must be the given hold object.
+		const ObjectState* heldObject = m_holdObjects[index];
+		if (!heldObject || heldObject->type != ObjectType::Hold) return false;
+
+		while (obj)
+		{
+			if (obj == (const HoldObjectState*)heldObject) return true;
+			obj = obj->prev;
+		}
+
+		return false;
+	}
+
+	// If this is the end of an hold but the button is not being held,
+	// it will still be counted as a hit hit as long as following two conditions are met.
+
+	// a) The previous tick for this hold object was hit.
+	if (tick->HasFlag(TickFlags::Start) || !tick->HasFlag(TickFlags::End)) return false;
+	if (!m_prevHoldHit[index]) return false;
+
+	// b) The last button release happened inside the 'near window' for the end of this hold object.
+	if (obj->time + obj->duration - m_buttonReleaseTime[index] - m_inputOffset > Scoring::goodHitTime) return false;
+
+	return true;
 }
 
 void Scoring::m_UpdateLasers(float deltaTime)
@@ -1207,6 +1259,7 @@ void Scoring::m_OnButtonReleased(Input::Button buttonCode)
 			//Logf("Button %d release bounce guard hit at %dms", Logger::Severity::Info, buttonCode, m_playback->GetLastTime());
 			return;
 		}
+		m_buttonReleaseTime[(uint32)buttonCode] = m_playback->GetLastTime();
 		m_buttonGuardTime[(uint32)buttonCode] = m_playback->GetLastTime();
 	}
 


### PR DESCRIPTION
Changed the logic based on the following hypothesis:
1. When each tick is being passed, the button must be held for the moment. (#355)
2. However, the last tick will be counted as long as...
  a. the previous hold tick was hit, and
  b. the last button released happened inside the "near window" of the end of the hold note.

Needs some playtesting though.