### PR TITLE
Fix crash when using out of range values for PitchShift effect

### DIFF
--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -669,7 +669,7 @@ PitchShiftDSP::~PitchShiftDSP()
 }
 void PitchShiftDSP::Process(float* out, uint32 numSamples)
 {
-	m_impl->pitch = amount;
+	m_impl->pitch = Math::Clamp(amount, -12.0f, 12.0f);
 	if(!m_impl->init)
 		m_impl->Init(audio);
 	m_impl->Process(out, numSamples);


### PR DESCRIPTION
This fixes the game locking up in the following level, which uses a PitchShift filter with pitch=690.0-740.0
https://ksm.dev/songs/90b95e50-e2dc-11ea-9bfb-77e35c0197b2