### PR TITLE
Simple audio assert fix (add sampleRate to DSPs which does not need them)

### DIFF
--- a/Audio/include/Audio/DSP.hpp
+++ b/Audio/include/Audio/DSP.hpp
@@ -67,6 +67,8 @@ private:
 class LimiterDSP : public DSP
 {
 public:
+	LimiterDSP(uint32 sampleRate);
+
 	float releaseTime = 0.1f;
 	virtual void Process(float* out, uint32 numSamples);
 	virtual const char* GetName() const { return "LimiterDSP"; }
@@ -270,10 +272,11 @@ private:
 class PitchShiftDSP : public DSP
 {
 public:
+	PitchShiftDSP(uint32 sampleRate);
+
 	// Pitch change amount
 	float amount = 0.0f;
 
-	PitchShiftDSP();
 	~PitchShiftDSP();
 
 	virtual void Process(float* out, uint32 numSamples);

--- a/Audio/src/Audio.cpp
+++ b/Audio/src/Audio.cpp
@@ -110,7 +110,7 @@ void Audio_Impl::Mix(void* data, uint32& numSamples)
 }
 void Audio_Impl::Start()
 {
-	limiter = new LimiterDSP();
+	limiter = new LimiterDSP(GetSampleRate());
 	limiter->SetAudio(this);
 	limiter->releaseTime = 0.2f;
 

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -144,6 +144,10 @@ void CombinedFilterDSP::Process(float* out, uint32 numSamples)
 	peak.Process(out, numSamples);
 }
 
+LimiterDSP::LimiterDSP(uint32 sampleRate) : DSP()
+{
+	SetSampleRate(sampleRate);
+}
 void LimiterDSP::Process(float* out, uint32 numSamples)
 {
 	const float secondsPerSample = (float) m_audio->GetSecondsPerSample();
@@ -696,8 +700,9 @@ public:
 	}
 };
 
-PitchShiftDSP::PitchShiftDSP()
+PitchShiftDSP::PitchShiftDSP(uint32 sampleRate) : DSP()
 {
+	SetSampleRate(sampleRate);
 	m_impl = new PitchShiftDSP_Impl();
 }
 PitchShiftDSP::~PitchShiftDSP()

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -106,7 +106,7 @@ DSP* GameAudioEffect::CreateDSP(AudioPlayback& playback, uint32 sampleRate)
 	}
 	case EffectType::PitchShift:
 	{
-		PitchShiftDSP* ps = new PitchShiftDSP();
+		PitchShiftDSP* ps = new PitchShiftDSP(sampleRate);
 		ps->amount = pitchshift.amount.Sample(filterInput);
 		ret = ps;
 		break;


### PR DESCRIPTION
This is just to prevent the assert from triggering.