### PR TITLE
(Almost) made Application consider g_tickables as a stack

### DIFF
--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -40,7 +40,7 @@ public:
 	class Game* LaunchMap(const String& mapPath);
 	void Shutdown();
 
-	void AddTickable(class IApplicationTickable* tickable, class IApplicationTickable* insertBefore = nullptr);
+	void AddTickable(class IApplicationTickable* tickable);
 	void RemoveTickable(class IApplicationTickable* tickable, bool noDelete = false);
 
 	// Current running map path (full file path)
@@ -113,6 +113,10 @@ private:
 	void m_MainLoop();
 	void m_Tick();
 	void m_Cleanup();
+
+	void m_SuspendAllTickables();
+	void m_RemoveAllTickables();
+
 	void m_OnKeyPressed(SDL_Scancode code);
 	void m_OnKeyReleased(SDL_Scancode code);
 	void m_OnWindowResized(const Vector2i& newSize);

--- a/Main/include/TransitionScreen.hpp
+++ b/Main/include/TransitionScreen.hpp
@@ -10,8 +10,8 @@ class TransitionScreen : public IApplicationTickable
 public:
 	virtual ~TransitionScreen() = default;
 	static TransitionScreen* Create();
-	virtual void TransitionTo(class Game* next, IApplicationTickable* before = nullptr) = 0;
-	virtual void TransitionTo(IAsyncLoadableApplicationTickable* next, bool noCancel = true, IApplicationTickable* before = nullptr) = 0;
+	virtual void TransitionTo(class Game* next) = 0;
+	virtual void TransitionTo(IAsyncLoadableApplicationTickable* next, bool noCancel = true) = 0;
 	virtual void RemoveOnComplete(DelegateHandle handle) = 0;
 	virtual void RemoveAllOnComplete(void* handle) = 0;
 

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -928,7 +928,7 @@ void Application::m_MainLoop()
 					// so Game must be removed after transition to ScoreScreen is issued.
 					// TODO: Fix it so that Game is removed when the transition to ScoreScreen is issued.
 					// (except when 'back to practice setup' option is active; in this case ScoreScreen should be added on top of Game)
-					Logf("Removing an IApplicationTickable which is not on the top", Logger::Severity::Debug);
+					Log("Removing an IApplicationTickable which is not on the top", Logger::Severity::Debug);
 					g_tickables.Remove(ch.tickable);
 				}
 				if (ch.mode == TickableChange::Removed)

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -234,8 +234,6 @@ public:
 		}
 
 		// Save practice indices
-		// TODO: this crashes when the window is closed during gaming
-		// because m_db is freed (which is owned by SongSelect) before this destructor is called.
 		if (m_db && m_isPracticeMode)
 		{
 			StorePracticeSetupIndex();

--- a/Main/src/TransitionScreen.cpp
+++ b/Main/src/TransitionScreen.cpp
@@ -156,7 +156,7 @@ public:
 		return true;
 	}
 
-	virtual void TransitionTo(IAsyncLoadableApplicationTickable *next, bool noCancel, IApplicationTickable* before)
+	virtual void TransitionTo(IAsyncLoadableApplicationTickable *next, bool noCancel)
 	{
 		m_isGame = false;
 		m_InitTransition(next);
@@ -181,10 +181,10 @@ public:
 			g_jobSheduler->Queue(m_loadingJob);
 		}
 
-		g_application->AddTickable(this, before);
+		g_application->AddTickable(this);
 	}
 
-	virtual void TransitionTo(Game* next, IApplicationTickable* before)
+	virtual void TransitionTo(Game* next)
 	{
 		m_isGame = true;
 		m_canCancel = true;
@@ -261,7 +261,7 @@ public:
 		{
 			g_jobSheduler->Queue(m_loadingJob);
 		}
-		g_application->AddTickable(this, before);
+		g_application->AddTickable(this);
 	}
 
 	void Render(float deltaTime)


### PR DESCRIPTION
The main change is to destruct tickables in reverse order when the program is closed. I believe that this is the reason behind stray crash dumps.
The code is not yet tested when `JoinMultiFromInvite` is being done (I couldn't test it alone), but otherwise there should be no side effect during playing a game.

Also, for me it seemed more natural to add and remove the tickable on top of the stack `g_tickables`, so I removed functions which lets tickables be added below the top of `g_tickables` (there's no code which uses this).
I couldn't enforce tickables be removed from the top of `g_tickables`, however, because `Game` must be removed after the transition to `ScoreScreen` is added. This can be avoided but I wanted this PR to be a short one.