### PR TITLE
Remove -Werror

### DIFF
--- a/Main/CMakeLists.txt
+++ b/Main/CMakeLists.txt
@@ -63,7 +63,7 @@ if(MSVC)
     set_target_properties(usc-game PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
     set_target_properties(usc-game PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
 elseif(NOT APPLE)
-    target_compile_options(usc-game PUBLIC -Wall -Wextra -Werror -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function)
+    target_compile_options(usc-game PUBLIC -Wall -Wextra -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function)
 endif(MSVC)
 
 # Dependencies


### PR DESCRIPTION
-Werror should never be use in build as this might prompt new errors when a compiler choose to add some new warning by default.