### PR TITLE
Customizable timing window

### DIFF
--- a/Beatmap/include/Beatmap/MapDatabase.hpp
+++ b/Beatmap/include/Beatmap/MapDatabase.hpp
@@ -30,6 +30,11 @@ struct ScoreIndex
 	String userName;
 	String userId;
 	bool localScore;
+
+	int32 hitWindowPerfect;
+	int32 hitWindowGood;
+	int32 hitWindowHold;
+	int32 hitWindowMiss;
 };
 
 

--- a/Main/include/ChatOverlay.hpp
+++ b/Main/include/ChatOverlay.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "ApplicationTickable.hpp"
 #include "GameConfig.hpp"
-#include <queue>
 #include "Application.hpp"
 #include "Input.hpp"
 #include <SDL2/SDL.h>

--- a/Main/include/DownloadScreen.hpp
+++ b/Main/include/DownloadScreen.hpp
@@ -5,7 +5,6 @@
 #include "Shared/Thread.hpp"
 #include "cpr/cpr.h"
 #include "PreviewPlayer.hpp"
-#include <queue>
 
 struct ArchiveRequest
 {

--- a/Main/include/Game.hpp
+++ b/Main/include/Game.hpp
@@ -4,6 +4,7 @@
 #include <Beatmap/MapDatabase.hpp>
 #include "json.hpp"
 #include "GameFailCondition.hpp"
+#include "HitStat.hpp"
 
 class MultiplayerScreen;
 
@@ -31,6 +32,8 @@ struct ScoreReplay
 	int32 maxScore = 0;
 	size_t nextHitStat = 0;
 	Vector<SimpleHitStat> replay;
+
+	HitWindow hitWindow = HitWindow::NORMAL;
 };
 
 GameFlags operator|(const GameFlags& a, const GameFlags& b);

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -24,6 +24,9 @@ DefineEnum(GameConfigKeys,
 		   LogLevel,
 
 		   // Game settings
+		   HitWindowPerfect,
+		   HitWindowGood,
+		   HitWindowHold,
 		   HiSpeed,
 		   SpeedMod,
 		   ModSpeed,

--- a/Main/include/GameplaySettingsDialog.hpp
+++ b/Main/include/GameplaySettingsDialog.hpp
@@ -1,14 +1,21 @@
 #pragma once
 #include "BaseGameSettingsDialog.hpp"
 
+class SongSelect;
+
 class GameplaySettingsDialog: public BaseGameSettingsDialog
 {
 public:
-    GameplaySettingsDialog();
+    GameplaySettingsDialog(SongSelect* songSelectScreen);
 
     void InitTabs() override;
     void OnAdvanceTab() override;
 
     Delegate<> onPressAutoplay;
     Delegate<> onPressPractice;
+    Delegate<int> onSongOffsetChange;
+
+private:
+    SongSelect* songSelectScreen;
+    Setting m_CreateSongOffsetSetting();
 };

--- a/Main/include/HitStat.hpp
+++ b/Main/include/HitStat.hpp
@@ -42,6 +42,8 @@ struct HitWindow
 	inline HitWindow(const HitWindow& that) noexcept : perfect(that.perfect), good(that.good), hold(that.hold), miss(that.miss) { Validate(); }
 
 	static HitWindow FromConfig();
+	void SaveConfig() const;
+
 	void ToLuaTable(struct lua_State* L);
 
 	inline HitWindow& operator= (const HitWindow& that) noexcept { perfect = that.perfect; good = that.good; hold = that.hold; miss = that.miss; return *this; }

--- a/Main/include/MultiplayerScreen.hpp
+++ b/Main/include/MultiplayerScreen.hpp
@@ -5,7 +5,6 @@
 #include "Shared/Thread.hpp"
 #include "GameConfig.hpp"
 #include "cpr/cpr.h"
-#include <queue>
 #include "Beatmap/MapDatabase.hpp"
 #include "json.hpp"
 #include "TCPSocket.hpp"

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -23,16 +23,21 @@ TickFlags operator&(const TickFlags& a, const TickFlags& b);
 
 struct HitWindow
 {
+	enum class Type { None = 0, Normal, Hard };
+
 	inline HitWindow(MapTime perfect, MapTime good) noexcept : perfect(perfect), good(good) { Validate(); }
 	inline HitWindow(MapTime perfect, MapTime good, MapTime hold) noexcept : perfect(perfect), good(good), hold(hold) { Validate(); }
 	inline HitWindow(const HitWindow& that) noexcept : perfect(that.perfect), good(that.good), hold(that.hold), miss(that.miss) { Validate(); }
 
 	static HitWindow FromConfig();
+	void ToLuaTable(struct lua_State* L);
 
 	inline HitWindow& operator= (const HitWindow& that) noexcept { perfect = that.perfect; good = that.good; hold = that.hold; miss = that.miss; return *this; }
 
 	constexpr bool operator== (const HitWindow& that) const noexcept { return perfect == that.perfect && good == that.good && hold == that.hold && miss == that.miss; }
 	constexpr bool operator<= (const HitWindow& that) const noexcept { return perfect <= that.perfect && good <= that.good && hold <= that.hold && miss <= that.miss; }
+
+	constexpr Type GetType() const noexcept { if (*this <= HARD) return Type::Hard; else if (*this <= NORMAL) return Type::Normal; else return Type::None; }
 
 	inline bool Validate()
 	{

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -21,6 +21,19 @@ enum class TickFlags : uint8
 TickFlags operator|(const TickFlags& a, const TickFlags& b);
 TickFlags operator&(const TickFlags& a, const TickFlags& b);
 
+struct HitWindow
+{
+	HitWindow(MapTime perfect, MapTime good) noexcept : perfect(perfect), good(good), hold(good + (good/2)) {}
+
+	const MapTime miss = 250;
+	const MapTime hold = 138;
+	const MapTime good = 92;
+	const MapTime perfect = 46;
+
+	static const HitWindow NORMAL;
+	static const HitWindow HARD;
+};
+
 // Tick object to record hits
 struct ScoreTick
 {
@@ -29,11 +42,11 @@ public:
 	ScoreTick(ObjectState* object) : object(object) {};
 
 	// Returns the time frame in which this tick can be hit
-	MapTime GetHitWindow() const;
+	MapTime GetHitWindow(const HitWindow& hitWindow) const;
 	// Hit rating when hitting object at given time
-	ScoreHitRating GetHitRating(MapTime currentTime) const;
+	ScoreHitRating GetHitRating(const HitWindow& hitWindow, MapTime currentTime) const;
 	// Hit rating when hitting object give a delta 
-	ScoreHitRating GetHitRatingFromDelta(MapTime delta) const;
+	ScoreHitRating GetHitRatingFromDelta(const HitWindow& hitWindow, MapTime delta) const;
 	// Check a flag
 	bool HasFlag(TickFlags flag) const;
 	void SetFlag(TickFlags flag);
@@ -160,10 +173,7 @@ public:
 	Delegate<> OnScoreChanged;
 
 	// Object timing window
-	static const MapTime missHitTime;
-	static const MapTime holdHitTime;
-	static const MapTime goodHitTime;
-	static const MapTime perfectHitTime;
+	HitWindow hitWindow = HitWindow::NORMAL;
 	static const float idleLaserSpeed;
 
 	// Map total infos

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -49,10 +49,10 @@ struct HitWindow
 		return false;
 	}
 
-	MapTime miss = 250;
+	MapTime perfect = 46;
+	MapTime good = 92;
 	MapTime hold = 138;
-	MapTime good;
-	MapTime perfect;
+	MapTime miss = 250;
 
 	static const HitWindow NORMAL;
 	static const HitWindow HARD;

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -21,48 +21,6 @@ enum class TickFlags : uint8
 TickFlags operator|(const TickFlags& a, const TickFlags& b);
 TickFlags operator&(const TickFlags& a, const TickFlags& b);
 
-struct HitWindow
-{
-	enum class Type { None = 0, Normal, Hard };
-
-	inline HitWindow(MapTime perfect, MapTime good) noexcept : perfect(perfect), good(good) { Validate(); }
-	inline HitWindow(MapTime perfect, MapTime good, MapTime hold) noexcept : perfect(perfect), good(good), hold(hold) { Validate(); }
-	inline HitWindow(const HitWindow& that) noexcept : perfect(that.perfect), good(that.good), hold(that.hold), miss(that.miss) { Validate(); }
-
-	static HitWindow FromConfig();
-	void ToLuaTable(struct lua_State* L);
-
-	inline HitWindow& operator= (const HitWindow& that) noexcept { perfect = that.perfect; good = that.good; hold = that.hold; miss = that.miss; return *this; }
-
-	constexpr bool operator== (const HitWindow& that) const noexcept { return perfect == that.perfect && good == that.good && hold == that.hold && miss == that.miss; }
-	constexpr bool operator<= (const HitWindow& that) const noexcept { return perfect <= that.perfect && good <= that.good && hold <= that.hold && miss <= that.miss; }
-
-	constexpr Type GetType() const noexcept { if (*this <= HARD) return Type::Hard; else if (*this <= NORMAL) return Type::Normal; else return Type::None; }
-
-	inline bool Validate()
-	{
-		if (perfect <= good && good <= hold && hold <= miss && miss <= NORMAL.miss)
-			return true;
-
-		Logf("Invalid timing window: %d/%d/%d/%d", Logger::Severity::Warning, perfect, good, hold, miss);
-
-		if (miss > NORMAL.miss) miss = NORMAL.miss;
-		if (hold > miss) hold = miss;
-		if (good > hold) good = hold;
-		if (perfect > good) perfect = good;
-
-		return false;
-	}
-
-	MapTime perfect = 46;
-	MapTime good = 92;
-	MapTime hold = 138;
-	MapTime miss = 250;
-
-	static const HitWindow NORMAL;
-	static const HitWindow HARD;
-};
-
 // Tick object to record hits
 struct ScoreTick
 {

--- a/Main/include/SkinHttp.hpp
+++ b/Main/include/SkinHttp.hpp
@@ -2,7 +2,6 @@
 #include "stdafx.h"
 #include "Shared/Thread.hpp"
 #include "cpr/cpr.h"
-#include <queue>
 
 struct AsyncRequest
 {

--- a/Main/include/SongSelect.hpp
+++ b/Main/include/SongSelect.hpp
@@ -61,4 +61,6 @@ public:
 	virtual ~SongSelect() = default;
 	static SongSelect* Create();
 	static SongSelect* Create(MultiplayerScreen*);
+
+	virtual ChartIndex* GetCurrentSelectedChart() { return 0; }
 };

--- a/Main/include/TCPSocket.hpp
+++ b/Main/include/TCPSocket.hpp
@@ -4,7 +4,6 @@
 #include "cpr/cpr.h"
 #include "json.hpp"
 #include <stack>
-#include <queue>
 
 #ifdef _WIN32
 /* See http://stackoverflow.com/questions/12765743/getaddrinfo-on-win32 */

--- a/Main/src/CalibrationScreen.cpp
+++ b/Main/src/CalibrationScreen.cpp
@@ -261,10 +261,13 @@ void CalibrationScreen::m_OnButtonPressed(Input::Button buttonCode)
 			m_inputOffset = -m_average(m_zeroOffsetDeltas);
 		}
 
-		if (hitDelta <= Scoring::perfectHitTime) {
+		// TODO: use HitWindow based on current setting
+		HitWindow hitWindow = HitWindow::NORMAL;
+
+		if (hitDelta <= hitWindow.perfect) {
 			m_track.AddEffect(new ButtonHitEffect((int)buttonCode, m_track.hitColors[2]));
 		}
-		else if (hitDelta <= Scoring::goodHitTime) {
+		else if (hitDelta <= hitWindow.good) {
 			m_track.AddEffect(new ButtonHitEffect((int)buttonCode, m_track.hitColors[1]));
 		}
 		else {

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -1175,8 +1175,8 @@ public:
 		m_scoring.OnLaserSlam.Add(this, &Game_Impl::OnLaserSlam);
 		m_scoring.OnLaserExit.Add(this, &Game_Impl::OnLaserExit);
 
-		m_playback.hittableObjectEnter = Scoring::missHitTime + g_gameConfig.GetInt(GameConfigKeys::InputOffset);
-		m_playback.hittableObjectLeave = Scoring::goodHitTime;
+		m_playback.hittableObjectEnter = m_scoring.hitWindow.miss + g_gameConfig.GetInt(GameConfigKeys::InputOffset);
+		m_playback.hittableObjectLeave = m_scoring.hitWindow.good;
 
 		if(g_application->GetAppCommandLine().Contains("-autobuttons"))
 		{

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -24,12 +24,6 @@
 #include "GameConfig.hpp"
 #include <Shared/Time.hpp>
 
-extern "C"
-{
-#include "lua.h"
-#include "lauxlib.h"
-}
-
 #include "GUI/HealthGauge.hpp"
 #include "PracticeModeSettingsDialog.hpp"
 

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -337,6 +337,14 @@ public:
 					replay.maxScore = score->score;
 					FileReader replayReader(replayFile);
 					replayReader.SerializeObject(replay.replay);
+
+					if (replayReader.Tell() + 16 <= replayReader.GetSize())
+					{
+						replayReader.Serialize(&(replay.hitWindow.perfect), 4);
+						replayReader.Serialize(&(replay.hitWindow.good), 4);
+						replayReader.Serialize(&(replay.hitWindow.hold), 4);
+						replayReader.Serialize(&(replay.hitWindow.miss), 4);
+					}
 				}
 			}
 

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -2857,17 +2857,9 @@ return Scoring::CalculateBadge(scoreData);
 		lua_pushboolean(L, m_multiplayer != nullptr);
 		lua_settable(L, -3);
 
-		{
-			const HitWindow hitWindow = GetHitWindow();
-
-			lua_pushstring(L, "hitWindow");
-			lua_newtable(L);
-			pushIntToTable("perfect", hitWindow.perfect);
-			pushIntToTable("good", hitWindow.good);
-			pushIntToTable("hold", hitWindow.hold);
-			pushIntToTable("miss", hitWindow.miss);
-			lua_settable(L, -3);
-		}
+		lua_pushstring(L, "hitWindow");
+		GetHitWindow().ToLuaTable(L);
+		lua_settable(L, -3);
 
 		if (m_multiplayer != nullptr)
 		{

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -2,6 +2,7 @@
 #include "GameConfig.hpp"
 
 #include "Shared/Log.hpp"
+#include "Scoring.hpp"
 
 inline static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigKeys> keys)
 {
@@ -65,6 +66,10 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::ShowFps, false);
 	Set(GameConfigKeys::ForcePortrait, false);
 	Set(GameConfigKeys::SkipScore, true);
+
+	Set(GameConfigKeys::HitWindowPerfect, HitWindow::NORMAL.perfect);
+	Set(GameConfigKeys::HitWindowGood, HitWindow::NORMAL.good);
+	Set(GameConfigKeys::HitWindowHold, HitWindow::NORMAL.hold);
 	Set(GameConfigKeys::HiSpeed, 1.0f);
 	Set(GameConfigKeys::GlobalOffset, 0);
 	Set(GameConfigKeys::InputOffset, 0);

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -2,7 +2,7 @@
 #include "GameConfig.hpp"
 
 #include "Shared/Log.hpp"
-#include "Scoring.hpp"
+#include "HitStat.hpp"
 
 inline static void ConvertKeyCodeToScanCode(GameConfig& config, std::vector<GameConfigKeys> keys)
 {

--- a/Main/src/HitStat.cpp
+++ b/Main/src/HitStat.cpp
@@ -1,5 +1,9 @@
 #include "stdafx.h"
 #include "HitStat.hpp"
+#include "GameConfig.hpp"
+
+const HitWindow HitWindow::NORMAL = HitWindow(46, 92);
+const HitWindow HitWindow::HARD = HitWindow(23, 46);
 
 HitStat::HitStat(ObjectState* object) : object(object)
 {
@@ -8,4 +12,42 @@ HitStat::HitStat(ObjectState* object) : object(object)
 bool HitStat::operator<(const HitStat& other)
 {
 	return time < other.time;
+}
+
+HitWindow HitWindow::FromConfig()
+{
+	HitWindow hitWindow = HitWindow(
+		g_gameConfig.GetInt(GameConfigKeys::HitWindowPerfect),
+		g_gameConfig.GetInt(GameConfigKeys::HitWindowGood),
+		g_gameConfig.GetInt(GameConfigKeys::HitWindowHold)
+	);
+
+	if (!(hitWindow <= HitWindow::NORMAL))
+	{
+		Log("HitWindow is automatically adjusted to NORMAL", Logger::Severity::Warning);
+		hitWindow = HitWindow::NORMAL;
+
+		g_gameConfig.Set(GameConfigKeys::HitWindowPerfect, hitWindow.perfect);
+		g_gameConfig.Set(GameConfigKeys::HitWindowGood, hitWindow.good);
+		g_gameConfig.Set(GameConfigKeys::HitWindowHold, hitWindow.hold);
+	}
+
+	return hitWindow;
+}
+
+void HitWindow::ToLuaTable(lua_State* L)
+{
+	auto pushIntToTable = [&](const char* name, int data)
+	{
+		lua_pushstring(L, name);
+		lua_pushinteger(L, data);
+		lua_settable(L, -3);
+	};
+
+	lua_newtable(L);
+	pushIntToTable("type", static_cast<int>(GetType()));
+	pushIntToTable("perfect", perfect);
+	pushIntToTable("good", good);
+	pushIntToTable("hold", hold);
+	pushIntToTable("miss", miss);
 }

--- a/Main/src/HitStat.cpp
+++ b/Main/src/HitStat.cpp
@@ -26,13 +26,17 @@ HitWindow HitWindow::FromConfig()
 	{
 		Log("HitWindow is automatically adjusted to NORMAL", Logger::Severity::Warning);
 		hitWindow = HitWindow::NORMAL;
-
-		g_gameConfig.Set(GameConfigKeys::HitWindowPerfect, hitWindow.perfect);
-		g_gameConfig.Set(GameConfigKeys::HitWindowGood, hitWindow.good);
-		g_gameConfig.Set(GameConfigKeys::HitWindowHold, hitWindow.hold);
+		hitWindow.SaveConfig();
 	}
 
 	return hitWindow;
+}
+
+void HitWindow::SaveConfig() const
+{
+	g_gameConfig.Set(GameConfigKeys::HitWindowPerfect, perfect);
+	g_gameConfig.Set(GameConfigKeys::HitWindowGood, good);
+	g_gameConfig.Set(GameConfigKeys::HitWindowHold, hold);
 }
 
 void HitWindow::ToLuaTable(lua_State* L)

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -366,6 +366,11 @@ public:
 			newScore->userName = g_gameConfig.GetString(GameConfigKeys::MultiplayerUsername);
 			newScore->localScore = true;
 
+			newScore->hitWindowPerfect = m_hitWindow.perfect;
+			newScore->hitWindowGood = m_hitWindow.good;
+			newScore->hitWindowHold = m_hitWindow.hold;
+			newScore->hitWindowMiss = m_hitWindow.miss;
+
 			m_mapDatabase.AddScore(newScore);
 
 		 	chart->scores.Add(newScore);

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -38,6 +38,8 @@ private:
 	String m_jacketPath;
 	uint32 m_timedHits[2];
 
+	HitWindow m_hitWindow = HitWindow::NORMAL;
+
 	//0 = normal, 1 = absolute
 	float m_meanHitDelta[2] = {0.f, 0.f};
 	MapTime m_medianHitDelta[2] = {0, 0};
@@ -170,6 +172,8 @@ public:
 
 		m_meanHitDelta[1] = scoring.GetMeanHitDelta(true);
 		m_medianHitDelta[1] = scoring.GetMedianHitDelta(true);
+
+		m_hitWindow = scoring.hitWindow;
 
 		// Make texture for performance graph samples
 		m_graphTex = TextureRes::Create(g_gl);
@@ -440,6 +444,10 @@ public:
 			m_PushStringToTable("mission", m_mission);
 			m_PushIntToTable("retryCount", m_retryCount);
 		}
+
+		lua_pushstring(m_lua, "hitWindow");
+		m_hitWindow.ToLuaTable(m_lua);
+		lua_settable(m_lua, -3);
 
 		//Push gauge samples
 		lua_pushstring(m_lua, "gaugeSamples");

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -348,6 +348,10 @@ public:
 			{
 				FileWriter fw(replayFile);
 				fw.SerializeObject(m_simpleHitStats);
+				fw.Serialize(&(m_hitWindow.perfect), 4);
+				fw.Serialize(&(m_hitWindow.good), 4);
+				fw.Serialize(&(m_hitWindow.hold), 4);
+				fw.Serialize(&(m_hitWindow.miss), 4);
 			}
 
 			newScore->score = m_score;

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1019,7 +1019,7 @@ bool Scoring::m_IsBeingHold(const ScoreTick* tick) const
 	if (!m_prevHoldHit[index]) return false;
 
 	// b) The last button release happened inside the 'near window' for the end of this hold object.
-	if (obj->time + obj->duration - m_buttonReleaseTime[index] - m_inputOffset > hitWindow.hold) return false;
+	if (obj->time + obj->duration - m_buttonReleaseTime[index] - static_cast<MapTime>(m_inputOffset) > hitWindow.hold) return false;
 
 	return true;
 }

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -4,15 +4,6 @@
 #include <math.h>
 #include "GameConfig.hpp"
 
-extern "C"
-{
-#include "lua.h"
-#include "lauxlib.h"
-}
-
-const HitWindow HitWindow::NORMAL = HitWindow(46, 92);
-const HitWindow HitWindow::HARD = HitWindow(23, 46);
-
 const float Scoring::idleLaserSpeed = 1.0f;
 
 Scoring::Scoring()
@@ -1426,42 +1417,4 @@ TickFlags operator|(const TickFlags& a, const TickFlags& b)
 TickFlags operator&(const TickFlags& a, const TickFlags& b)
 {
 	return (TickFlags)((uint8)a & (uint8)b);
-}
-
-HitWindow HitWindow::FromConfig()
-{
-	HitWindow hitWindow = HitWindow(
-		g_gameConfig.GetInt(GameConfigKeys::HitWindowPerfect),
-		g_gameConfig.GetInt(GameConfigKeys::HitWindowGood),
-		g_gameConfig.GetInt(GameConfigKeys::HitWindowHold)
-	);
-
-	if (!(hitWindow <= HitWindow::NORMAL))
-	{
-		Log("HitWindow is automatically adjusted to NORMAL", Logger::Severity::Warning);
-		hitWindow = HitWindow::NORMAL;
-
-		g_gameConfig.Set(GameConfigKeys::HitWindowPerfect, hitWindow.perfect);
-		g_gameConfig.Set(GameConfigKeys::HitWindowGood, hitWindow.good);
-		g_gameConfig.Set(GameConfigKeys::HitWindowHold, hitWindow.hold);
-	}
-
-	return hitWindow;
-}
-
-void HitWindow::ToLuaTable(lua_State* L)
-{
-	auto pushIntToTable = [&](const char* name, int data)
-	{
-		lua_pushstring(L, name);
-		lua_pushinteger(L, data);
-		lua_settable(L, -3);
-	};
-
-	lua_newtable(L);
-	pushIntToTable("type", static_cast<int>(GetType()));
-	pushIntToTable("perfect", perfect);
-	pushIntToTable("good", good);
-	pushIntToTable("hold", hold);
-	pushIntToTable("miss", miss);
 }

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -136,6 +136,7 @@ void Scoring::Reset(const MapTimeRange& range)
 	m_assistPunish = g_gameConfig.GetFloat(GameConfigKeys::LaserPunish);
 	m_assistChangeExponent = g_gameConfig.GetFloat(GameConfigKeys::LaserChangeExponent);
 	m_assistChangePeriod = g_gameConfig.GetFloat(GameConfigKeys::LaserChangeTime);
+
 	// Recalculate maximum score
 	mapTotals = CalculateMapTotals();
 
@@ -1419,4 +1420,13 @@ TickFlags operator|(const TickFlags& a, const TickFlags& b)
 TickFlags operator&(const TickFlags& a, const TickFlags& b)
 {
 	return (TickFlags)((uint8)a & (uint8)b);
+}
+
+HitWindow HitWindow::FromConfig()
+{
+	return HitWindow(
+		g_gameConfig.GetInt(GameConfigKeys::HitWindowPerfect),
+		g_gameConfig.GetInt(GameConfigKeys::HitWindowGood),
+		g_gameConfig.GetInt(GameConfigKeys::HitWindowHold)
+	);
 }

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -264,9 +264,7 @@ private:
 		g_gameConfig.Set(GameConfigKeys::Laser1Color, m_laserColors[1]);
 
 		m_hitWindow.Validate();
-		g_gameConfig.Set(GameConfigKeys::HitWindowPerfect, m_hitWindow.perfect);
-		g_gameConfig.Set(GameConfigKeys::HitWindowGood, m_hitWindow.good);
-		g_gameConfig.Set(GameConfigKeys::HitWindowHold, m_hitWindow.hold);
+		m_hitWindow.SaveConfig();
 
 		String songsPath = String(m_songsPath, m_pathlen);
 		songsPath.TrimBack('\n');

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -204,6 +204,8 @@ private:
 	bool m_useBTGamepad = false;
 	bool m_useLaserGamepad = false;
 	bool m_altBinds = false;
+	
+	HitWindow m_hitWindow = HitWindow::NORMAL;
 
 	String m_skinBeforeSkinSettings = "";
 
@@ -261,6 +263,11 @@ private:
 
 		g_gameConfig.Set(GameConfigKeys::Laser0Color, m_laserColors[0]);
 		g_gameConfig.Set(GameConfigKeys::Laser1Color, m_laserColors[1]);
+
+		m_hitWindow.Validate();
+		g_gameConfig.Set(GameConfigKeys::HitWindowPerfect, m_hitWindow.perfect);
+		g_gameConfig.Set(GameConfigKeys::HitWindowGood, m_hitWindow.good);
+		g_gameConfig.Set(GameConfigKeys::HitWindowHold, m_hitWindow.hold);
 
 		String songsPath = String(m_songsPath, m_pathlen);
 		songsPath.TrimBack('\n');
@@ -502,6 +509,8 @@ public:
 		m_laserColors[0] = g_gameConfig.GetFloat(GameConfigKeys::Laser0Color);
 		m_laserColors[1] = g_gameConfig.GetFloat(GameConfigKeys::Laser1Color);
 
+		m_hitWindow = HitWindow::FromConfig();
+
 		String songspath = g_gameConfig.GetString(GameConfigKeys::SongFolder);
 		strcpy(m_songsPath, songspath.c_str());
 		m_pathlen = songspath.length();
@@ -739,6 +748,55 @@ public:
 
 			ToggleSetting(GameConfigKeys::SkipScore, "Skip score screen on manual exit");
 			EnumSetting<Enum_AutoScoreScreenshotSettings>(GameConfigKeys::AutoScoreScreenshot, "Automatically capture score screenshots:");
+
+			{
+				nk_label(m_nctx, "Timing Window:", nk_text_alignment::NK_TEXT_LEFT);
+				nk_layout_row_dynamic(m_nctx, 30, 3);
+
+				const int hitWindowPerfect = nk_propertyi_sdl_text(m_nctx, "Crit", 0, m_hitWindow.perfect, HitWindow::NORMAL.miss, 1, 1);
+				if (hitWindowPerfect != m_hitWindow.perfect)
+				{
+					m_hitWindow.perfect = hitWindowPerfect;
+					if (m_hitWindow.good < m_hitWindow.perfect)
+						m_hitWindow.good = m_hitWindow.perfect;
+					if (m_hitWindow.hold < m_hitWindow.perfect)
+						m_hitWindow.hold = m_hitWindow.perfect;
+				}
+
+				const int hitWindowGood = nk_propertyi_sdl_text(m_nctx, "Near", 0, m_hitWindow.good, HitWindow::NORMAL.miss, 1, 1);
+				if (hitWindowGood != m_hitWindow.good)
+				{
+					m_hitWindow.good = hitWindowGood;
+					if (m_hitWindow.good < m_hitWindow.perfect)
+						m_hitWindow.perfect = m_hitWindow.good;
+					if (m_hitWindow.hold < m_hitWindow.good)
+						m_hitWindow.hold = m_hitWindow.good;
+				}
+
+				const int hitWindowHold = nk_propertyi_sdl_text(m_nctx, "Hold", 0, m_hitWindow.hold, HitWindow::NORMAL.miss, 1, 1);
+				if (hitWindowHold != m_hitWindow.hold)
+				{
+					m_hitWindow.hold = hitWindowHold;
+					if (m_hitWindow.hold < m_hitWindow.perfect)
+						m_hitWindow.perfect = m_hitWindow.hold;
+					if (m_hitWindow.hold < m_hitWindow.good)
+						m_hitWindow.good = m_hitWindow.hold;
+				}
+
+				nk_layout_row_dynamic(m_nctx, 30, 2);
+
+				if (nk_button_label(m_nctx, "Set to NORMAL (default)"))
+				{
+					m_hitWindow = HitWindow::NORMAL;
+				}
+
+				if (nk_button_label(m_nctx, "Set to HARD"))
+				{
+					m_hitWindow = HitWindow::HARD;
+				}
+
+				nk_layout_row_dynamic(m_nctx, 30, 1);
+			}
 
 			nk_label(m_nctx, "Songs folder path:", nk_text_alignment::NK_TEXT_LEFT);
 			nk_sdl_text(nk_edit_string(m_nctx, NK_EDIT_FIELD, m_songsPath, &m_pathlen, 1024, nk_filter_default));

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -13,7 +13,6 @@
 #include "ScoreScreen.hpp"
 #include "Shared/Enum.hpp"
 #include "Input.hpp"
-#include <queue>
 #include <SDL2/SDL.h>
 #include "nanovg.h"
 #include "CalibrationScreen.hpp"

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -753,7 +753,7 @@ public:
 				nk_label(m_nctx, "Timing Window:", nk_text_alignment::NK_TEXT_LEFT);
 				nk_layout_row_dynamic(m_nctx, 30, 3);
 
-				const int hitWindowPerfect = nk_propertyi_sdl_text(m_nctx, "Crit", 0, m_hitWindow.perfect, HitWindow::NORMAL.miss, 1, 1);
+				const int hitWindowPerfect = nk_propertyi_sdl_text(m_nctx, "Crit", 0, m_hitWindow.perfect, HitWindow::NORMAL.perfect, 1, 1);
 				if (hitWindowPerfect != m_hitWindow.perfect)
 				{
 					m_hitWindow.perfect = hitWindowPerfect;
@@ -763,7 +763,7 @@ public:
 						m_hitWindow.hold = m_hitWindow.perfect;
 				}
 
-				const int hitWindowGood = nk_propertyi_sdl_text(m_nctx, "Near", 0, m_hitWindow.good, HitWindow::NORMAL.miss, 1, 1);
+				const int hitWindowGood = nk_propertyi_sdl_text(m_nctx, "Near", 0, m_hitWindow.good, HitWindow::NORMAL.good, 1, 1);
 				if (hitWindowGood != m_hitWindow.good)
 				{
 					m_hitWindow.good = hitWindowGood;
@@ -773,7 +773,7 @@ public:
 						m_hitWindow.hold = m_hitWindow.good;
 				}
 
-				const int hitWindowHold = nk_propertyi_sdl_text(m_nctx, "Hold", 0, m_hitWindow.hold, HitWindow::NORMAL.miss, 1, 1);
+				const int hitWindowHold = nk_propertyi_sdl_text(m_nctx, "Hold", 0, m_hitWindow.hold, HitWindow::NORMAL.hold, 1, 1);
 				if (hitWindowHold != m_hitWindow.hold)
 				{
 					m_hitWindow.hold = hitWindowHold;

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -1331,7 +1331,7 @@ private:
 	PreviewParams m_previewParams;
 
 	Timer m_dbUpdateTimer;
-	MapDatabase *m_mapDatabase;
+	MapDatabase* m_mapDatabase;
 
 	// Map selection wheel
 	Ref<SelectionWheel> m_selectionWheel;
@@ -1346,7 +1346,7 @@ private:
 	PreviewPlayer m_previewPlayer;
 
 	// Current map that has music being preview played
-	ChartIndex *m_currentPreviewAudio;
+	ChartIndex* m_currentPreviewAudio;
 
 	// Select sound
 	Sample m_selectSound;
@@ -1363,9 +1363,9 @@ private:
 	uint64_t m_previewDelayTicks = 0;
 	Map<Input::Button, float> m_timeSinceButtonPressed;
 	Map<Input::Button, float> m_timeSinceButtonReleased;
-	lua_State *m_lua = nullptr;
+	lua_State* m_lua = nullptr;
 
-	MultiplayerScreen *m_multiplayer = nullptr;
+	MultiplayerScreen* m_multiplayer = nullptr;
 	CollectionDialog m_collDiag;
 	GameplaySettingsDialog m_settDiag;
 
@@ -1373,9 +1373,11 @@ private:
 	bool m_transitionedToGame = false;
 	int32 m_lastMapIndex = -1;
 
-	DBUpdateScreen *m_dbUpdateScreen = nullptr;
+	DBUpdateScreen* m_dbUpdateScreen = nullptr;
 
 public:
+	SongSelect_Impl() : m_settDiag(this) {}
+
 	bool AsyncLoad() override
 	{
 		m_selectSound = g_audio->CreateSample("audio/menu_click.wav");
@@ -1424,22 +1426,10 @@ public:
 
 	void m_SetCurrentChartOffset(int newValue)
 	{
-		ChartIndex* chart = m_selectionWheel->GetSelectedChart();
-		if (chart)
+		if (ChartIndex* chart = GetCurrentSelectedChart())
 		{
 			chart->custom_offset = newValue;
 		}
-	}
-
-	int m_GetCurrentChartOffset()
-	{
-		ChartIndex* chart = m_selectionWheel->GetSelectedChart();
-		if (chart)
-		{
-			return m_selectionWheel->GetSelectedChart()->custom_offset;
-		}
-
-		return 0;
 	}
 
 	bool AsyncFinalize() override
@@ -1502,23 +1492,12 @@ public:
 		if (!m_settDiag.Init())
 			return false;
 
-		GameplaySettingsDialog::Tab songTab = std::make_unique<GameplaySettingsDialog::TabData>();
-		GameplaySettingsDialog::Setting songOffsetSetting = std::make_unique<GameplaySettingsDialog::SettingData>("Song Offset", SettingType::Integer);
-		songTab->name = "Song";
-		songOffsetSetting->name = "Song Offset";
-		songOffsetSetting->type = SettingType::Integer;
-		songOffsetSetting->intSetting.val = 0;
-		songOffsetSetting->intSetting.min = -200;
-		songOffsetSetting->intSetting.max = 200;
-		songOffsetSetting->setter.AddLambda([this](const auto& data) { m_SetCurrentChartOffset(data.intSetting.val); });
-		songOffsetSetting->getter.AddLambda([this](auto& data) { data.intSetting.val = m_GetCurrentChartOffset(); });
-		songTab->settings.push_back(std::move(songOffsetSetting));
-		m_settDiag.AddTab(std::move(songTab));
+		m_settDiag.onSongOffsetChange.Add(this, &SongSelect_Impl::m_SetCurrentChartOffset);
 
 		m_settDiag.onPressAutoplay.AddLambda([this]() {
 			if (m_multiplayer != nullptr) return;
 
-			ChartIndex* chart = m_selectionWheel->GetSelectedChart();
+			ChartIndex* chart = GetCurrentSelectedChart();
 			Game* game = Game::Create(chart, Game::FlagsFromSettings());
 			if (!game)
 			{
@@ -1538,7 +1517,7 @@ public:
 		m_settDiag.onPressPractice.AddLambda([this]() {
 			if (m_multiplayer != nullptr) return;
 
-			ChartIndex* chart = m_selectionWheel->GetSelectedChart();
+			ChartIndex* chart = GetCurrentSelectedChart();
 			m_mapDatabase->UpdateChartOffset(chart);
 
 			Game* practiceGame = Game::CreatePractice(chart, Game::FlagsFromSettings());
@@ -1679,13 +1658,13 @@ public:
 				if (m_multiplayer != nullptr)
 				{
 					// When we are in multiplayer, just report the song and exit instead
-					m_multiplayer->SetSelectedMap(folder, m_selectionWheel->GetSelectedChart());
+					m_multiplayer->SetSelectedMap(folder, GetCurrentSelectedChart());
 
 					g_application->RemoveTickable(this);
 					return;
 				}
 
-				ChartIndex *chart = m_selectionWheel->GetSelectedChart();
+				ChartIndex* chart = GetCurrentSelectedChart();
 				m_mapDatabase->UpdateChartOffset(chart);
 				Game *game = Game::Create(chart, Game::FlagsFromSettings());
 				if (!game)
@@ -1737,11 +1716,11 @@ public:
 				{
 				case Input::Button::BT_1:
 					if (g_input.GetButton(Input::Button::BT_2))
-						m_collDiag.Open(*m_selectionWheel->GetSelectedChart());
+						m_collDiag.Open(*GetCurrentSelectedChart());
 					break;
 				case Input::Button::BT_2:
 					if (g_input.GetButton(Input::Button::BT_1))
-						m_collDiag.Open(*m_selectionWheel->GetSelectedChart());
+						m_collDiag.Open(*GetCurrentSelectedChart());
 					break;
 
 				case Input::Button::FX_1:
@@ -1884,7 +1863,7 @@ public:
 			}
 			else if (code == SDL_SCANCODE_F1 && m_hasCollDiag)
 			{
-				m_collDiag.Open(*m_selectionWheel->GetSelectedChart());
+				m_collDiag.Open(*GetCurrentSelectedChart());
 			}
 			else if (code == SDL_SCANCODE_F2)
 			{
@@ -1919,7 +1898,7 @@ public:
 				String paramFormat = g_gameConfig.GetString(GameConfigKeys::EditorParamsFormat);
 				String path = Path::Normalize(g_gameConfig.GetString(GameConfigKeys::EditorPath));
 				String param = Utility::Sprintf(paramFormat.c_str(),
-												Utility::Sprintf("\"%s\"", Path::Absolute(m_selectionWheel->GetSelectedChart()->path)));
+												Utility::Sprintf("\"%s\"", Path::Absolute(GetCurrentSelectedChart()->path)));
 				Path::Run(path, param.GetData());
 			}
 			else if (code == SDL_SCANCODE_F12)
@@ -2093,6 +2072,11 @@ public:
 	void MakeMultiplayer(MultiplayerScreen *multiplayer)
 	{
 		m_multiplayer = multiplayer;
+	}
+
+	virtual ChartIndex* GetCurrentSelectedChart() override
+	{
+		return m_selectionWheel->GetSelectedChart();
 	}
 };
 

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -43,6 +43,12 @@
 #include <Graphics/Font.hpp>
 using namespace Graphics;
 
+extern "C"
+{
+#include "lua.h"
+#include "lauxlib.h"
+}
+
 #include "BasicDefinitions.hpp"
 
 // Asset loading macro

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -26,6 +26,8 @@
 #include <memory>
 #include <functional>
 
+#include <queue>
+
 // TODO: reference additional headers your program requires here
 #include <Shared/Shared.hpp>
 

--- a/bin/skins/Default/scripts/gameplay.lua
+++ b/bin/skins/Default/scripts/gameplay.lua
@@ -355,6 +355,8 @@ function render(deltaTime)
         then play_mode = "Autoplay"
     elseif gameplay.playbackSpeed ~= nil and gameplay.playbackSpeed < 1
         then play_mode = string.format("Speed: x%.2f", gameplay.playbackSpeed)
+    elseif gameplay.hitWindow ~= nil and gameplay.hitWindow.type == 0
+        then play_mode = "Expand Judge"
     end
     
     if play_mode ~= "" then

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -252,6 +252,10 @@ render = function(deltaTime, showStats)
 	    gfx.FontSize(50)
 		gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
 		gfx.Text("Autoplay", 250, 345)
+    elseif result.hitWindow ~= nil and result.hitWindow.type == 0 then
+	    gfx.FontSize(30)
+		gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
+		gfx.Text("Expand Judge", 250, 360)
 	end
 	
     --Score data


### PR DESCRIPTION
Note: this PR is incompatible with #374 

- Custom window settings for perfects, nears, and holds
    - The timing windows are saved (on replay files and in the DB) for every replays.
    - Relevant infos are passed to skins via `gameplay.hitWindow` and `result.hitWindow`
- There are two preset window values
    - Normal: 46/92/138ms
    - Hard: 23/46/138ms
         - **Any opinions on which value to set for hold window?**
- To prevent abusing, window values wider than the normal window is not settable by default.
    - Even though the wider values can be set by editing the config file directly, the default skin would display "Expand Judge" for gameplay and result screens.
    - Also, for wide timing windows the score will not be saved.
- For multiplayers, the normal timing window is forced.

This is the first part of my attempt for improving timing-related auxiliary features.
Separating "hard-mode" from "normal mode" (like Jubeat does) is the end goal here, but I'm not planning to implement that soon.