### PR TITLE
Fixed crash related to unzipping EUC-JP archives

### DIFF
--- a/Shared/include/Shared/StringEncoding.hpp
+++ b/Shared/include/Shared/StringEncoding.hpp
@@ -15,7 +15,8 @@ enum class StringEncoding
 	CP850, DOS_Latin1 = CP850,
 	CP923, ISO8859_15 = CP923,
 	CP932, ShiftJIS = CP932,
-	CP949, EUC_KR = CP949
+	CP949, EUC_KR = CP949,
+	CP954, EUC_JP = CP954
 };
 
 constexpr const char* GetDisplayString(const StringEncoding encoding)
@@ -27,6 +28,7 @@ constexpr const char* GetDisplayString(const StringEncoding encoding)
 	case StringEncoding::CP923: return "CP923 (aka ISO 8859-15)";
 	case StringEncoding::CP932: return "CP932 (or ShiftJIS)";
 	case StringEncoding::CP949: return "CP949 (or EUC-KR)";
+	case StringEncoding::CP954: return "CP954 (or EUC-JP)";
 	case StringEncoding::Unknown: return "Unknown";
 	default: return "[an unknown encoding]";
 	}

--- a/Shared/include/Shared/StringEncodingConverter.hpp
+++ b/Shared/include/Shared/StringEncodingConverter.hpp
@@ -45,6 +45,7 @@ inline constexpr const char* StringEncodingConverter::GetIConvArg(const StringEn
 	case StringEncoding::CP923: return "cp923";
 	case StringEncoding::CP932: return "cp932";
 	case StringEncoding::CP949: return "cp949";
+	case StringEncoding::CP954: return "EUC-JP";
 
 	case StringEncoding::Unknown: default: return "";
 	}

--- a/Shared/include/Shared/StringEncodingHeuristic.hpp
+++ b/Shared/include/Shared/StringEncodingHeuristic.hpp
@@ -285,4 +285,15 @@ protected:
 	CharClass GetCharClass(const uint16_t ch) const override;
 };
 
+// Umm... Let's ignore JIS X 0212 for now...
+class CP954Heuristic : public TwoByteEncodingHeuristic
+{
+public:
+	StringEncoding GetEncoding() const override { return StringEncoding::CP954; }
+
+protected:
+	bool RequiresSecondByte(const uint8_t ch) const override;
+	CharClass GetCharClass(const uint16_t ch) const override;
+};
+
 #pragma endregion

--- a/Shared/src/StringEncodingConverter.cpp
+++ b/Shared/src/StringEncodingConverter.cpp
@@ -47,7 +47,7 @@ String StringEncodingConverter::ToUTF8(StringEncoding encoding, const char* str,
 			continue;
 		}
 
-		Logf("Error in StringEncodingConverter::ToUTF8: iconv failed with %d for encoding %s", Logger::Severity::Error, err, encoding);
+		Logf("Error in StringEncodingConverter::ToUTF8: iconv failed with %d for encoding %s", Logger::Severity::Error, err, GetDisplayString(encoding));
 		iconv_close(conv_d);
 		return String(str);
 	}

--- a/Shared/src/StringEncodingDetector.cpp
+++ b/Shared/src/StringEncodingDetector.cpp
@@ -9,13 +9,13 @@
 #include "archive.h"
 #include "archive_entry.h"
 
-// Other encodings, such as ISO 8859-15 and CP850, are disabled because they are not as frequent as others.
 class StringEncodingDetectorInternal final : public TieredStringEncodingHeuristic
 <
 	// UTF-8 always take top priority
 	StringEncodingHeuristicCollection<UTF8Heuristic>,
-	StringEncodingHeuristicCollection<CP932Heuristic>
-	// If heuristics become robust enough, re-enable these
+	// Japanese encodings take priority over others
+	StringEncodingHeuristicCollection<CP932Heuristic, CP954Heuristic>
+	// Disabled because they are not as frequent as ShiftJIS or EUC-JP
 	// StringEncodingHeuristicCollection<CP949Heuristic, CP850Heuristic, CP923Heuristic>
 >
 {};

--- a/Shared/src/StringEncodingHeuristic.cpp
+++ b/Shared/src/StringEncodingHeuristic.cpp
@@ -213,7 +213,7 @@ CharClass CP949Heuristic::GetEUCKRCharClass(const uint16_t ch) const
 	if (0xA3B0 <= ch && ch <= 0xA3B9 || 0xA3C1 <= ch && ch <= 0xA3DA || 0xA3E1 <= ch && ch <= 0xA3FA)
 		return CharClass::ALNUM;
 
-	// Kanji (Every kanji is regarded as rare even though some are not...)
+	// Kanji (Every kanji will be regarded as rare even though some are not...)
 	if (0xCAA1 <= ch && ch <= 0xFDFE)
 		return CharClass::KANJI_KSX1001;
 
@@ -265,8 +265,54 @@ CharClass CP949Heuristic::GetCharClass(const uint16_t ch) const
 	return CharClass::INVALID;
 }
 
+bool CP954Heuristic::RequiresSecondByte(const uint8_t ch) const
+{
+	return ch == 0x8E || 0xA1 <= ch && ch <= 0xFE;
+}
+
+CharClass CP954Heuristic::GetCharClass(const uint16_t ch) const
+{
+	if (ch < 0x80) return GetAsciiCharClass(static_cast<uint8_t>(ch));
+	if (ch < 0xFF) return CharClass::INVALID;
+
+	const uint8_t hi = static_cast<uint8_t>(ch >> 8);
+	const uint8_t lo = static_cast<uint8_t>(ch & 0xFF);
+
+	// JIS X 0201-jp
+	if (hi == 0x8E)
+	{
+		if (0xA1 <= lo && lo <= 0xA5 || lo == 0xDE || lo == 0xDF) return CharClass::OTHER_CHARS;
+		if (0xA6 <= lo && lo <= 0xDD) return CharClass::KANA;
+		return CharClass::INVALID;
+	}
+
+	if (hi < 0xA1 || hi > 0xFE || lo < 0xA1 || lo > 0xFE)
+		return CharClass::INVALID;
+
+	if (0xA2AF <= ch && ch <= 0xA2B9 || 0xA2C2 <= ch && ch <= 0xA2C9 || 0xA2D1 <= ch && ch <= 0xA2DB || 0xA2EB <= ch && ch <= 0xA2F1 || 0xA2FA <= ch && ch <= 0xA2FD)
+		return CharClass::INVALID;
+
+	if (ch <= 0xA2FE)
+		return CharClass::OTHER_CHARS;
+
+	if (0xA3B0 <= ch && ch <= 0xA3B9 || 0xA3C1 <= ch && ch <= 0xA3DA || 0xA3E1 <= ch && ch <= 0xA3FA)
+		return CharClass::ALNUM;
+
+	if (0xA4A1 <= ch && ch <= 0xA4F3 || 0xA5A1 <= ch && ch <= 0xA5F6)
+		return CharClass::KANA;
+
+	if (0xA6A1 <= ch && ch <= 0xA6B8 || 0xA6C1 <= ch && ch <= 0xA6D8 || 0xA7A1 <= ch && ch <= 0xA7C1 || 0xA7D1 <= ch && ch <= 0xA7F1 || 0xA8A1 <= ch && ch <= 0xA8C0)
+		return CharClass::OTHER_CHARS;
+
+	if (0xB0A1 <= ch && ch <= 0xCFD3 || 0xD0A1 <= ch && ch <= 0xF4A6)
+		return CharClass::KANJI_LEVEL_1;
+
+	return CharClass::INVALID;
+}
+
 // For debugging
 void StringEncodingHeuristic::DebugPrint() const
 {
-	Logf("Score: [%d] / Length: [%d] / Encoding: [%s]", Logger::Severity::Info, static_cast<int>(m_score), static_cast<int>(m_count), GetDisplayString(GetEncoding()));
+	Logf("Score: [%d] / Length: [%d] / Encoding: [%s]", Logger::Severity::Info,
+		static_cast<int>(m_score), static_cast<int>(m_count), GetDisplayString(GetEncoding()));
 }


### PR DESCRIPTION
Fixes the problem where downloading [this chart](https://ksm.dev/songs/33eb99b0-e8cc-11ea-8e1b-6fa10e1fdc61) crashes.
There's no false-positives for EUC-JPs among test-cases, so enabling EUC-JP looks OK.