### PR TITLE
Fixed rare glitch (or crash) when FX is being hit.

### DIFF
--- a/Audio/include/Audio/AudioBase.hpp
+++ b/Audio/include/Audio/AudioBase.hpp
@@ -7,8 +7,26 @@ class DSP
 {
 protected:
 	DSP() = default; // Abstract
+	DSP(const DSP&) = delete;
+
+	inline void SetSampleRate(uint32 sampleRate) {  m_sampleRate = sampleRate; }
+	uint32 GetStartSample() const;
+	uint32 GetCurrentSample() const;
+
+	// Smpling rate of m_audio (not m_audioBase)
+	// Only use this for initializing parameters
+	uint32 m_sampleRate = 0;
+
+	class AudioBase* m_audioBase = nullptr;
+	class Audio_Impl* m_audio = nullptr;
+
 public:
 	virtual ~DSP();
+
+	void SetAudio(class Audio_Impl* audio);
+	void SetAudioBase(class AudioBase* audioBase);
+	inline void RemoveAudioBase() { m_audioBase = nullptr; }
+
 	// Process <numSamples> amount of samples in stereo float format
 	virtual void Process(float* out, uint32 numSamples) = 0;
 	virtual const char* GetName() const = 0;
@@ -18,8 +36,6 @@ public:
 	uint32 startTime = 0;
 	int32 chartOffset = 0;
 	int32 lastTimingPoint = 0;
-	class AudioBase* audioBase = nullptr;
-	class Audio_Impl* audio = nullptr;
 };
 
 /*
@@ -37,6 +53,9 @@ public:
 
 	// Get the sample rate of this audio stream
 	virtual uint32 GetSampleRate() const = 0;
+
+	// Get the sample rate of the audio connected to this
+	uint32 GetAudioSampleRate() const;
 
 	// Gets pcm data from a decoded stream, nullptr if not available
 	virtual float* GetPCM() = 0;

--- a/Audio/include/Audio/AudioBase.hpp
+++ b/Audio/include/Audio/AudioBase.hpp
@@ -60,7 +60,7 @@ public:
 	// Gets pcm data from a decoded stream, nullptr if not available
 	virtual float* GetPCM() = 0;
 
-	void ProcessDSPs(float*& out, uint32 numSamples);
+	void ProcessDSPs(float* out, uint32 numSamples);
 	// Adds a signal processor to the audio
 	void AddDSP(DSP* dsp);
 	// Removes a signal processor from the audio

--- a/Audio/include/Audio/DSP.hpp
+++ b/Audio/include/Audio/DSP.hpp
@@ -20,7 +20,7 @@ public:
 class BQFDSP : public DSP
 {
 public:
-	BQFDSP();
+	BQFDSP(uint32 sampleRate);
 	float b0 = 1.0f;
 	float b1 = 0.0f;
 	float b2 = 0.0f;
@@ -52,6 +52,7 @@ private:
 class CombinedFilterDSP : public DSP
 {
 public:
+	CombinedFilterDSP(uint32 sampleRate);
 	void SetLowPass(float q, float freq, float peakQ, float peakGain);
 	void SetHighPass(float q, float freq, float peakQ, float peakGain);
 	virtual const char* GetName() const { return "CombinedFilterDSP"; }
@@ -77,6 +78,8 @@ private:
 class BitCrusherDSP : public DSP
 {
 public:
+	BitCrusherDSP(uint32 sampleRate);
+
 	// Duration of samples, <1 = disable
 	void SetPeriod(float period = 0);
 	virtual void Process(float* out, uint32 numSamples);
@@ -91,6 +94,8 @@ private:
 class GateDSP : public DSP
 {
 public:
+	GateDSP(uint32 sampleRate);
+
 	// The amount of time for a single cycle in samples
 	void SetLength(double length);
 	void SetGating(float gating);
@@ -112,6 +117,8 @@ private:
 class TapeStopDSP : public DSP
 {
 public:
+	TapeStopDSP(uint32 sampleRate);
+
 	void SetLength(double length);
 
 	virtual void Process(float* out, uint32 numSamples);
@@ -127,6 +134,8 @@ private:
 class RetriggerDSP : public DSP
 {
 public:
+	RetriggerDSP(uint32 sampleRate);
+
 	void SetLength(double length);
 	void SetResetDuration(uint32 resetDuration);
 	void SetGating(float gating);
@@ -148,6 +157,8 @@ private:
 class WobbleDSP : public BQFDSP
 {
 public:
+	WobbleDSP(uint32 sampleRate);
+
 	void SetLength(double length);
 
 	// Frequency range
@@ -166,6 +177,8 @@ private:
 class PhaserDSP : public DSP
 { 
 public:
+	PhaserDSP(uint32 sampleRate);
+
 	uint32 time = 0;
 
 	// Frequency range
@@ -197,6 +210,8 @@ private:
 class FlangerDSP : public DSP
 {
 public:
+	FlangerDSP(uint32 sampleRate);
+
 	void SetLength(double length);
 	void SetDelayRange(uint32 min, uint32 max);
 
@@ -218,6 +233,8 @@ private:
 class EchoDSP : public DSP
 {
 public:
+	EchoDSP(uint32 sampleRate);
+
 	void SetLength(double length);
 
 	float feedback = 0.6f;
@@ -235,6 +252,8 @@ private:
 class SidechainDSP : public DSP
 {
 public:
+	SidechainDSP(uint32 sampleRate);
+
 	// Set sidechain length in samples
 	void SetLength(double length);
 

--- a/Audio/src/Audio.cpp
+++ b/Audio/src/Audio.cpp
@@ -125,7 +125,7 @@ void Audio_Impl::Start()
 	m_sampleBuffer = new float[2 * m_sampleBufferLength];
 
 	limiter = new LimiterDSP();
-	limiter->audio = this;
+	limiter->SetAudio(this);
 	limiter->releaseTime = 0.2f;
 	globalDSPs.Add(limiter);
 	output->Start(this);
@@ -133,10 +133,12 @@ void Audio_Impl::Start()
 void Audio_Impl::Stop()
 {
 	output->Stop();
-	delete limiter;
 	globalDSPs.Remove(limiter);
 
+	delete limiter;
 	delete[] m_sampleBuffer;
+
+	limiter = nullptr;
 	m_sampleBuffer = nullptr;
 }
 void Audio_Impl::Register(AudioBase* audio)

--- a/Audio/src/Audio.cpp
+++ b/Audio/src/Audio.cpp
@@ -6,19 +6,17 @@
 #include "DSP.hpp"
 
 Audio* g_audio = nullptr;
-Audio_Impl impl;
+static Audio_Impl g_impl;
+
+Audio_Impl::Audio_Impl()
+{
+#if _DEBUG
+	InitMemoryGuard();
+#endif
+}
 
 void Audio_Impl::Mix(void* data, uint32& numSamples)
 {
-#if _DEBUG
-	static const uint32 guardBand = 1024;
-#else
-	static const uint32 guardBand = 0;
-#endif
-
-	// Per-Channel data buffer
-	float* tempData = new float[m_sampleBufferLength * 2 + guardBand];
-	uint32* guardBuffer = (uint32*)tempData + 2 * m_sampleBufferLength;
 	double adv = GetSecondsPerSample();
 
 	uint32 outputChannels = this->output->GetNumChannels();
@@ -38,43 +36,35 @@ void Audio_Impl::Mix(void* data, uint32& numSamples)
 		if(m_remainingSamples <= 0)
 		{
 			// Clear sample buffer storing a fixed amount of samples
-			memset(m_sampleBuffer, 0, sizeof(float) * 2 * m_sampleBufferLength);
+			m_sampleBuffer.fill(0);
 
 			// Render items
 			lock.lock();
 			for(auto& item : itemsToRender)
 			{
-				// Clearn per-channel data (and guard buffer in debug mode)
-				memset(tempData, 0, sizeof(float) * (2 * m_sampleBufferLength + guardBand));
-				item->Process(tempData, m_sampleBufferLength);
+				// Clear per-channel data
+				m_itemBuffer.fill(0);
+				item->Process(m_itemBuffer.data(), m_sampleBufferLength);
 #if _DEBUG
-				// Check for memory corruption
-				for(uint32 i = 0; i < guardBand; i++)
-				{
-					assert(guardBuffer[i] == 0);
-				}
+				CheckMemoryGuard();
 #endif
-				item->ProcessDSPs(tempData, m_sampleBufferLength);
+				item->ProcessDSPs(m_itemBuffer.data(), m_sampleBufferLength);
 #if _DEBUG
-				// Check for memory corruption
-				for(uint32 i = 0; i < guardBand; i++)
-				{
-					assert(guardBuffer[i] == 0);
-				}
+				CheckMemoryGuard();
 #endif
 
 				// Mix into buffer and apply volume scaling
 				for(uint32 i = 0; i < m_sampleBufferLength; i++)
 				{
-					m_sampleBuffer[i * 2 + 0] += tempData[i * 2] * item->GetVolume();
-					m_sampleBuffer[i * 2 + 1] += tempData[i * 2 + 1] * item->GetVolume();
+					m_sampleBuffer[i * 2 + 0] += m_itemBuffer[i * 2] * item->GetVolume();
+					m_sampleBuffer[i * 2 + 1] += m_itemBuffer[i * 2 + 1] * item->GetVolume();
 				}
 			}
 
 			// Process global DSPs
 			for(auto dsp : globalDSPs)
 			{
-				dsp->Process(m_sampleBuffer, m_sampleBufferLength);
+				dsp->Process(m_sampleBuffer.data(), m_sampleBufferLength);
 			}
 			lock.unlock();
 
@@ -117,16 +107,13 @@ void Audio_Impl::Mix(void* data, uint32& numSamples)
 		m_remainingSamples -= maxSamples;
 		currentNumberOfSamples += maxSamples;
 	}
-
-	delete[] tempData;
 }
 void Audio_Impl::Start()
 {
-	m_sampleBuffer = new float[2 * m_sampleBufferLength];
-
 	limiter = new LimiterDSP();
 	limiter->SetAudio(this);
 	limiter->releaseTime = 0.2f;
+
 	globalDSPs.Add(limiter);
 	output->Start(this);
 }
@@ -136,10 +123,7 @@ void Audio_Impl::Stop()
 	globalDSPs.Remove(limiter);
 
 	delete limiter;
-	delete[] m_sampleBuffer;
-
 	limiter = nullptr;
-	m_sampleBuffer = nullptr;
 }
 void Audio_Impl::Register(AudioBase* audio)
 {
@@ -177,9 +161,9 @@ Audio::~Audio()
 {
 	if(m_initialized)
 	{
-		impl.Stop();
-		delete impl.output;
-		impl.output = nullptr;
+		g_impl.Stop();
+		delete g_impl.output;
+		g_impl.output = nullptr;
 	}
 
 	assert(g_audio == this);
@@ -189,29 +173,29 @@ bool Audio::Init(bool exclusive)
 {
 	audioLatency = 0;
 
-	impl.output = new AudioOutput();
-	if(!impl.output->Init(exclusive))
+	g_impl.output = new AudioOutput();
+	if(!g_impl.output->Init(exclusive))
 	{
-		delete impl.output;
-		impl.output = nullptr;
+		delete g_impl.output;
+		g_impl.output = nullptr;
 		return false;
 	}
 
-	impl.Start();
+	g_impl.Start();
 
 	return m_initialized = true;
 }
 void Audio::SetGlobalVolume(float vol)
 {
-	impl.globalVolume = vol;
+	g_impl.globalVolume = vol;
 }
 uint32 Audio::GetSampleRate() const
 {
-	return impl.output->GetSampleRate();
+	return g_impl.output->GetSampleRate();
 }
 class Audio_Impl* Audio::GetImpl()
 {
-	return &impl;
+	return &g_impl;
 }
 
 Ref<AudioStream> Audio::CreateStream(const String& path, bool preload)
@@ -222,3 +206,14 @@ Sample Audio::CreateSample(const String& path)
 {
 	return SampleRes::Create(this, path);
 }
+
+#if _DEBUG
+void Audio_Impl::InitMemoryGuard()
+{
+	m_guard.fill(0);
+}
+void Audio_Impl::CheckMemoryGuard()
+{
+	for (auto x : m_guard) assert(x == 0);
+}
+#endif

--- a/Audio/src/AudioBase.cpp
+++ b/Audio/src/AudioBase.cpp
@@ -55,7 +55,7 @@ uint32 AudioBase::GetAudioSampleRate() const
 {
 	return audio->GetSampleRate();
 }
-void AudioBase::ProcessDSPs(float*& out, uint32 numSamples)
+void AudioBase::ProcessDSPs(float* out, uint32 numSamples)
 {
 	for(DSP* dsp : DSPs)
 	{

--- a/Audio/src/AudioBase.cpp
+++ b/Audio/src/AudioBase.cpp
@@ -3,10 +3,46 @@
 #include "Audio.hpp"
 #include "Audio_Impl.hpp"
 
+uint32 DSP::GetStartSample() const
+{
+	return static_cast<uint32>(startTime * static_cast<double>(m_audio->GetSampleRate()) / 1000.0);
+}
+
+uint32 DSP::GetCurrentSample() const
+{
+	return static_cast<uint32>(m_audioBase->GetPosition() * static_cast<double>(m_audio->GetSampleRate()) / 1000.0);
+}
+
 DSP::~DSP()
 {
 	// Make sure this is removed from parent
-	assert(!audioBase);
+	assert(!m_audioBase);
+}
+
+void DSP::SetAudio(Audio_Impl* audio)
+{
+	assert(!m_audio && !m_audioBase);
+
+	m_audio = audio;
+	m_audioBase = nullptr;
+}
+
+void DSP::SetAudioBase(class AudioBase* audioBase)
+{
+	if (!audioBase)
+	{
+		m_audioBase = nullptr;
+		m_audio = nullptr;
+
+		return;
+	}
+
+	assert(!m_audio && !m_audioBase);
+
+	m_audioBase = audioBase;
+	m_audio = audioBase->audio;
+
+	assert(m_sampleRate == m_audio->GetSampleRate());
 }
 
 AudioBase::~AudioBase()
@@ -14,6 +50,10 @@ AudioBase::~AudioBase()
 	// Check this to make sure the audio is not being destroyed while it is still registered
 	assert(!audio);
 	assert(DSPs.empty());
+}
+uint32 AudioBase::GetAudioSampleRate() const
+{
+	return audio->GetSampleRate();
 }
 void AudioBase::ProcessDSPs(float*& out, uint32 numSamples)
 {
@@ -33,17 +73,16 @@ void AudioBase::AddDSP(DSP* dsp)
 			return l < r;
 		return l->priority < r->priority;
 	});
-	dsp->audioBase = this;
-	dsp->audio = audio;
+	dsp->SetAudioBase(this);
 	audio->lock.unlock();
 }
 void AudioBase::RemoveDSP(DSP* dsp)
 {
 	assert(DSPs.Contains(dsp));
+
 	audio->lock.lock();
 	DSPs.Remove(dsp);
-	dsp->audioBase = nullptr;
-	dsp->audio = nullptr;
+	dsp->SetAudioBase(nullptr);
 	audio->lock.unlock();
 }
 
@@ -59,7 +98,7 @@ void AudioBase::Deregister()
 	// It is safe to do here since the audio won't be rendered again after a call to deregister
 	for(DSP* dsp : DSPs)
 	{
-		dsp->audioBase = nullptr;
+		dsp->RemoveAudioBase();
 	}
 	DSPs.clear();
 }

--- a/Audio/src/AudioStreamBase.cpp
+++ b/Audio/src/AudioStreamBase.cpp
@@ -156,7 +156,7 @@ void AudioStreamBase::Process(float* out, uint32 numSamples)
 				outCount++;
 
 				// Increment source sample with resampling
-				m_sampleStep += m_sampleStepIncrement * PlaybackSpeed;
+				m_sampleStep += static_cast<uint64>(m_sampleStepIncrement * PlaybackSpeed);
 				while(m_sampleStep >= fp_sampleStep)
 				{
 					m_sampleStep -= fp_sampleStep;

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -279,8 +279,8 @@ void TapeStopDSP::SetLength(double length)
 }
 void TapeStopDSP::Process(float* out, uint32 numSamples)
 {
-	uint32 startSample = startTime * m_audio->GetSampleRate() / 1000.0;
-	uint32 currentSample = m_audioBase->GetPosition() * m_audio->GetSampleRate() / 1000.0;
+	const uint32 startSample = GetStartSample();
+	const uint32 currentSample = GetCurrentSample();
 
 	for(uint32 i = 0; i < numSamples; i++)
 	{
@@ -369,14 +369,14 @@ void RetriggerDSP::Process(float* out, uint32 numSamples)
 		if (m_resetDuration > 0)
 		{
 			startOffset = (nowSample + i - baseStartRepeat) / (int)m_resetDuration;
-			startOffset = startOffset * m_resetDuration * rateMult;
+			startOffset = static_cast<int>(startOffset * m_resetDuration * rateMult);
 		}
 		else
 		{
-			startOffset = (startSample - baseStartRepeat) * rateMult;
+			startOffset = static_cast<int>((startSample - baseStartRepeat) * rateMult);
 		}
 
-		int pcmSample = pcmStartSample + startOffset + (int)m_currentSample * rateMult;
+		int pcmSample = static_cast<int>(pcmStartSample) + startOffset + static_cast<int>(m_currentSample * rateMult);
 		float gating = 1.0f;
 		if (m_currentSample > m_gateLength)
 			gating = 0;
@@ -508,13 +508,12 @@ void FlangerDSP::SetLength(double length) {
 void FlangerDSP::SetDelayRange(uint32 offset, uint32 depth)
 {
 	// Assuming 44100hz is the base sample rate
-	uint32 max = offset + depth;
-	uint32 min = offset;
+	const uint32 max = offset + depth;
+	const uint32 min = offset;
 
-
-	float mult = (float) m_sampleRate / 44100.f;
-	m_min = min * mult;
-	m_max = max * mult;
+	const float mult = (float) m_sampleRate / 44100.f;
+	m_min = static_cast<uint32>(min * mult);
+	m_max = static_cast<uint32>(max * mult);
 	m_bufferLength = m_max * 2;
 	m_sampleBuffer.resize(m_bufferLength);
 }

--- a/Main/include/Audio/AudioPlayback.hpp
+++ b/Main/include/Audio/AudioPlayback.hpp
@@ -14,7 +14,7 @@ public:
 	GameAudioEffect(const AudioEffect& other);
 
 	// Creates a DSP matching this effect
-	DSP* CreateDSP(class AudioBase* audioTrack, AudioPlayback& playback);
+	DSP* CreateDSP(AudioPlayback& playback, uint32 sampleRate);
 	// Applies the given parameters overriding some settings for this effect (depending on the effect)
 	void SetParams(DSP* dsp, AudioPlayback& playback, HoldObjectState* object);
 };
@@ -75,7 +75,7 @@ public:
 	void SetFXTrackEnabled(bool enabled);
 	
 	// Switch audio track
-	void SetSwitchableTrackEnabled(size_t index, bool enabled);
+	void SetSwitchableTrackEnabled(int index, bool enabled);
 	void ResetSwitchableTracks();
 
 	BeatmapPlayback& GetBeatmapPlayback();

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -181,18 +181,23 @@ void AudioPlayback::SetEffect(uint32 index, HoldObjectState* object, class Beatm
 	if (m_buttonEffects[index].type == EffectType::SwitchAudio)
 		return;
 
-	dsp = m_buttonEffects[index].CreateDSP(m_GetDSPTrack().get(), *this);
+	Ref<AudioStream> audioTrack = m_GetDSPTrack();
+
+	dsp = m_buttonEffects[index].CreateDSP(*this, audioTrack->GetAudioSampleRate());
+	if (!dsp) return;
+
 	Logf("Set effect: %s", Logger::Severity::Debug, dsp->GetName());
 
-	if(dsp)
-	{
-		m_buttonEffects[index].SetParams(dsp, *this, object);
-		// Initialize mix value to previous value
-		dsp->mix = m_effectMix[index];
-		dsp->startTime = object->time;
-		dsp->chartOffset = playback.GetBeatmap().GetMapSettings().offset;
-		dsp->lastTimingPoint = playback.GetCurrentTimingPoint().time;
-	}
+	m_buttonEffects[index].SetParams(dsp, *this, object);
+
+	// Initialize mix value to previous value
+	dsp->mix = m_effectMix[index];
+	dsp->startTime = object->time;
+	dsp->chartOffset = playback.GetBeatmap().GetMapSettings().offset;
+	dsp->lastTimingPoint = playback.GetCurrentTimingPoint().time;
+
+	// Add the DSP to the track
+	audioTrack->AddDSP(dsp);
 }
 void AudioPlayback::SetEffectEnabled(uint32 index, bool enabled)
 {
@@ -251,12 +256,16 @@ void AudioPlayback::SetLaserFilterInput(float input, bool active)
 			if(m_fxtrack && m_laserEffectType == EffectType::Bitcrush)
 				return;
 
-			m_laserDSP = m_laserEffect.CreateDSP(m_GetDSPTrack().get(), *this);
+			Ref<AudioStream> audioTrack = m_GetDSPTrack();
+
+			m_laserDSP = m_laserEffect.CreateDSP(*this, audioTrack->GetAudioSampleRate());
 			if(!m_laserDSP)
 			{
 				Logf("Failed to create laser DSP with type %d", Logger::Severity::Warning, m_laserEffect.type);
 				return;
 			}
+
+			audioTrack->AddDSP(m_laserDSP);
 		}
 
 		// Set params
@@ -267,6 +276,7 @@ void AudioPlayback::SetLaserFilterInput(float input, bool active)
 	{
 		if (m_laserSwitchable > 0)
 			SetSwitchableTrackEnabled(m_laserSwitchable, true);
+
 		m_laserSwitchable = -1;
 		m_CleanupDSP(m_laserDSP);
 		m_laserInput = 0.0f;
@@ -308,12 +318,12 @@ void AudioPlayback::SetFXTrackEnabled(bool enabled)
 	}
 	m_fxtrackEnabled = enabled;
 }
-void AudioPlayback::SetSwitchableTrackEnabled(size_t index, bool enabled)
+void AudioPlayback::SetSwitchableTrackEnabled(int index, bool enabled)
 {
 	if (m_fxtrack)
 		return;
 
-	assert(index < m_switchables.size());
+	assert(0 <= index && index < m_switchables.size());
 
 	int32 disableTrack = -1;
 	int32 enableTrack = -1;
@@ -399,6 +409,7 @@ void AudioPlayback::m_SetLaserEffectParameter(float input)
 {
 	if(!m_laserDSP)
 		return;
+
 	assert(input >= 0.0f && input <= 1.0f);
 
 	// Mix float biquad filters, these are applied manualy by changing the filter parameters (gain,q,freq,etc.)

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -4,7 +4,7 @@
 #include <Audio/DSP.hpp>
 #include <Audio/Audio.hpp>
 
-DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& playback)
+DSP* GameAudioEffect::CreateDSP(AudioPlayback& playback, uint32 sampleRate)
 {
 	DSP* ret = nullptr;
 
@@ -14,20 +14,19 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	float filterInput = playback.GetLaserFilterInput();
 	uint32 actualLength = duration.Sample(filterInput).Absolute(noteDuration);
 	uint32 maxLength = Math::Max(duration.Sample(0.f).Absolute(noteDuration), duration.Sample(1.f).Absolute(noteDuration));
+
 	switch(type)
 	{
 	case EffectType::Bitcrush:
 	{
-		BitCrusherDSP* bcDSP = new BitCrusherDSP();
-		audioTrack->AddDSP(bcDSP);
+		BitCrusherDSP* bcDSP = new BitCrusherDSP(sampleRate);
 		bcDSP->SetPeriod((float)bitcrusher.reduction.Sample(filterInput));
 		ret = bcDSP;
 		break;
 	}
 	case EffectType::Echo:
 	{
-		EchoDSP* echoDSP = new EchoDSP();
-		audioTrack->AddDSP(echoDSP);
+		EchoDSP* echoDSP = new EchoDSP(sampleRate);
 		echoDSP->feedback = echo.feedback.Sample(filterInput) / 100.0f;
 		echoDSP->SetLength(actualLength);
 		ret = echoDSP;
@@ -38,17 +37,13 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	case EffectType::HighPassFilter:
 	{
 		// Don't set anthing for biquad Filters
-		BQFDSP* bqfDSP = new BQFDSP();
-
-
-		audioTrack->AddDSP(bqfDSP);
+		BQFDSP* bqfDSP = new BQFDSP(sampleRate);
 		ret = bqfDSP;
 		break;
 	}
 	case EffectType::Gate:
 	{
-		GateDSP* gateDSP = new GateDSP();
-		audioTrack->AddDSP(gateDSP);
+		GateDSP* gateDSP = new GateDSP(sampleRate);
 		gateDSP->SetLength(actualLength);
 		gateDSP->SetGating(gate.gate.Sample(filterInput));
 		ret = gateDSP;
@@ -56,16 +51,14 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	}
 	case EffectType::TapeStop:
 	{
-		TapeStopDSP* tapestopDSP = new TapeStopDSP();
-		audioTrack->AddDSP(tapestopDSP);
+		TapeStopDSP* tapestopDSP = new TapeStopDSP(sampleRate);
 		tapestopDSP->SetLength(actualLength);
 		ret = tapestopDSP;
 		break;
 	}
 	case EffectType::Retrigger:
 	{
-		RetriggerDSP* retriggerDSP = new RetriggerDSP();
-		audioTrack->AddDSP(retriggerDSP);
+		RetriggerDSP* retriggerDSP = new RetriggerDSP(sampleRate);
 		retriggerDSP->SetMaxLength(maxLength);
 		retriggerDSP->SetLength(actualLength);
 		retriggerDSP->SetGating(retrigger.gate.Sample(filterInput));
@@ -75,8 +68,7 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	}
 	case EffectType::Wobble:
 	{
-		WobbleDSP* wb = new WobbleDSP();
-		audioTrack->AddDSP(wb);
+		WobbleDSP* wb = new WobbleDSP(sampleRate);
 		wb->SetLength(actualLength);
 		wb->q = wobble.q.Sample(filterInput);
 		wb->fmax = wobble.max.Sample(filterInput);
@@ -86,8 +78,7 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	}
 	case EffectType::Phaser:
 	{
-		PhaserDSP* phs = new PhaserDSP();
-		audioTrack->AddDSP(phs);
+		PhaserDSP* phs = new PhaserDSP(sampleRate);
 		phs->SetLength(actualLength);
 		phs->dmin = phaser.min.Sample(filterInput);
 		phs->dmax = phaser.max.Sample(filterInput);
@@ -97,8 +88,7 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	}
 	case EffectType::Flanger:
 	{
-		FlangerDSP* fl = new FlangerDSP();
-		audioTrack->AddDSP(fl);
+		FlangerDSP* fl = new FlangerDSP(sampleRate);
 		fl->SetLength(actualLength);
 		fl->SetDelayRange(abs(flanger.offset.Sample(filterInput)),
 			abs(flanger.depth.Sample(filterInput)));
@@ -107,8 +97,7 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	}
 	case EffectType::SideChain:
 	{
-		SidechainDSP* sc = new SidechainDSP();
-		audioTrack->AddDSP(sc);
+		SidechainDSP* sc = new SidechainDSP(sampleRate);
 		sc->SetLength(actualLength);
 		sc->amount = 1.0f;
 		sc->curve = Interpolation::CubicBezier(0.39, 0.575, 0.565, 1);
@@ -118,7 +107,6 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	case EffectType::PitchShift:
 	{
 		PitchShiftDSP* ps = new PitchShiftDSP();
-		audioTrack->AddDSP(ps);
 		ps->amount = pitchshift.amount.Sample(filterInput);
 		ret = ps;
 		break;
@@ -130,6 +118,7 @@ DSP* GameAudioEffect::CreateDSP(class AudioBase* audioTrack, AudioPlayback& play
 	if(!ret)
 	{
 		Logf("Failed to create game audio effect for type \"%s\"", Logger::Severity::Warning, Enum_EffectType::ToString(type));
+		return nullptr;
 	}
 
 	return ret;

--- a/Tests.Game/src/TestAudio.cpp
+++ b/Tests.Game/src/TestAudio.cpp
@@ -55,7 +55,7 @@ Test("Audio.Music.Phaser")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			phaser = new PhaserDSP();
+			phaser = new PhaserDSP(song->GetAudioSampleRate());
 			phaser->dmin = 800.0f;
 			phaser->dmax = 1000.0f;
 			phaser->fb = 0.8f;
@@ -82,7 +82,7 @@ Test("Audio.Music.Wobble")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			wobble = new WobbleDSP();
+			wobble = new WobbleDSP(song->GetAudioSampleRate());
 			song->AddDSP(wobble);
 			wobble->SetLength(200);
 		}
@@ -110,7 +110,7 @@ Test("Audio.Music.LPF")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			filter = new BQFDSP();
+			filter = new BQFDSP(song->GetAudioSampleRate());
 			song->AddDSP(filter);
 			filter->SetLowPass(1.0f, 500.0f);
 		}
@@ -160,7 +160,7 @@ Test("Audio.Music.LPFMix")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			filter = new BQFDSP();
+			filter = new BQFDSP(song->GetAudioSampleRate());
 			song->AddDSP(filter);
 			filter->SetLowPass(1.0f, 500.0f);
 		}
@@ -210,7 +210,7 @@ Test("Audio.Music.Peaking")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			filter = new BQFDSP();
+			filter = new BQFDSP(song->GetAudioSampleRate());
 			song->AddDSP(filter);
 			filter->SetLowPass(1.0f, 500.0f);
 		}
@@ -260,7 +260,7 @@ Test("Audio.Music.Echo")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			EchoDSP* echo = new EchoDSP();
+			EchoDSP* echo = new EchoDSP(song->GetAudioSampleRate());
 			song->AddDSP(echo);
 			echo->SetLength(3000);
 			echo->feedback = 0.4f;
@@ -286,7 +286,7 @@ Test("Audio.Music.Flanger")
 		{
 			TestMusicPlayer::Init(songPath, startOffset);
 
-			FlangerDSP* fl = new FlangerDSP();
+			FlangerDSP* fl = new FlangerDSP(song->GetAudioSampleRate());
 			song->AddDSP(fl);
 			fl->SetDelayRange(10, 120);
 			fl->SetLength(24100);

--- a/Tests.Game/src/TestBeatmap.cpp
+++ b/Tests.Game/src/TestBeatmap.cpp
@@ -171,7 +171,7 @@ Test("Beatmap.DoubleFilter")
 
 			for(int i = 0; i < 2; i++)
 			{
-				filter[i] = new BQFDSP();
+				filter[i] = new BQFDSP(song->GetAudioSampleRate());
 				song->AddDSP(filter[i]);
 			}
 		}
@@ -277,7 +277,7 @@ Test("Beatmap.SingleFilter")
 				}
 			});
 
-			filter = new BQFDSP();
+			filter = new BQFDSP(song->GetAudioSampleRate());
 			song->AddDSP(filter);
 		}
 		void Update(float dt) override


### PR DESCRIPTION
The first commit fixes #394.

The second commit is mainly to remove the dynamic allocation for `float* tempData`.
While there's no need to do so, I also moved buffer directly inside `Audio_Impl`.

As I ranted in #394, the audio processing still contains problems, but this should be enough for quick dirty fix for the crash.