### PR TITLE
Added an option for customizing score display

### DIFF
--- a/Main/include/Game.hpp
+++ b/Main/include/Game.hpp
@@ -25,7 +25,8 @@ End};
 
 struct ScoreReplay
 {
-	int32 currentScore = 0;
+	int32 currentScore = 0; //< Current score; updated during playback
+	int32 currentMaxScore = 0; //< Current max possible score; updated during playback
 	int32 maxScore = 0;
 	int32 nextHitStat = 0;
 	Vector<SimpleHitStat> replay;

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -21,7 +21,7 @@ DefineEnum(GameConfigKeys,
 		   VSync,
 		   ShowFps,
 		   ForcePortrait,
-	       LogLevel,
+		   LogLevel,
 
 		   // Game settings
 		   HiSpeed,
@@ -52,6 +52,7 @@ DefineEnum(GameConfigKeys,
 		   DistantButtonScale,
 		   BTOverFXScale,
 		   DisableBackgrounds,
+		   ScoreDisplayMode,
 
 		   // Input device setting per element
 		   LaserInputDevice,
@@ -163,6 +164,11 @@ DefineEnum(AbortMethod,
 		   None,
 		   Press,
 		   Hold)
+
+DefineEnum(ScoreDisplayModes,
+		   Additive,
+		   Subtractive,
+		   Average)
 
 #ifdef Always
 #undef Always

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -117,6 +117,16 @@ public:
 	uint32 CalculateCurrentScore() const;
 	uint32 CalculateScore(uint32 hitScore) const;
 
+	uint32 CalculateCurrentDisplayScore() const;
+	uint32 CalculateCurrentDisplayScore(const ScoreReplay& replay) const;
+	uint32 CalculateCurrentDisplayScore(uint32 currHit, uint32 currMaxHit) const;
+
+	// The score if the rest would be played perfectly
+	uint32 CalculateCurrentMaxPossibleScore(uint32 currHit, uint32 currMaxHit) const;
+
+	// The score based on the current pace
+	uint32 CalculateCurrentAverageScore(uint32 currHit, uint32 currMaxHit) const;
+
 	// Calculates the grade connected to the current score
 	// Ranges from 0 to 5 (AAA,AA,A,B,C,D) in that order
 	uint32 CalculateCurrentGrade() const;
@@ -145,7 +155,7 @@ public:
 
 	// Called when score has changed
 	//	(New Score)
-	Delegate<uint32> OnScoreChanged;
+	Delegate<> OnScoreChanged;
 
 	// Object timing window
 	static const MapTime missHitTime;

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -46,8 +46,8 @@ void GameConfig::SetKeyBinding(GameConfigKeys key, Graphics::Key value)
 
 void GameConfig::InitDefaults()
 {
-	// This will be set to appropriate value in Application::m_LoadConfig.
-	// Do not set this to GameConfig::VERSION here. It will cause problems for config files with no ConfigVersion field.
+	// Do not set ConfigVersion to GameConfig::VERSION here. It will cause problems for config files with no ConfigVersion field.
+	// For new config, ConfigVersion will be set to the appropriate value in Application::m_LoadConfig.
 	Set(GameConfigKeys::ConfigVersion, 0);
 
 	Set(GameConfigKeys::ScreenWidth, 1280);
@@ -95,6 +95,7 @@ void GameConfig::InitDefaults()
 	SetEnum<Logger::Enum_Severity>(GameConfigKeys::LogLevel, Logger::Severity::Normal);
 
 	SetEnum<Enum_SpeedMods>(GameConfigKeys::SpeedMod, SpeedMods::MMod);
+	SetEnum<Enum_ScoreDisplayModes>(GameConfigKeys::ScoreDisplayMode, ScoreDisplayModes::Additive);
 
 	// Input settings
 	SetEnum<Enum_InputDevice>(GameConfigKeys::ButtonInputDevice, InputDevice::Keyboard);

--- a/Main/src/GameplaySettingsDialog.cpp
+++ b/Main/src/GameplaySettingsDialog.cpp
@@ -141,6 +141,7 @@ bool GameplaySettingsDialog::Init()
     gameTab->settings.push_back(m_CreateToggleSetting(GameConfigKeys::RandomizeChart, "Random"));
     gameTab->settings.push_back(m_CreateToggleSetting(GameConfigKeys::MirrorChart, "Mirror"));
     gameTab->settings.push_back(m_CreateToggleSetting(GameConfigKeys::DisableBackgrounds, "Hide Backgrounds"));
+    gameTab->settings.push_back(m_CreateEnumSetting<Enum_ScoreDisplayModes>(GameConfigKeys::ScoreDisplayMode, "Score Display"));
 
     Tab hidsudTab = std::make_unique<TabData>();
     hidsudTab->name = "Hid/Sud";

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -589,6 +589,7 @@ public:
 		{
 			RenderSettingsInput();
 			RenderSettingsGame();
+			RenderSettingsDisplay();
 			RenderSettingsSystem();
 			RenderSettingsOnline();
 
@@ -731,6 +732,21 @@ public:
 			FloatSetting(GameConfigKeys::ModSpeed, "ModSpeed", 50, 1500, 0.5f);
 			ToggleSetting(GameConfigKeys::AutoSaveSpeed, "Save hispeed changes during gameplay");
 
+			ToggleSetting(GameConfigKeys::SkipScore, "Skip score screen on manual exit");
+			EnumSetting<Enum_AutoScoreScreenshotSettings>(GameConfigKeys::AutoScoreScreenshot, "Automatically capture score screenshots:");
+
+			nk_label(m_nctx, "Songs folder path:", nk_text_alignment::NK_TEXT_LEFT);
+			nk_sdl_text(nk_edit_string(m_nctx, NK_EDIT_FIELD, m_songsPath, &m_pathlen, 1024, nk_filter_default));
+
+			nk_tree_pop(m_nctx);
+		}
+	}
+
+	// Display settings
+	void RenderSettingsDisplay()
+	{
+		if (nk_tree_push(m_nctx, NK_TREE_NODE, "Display", NK_MINIMIZED))
+		{
 			nk_layout_row_dynamic(m_nctx, 75, 2);
 			if (nk_group_begin(m_nctx, "Hidden", NK_WINDOW_NO_SCROLLBAR))
 			{
@@ -750,11 +766,6 @@ public:
 			ToggleSetting(GameConfigKeys::DisableBackgrounds, "Disable Song Backgrounds");
 			FloatSetting(GameConfigKeys::DistantButtonScale, "Distant Button Scale", 1.0f, 5.0f);
 			ToggleSetting(GameConfigKeys::ShowCover, "Show Track Cover");
-			ToggleSetting(GameConfigKeys::SkipScore, "Skip score screen on manual exit");
-			EnumSetting<Enum_AutoScoreScreenshotSettings>(GameConfigKeys::AutoScoreScreenshot, "Automatically capture score screenshots:");
-
-			nk_label(m_nctx, "Songs folder path:", nk_text_alignment::NK_TEXT_LEFT);
-			nk_sdl_text(nk_edit_string(m_nctx, NK_EDIT_FIELD, m_songsPath, &m_pathlen, 1024, nk_filter_default));
 
 			if (m_skins.size() > 0)
 			{
@@ -766,7 +777,6 @@ public:
 			}
 
 			EnumSetting<Enum_ScoreDisplayModes>(GameConfigKeys::ScoreDisplayMode, "In-game score display is:");
-
 			RenderSettingsLaserColor();
 
 			nk_tree_pop(m_nctx);

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -697,7 +697,7 @@ public:
 				IntSetting(GameConfigKeys::RestartPlayHoldDuration, "Restart Hold Duration (ms):", 250, 10000, 250);
 			}
 
-			EnumSetting<Enum_AbortMethod>(GameConfigKeys::ExitPlayMethod, "Exit gameplay with:");
+			EnumSetting<Enum_AbortMethod>(GameConfigKeys::ExitPlayMethod, "Exit gameplay with Back:");
 			if (g_gameConfig.GetEnum<Enum_AbortMethod>(GameConfigKeys::ExitPlayMethod) == AbortMethod::Hold)
 			{
 				IntSetting(GameConfigKeys::ExitPlayHoldDuration, "Exit Hold Duration (ms):", 250, 10000, 250);
@@ -764,6 +764,8 @@ public:
 					g_gameWindow->SetCursor(cursorImg, Vector2i(5, 5));
 				}
 			}
+
+			EnumSetting<Enum_ScoreDisplayModes>(GameConfigKeys::ScoreDisplayMode, "In-game score display is:");
 
 			RenderSettingsLaserColor();
 


### PR DESCRIPTION
ScoreDisplayMode
* `Additive`: Default behavior; the score is added from 0
* `Subtractive`: The score is subtracted from the perfect score
* `Average`: The score is based on current accuracy

`Subtractive` is very useful for practicing.
While `Average` is not very useful compared to other two settings, I added it for completeness.

This only affects play scores and replay scores which are passed to skins.
For multiplayers, the multiplayer scoreboard (shown on the left for the default skin) is not affected.