### PR TITLE
Update manual tilt conversion to be KSM correct

### DIFF
--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -825,7 +825,7 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream &input, bool metadataOnly)
 					ZoomControlPoint *point = new ZoomControlPoint();
 					point->time = mapTime;
 					point->index = 3;
-					point->zoom = atof(*p.second) / -(360.0 / 14.0);
+					point->zoom = atof(*p.second) * -(10.0 / 360.0);
 					point->instant = lastManualTiltPoint ? lastManualTiltPoint->time == point->time : false;
 					m_zoomControlPoints.Add(point);
 					CHECK_FIRST;

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -825,19 +825,9 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream &input, bool metadataOnly)
 					ZoomControlPoint *point = new ZoomControlPoint();
 					point->time = mapTime;
 					point->index = 3;
-					point->zoom = atof(*p.second) / -(360.0 / 10.0);
+					point->zoom = atof(*p.second) / -(360.0 / 14.0);
 					point->instant = lastManualTiltPoint ? lastManualTiltPoint->time == point->time : false;
-
-					if (fabsf(point->zoom) > 10 / 360.f)
-					{
-						// Convert KSM manual tilt values above 100 to a scale such that
-						// 150 = 17.5 and 200 = 25 degrees (corresponding to BIGGER and BIGGEST)
-						// Should only be applied to .ksh charts
-						float angle = fabsf(point->zoom) * 36.f; // Angle but divided by ten for easier calculation
-						point->zoom = Math::Sign(point->zoom) * ((((angle - 1) * 0.5f) + angle) / 36.f);
-					}
-
-					lastManualTiltPoint = m_zoomControlPoints.Add(point);
+					m_zoomControlPoints.Add(point);
 					CHECK_FIRST;
 
 					isManualTilt = true;

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -827,7 +827,8 @@ bool Beatmap::m_ProcessKShootMap(BinaryStream &input, bool metadataOnly)
 					point->index = 3;
 					point->zoom = atof(*p.second) * -(10.0 / 360.0);
 					point->instant = lastManualTiltPoint ? lastManualTiltPoint->time == point->time : false;
-					m_zoomControlPoints.Add(point);
+					
+					lastManualTiltPoint = m_zoomControlPoints.Add(point);
 					CHECK_FIRST;
 
 					isManualTilt = true;

--- a/Main/include/Camera.hpp
+++ b/Main/include/Camera.hpp
@@ -17,6 +17,7 @@ static const float KSM_PITCH_UNIT_PRE_168 = 7.0f;
 static const float KSM_PITCH_UNIT_POST_168 = 180.0f / 12;
 // Percent of m_rollIntensity where camera rolls at its slowest rate
 static const float SLOWEST_TILT_THRESHOLD = 0.1f;
+// If this value is changed, remember to change the manual tilt roll calculation in BeatmapFromKSH as well
 static const float MAX_ROLL_ANGLE = 10 / 360.f;
 static const float ROLL_SPEED = 4;
 


### PR DESCRIPTION
Conversion of manual tilt values was changed in KSM so that it is scaled based off of 10 degrees. This probably happened in update 1.70a, where roll angles were changed to be inline with SDVX and USC. This PR updates USC's manual tilt value conversion to reflect these changes.

Since there's no mention of this change in the [KSH format doc](https://github.com/m4saka/ksh/blob/master/ksh_format.md), backwards compatibility shouldn't be an issue.