### PR TITLE
Added fallback directory check when d_type is UNKNOWN/LNK

### DIFF
--- a/Shared/src/Unix/Files.cpp
+++ b/Shared/src/Unix/Files.cpp
@@ -6,6 +6,7 @@
 #include "File.hpp"
 
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <dirent.h>
 
 static Vector<FileInfo> _ScanFiles(String rootFolder, String extFilter, bool recurse, bool* interrupt)
@@ -54,8 +55,14 @@ static Vector<FileInfo> _ScanFiles(String rootFolder, String extFilter, bool rec
                 info.fullPath = Path::Normalize(searchPath + Path::sep + filename);
 				info.lastWriteTime = File::GetLastWriteTime(info.fullPath); // linux doesn't provide this timestamp in the directory entry
 				info.type = FileType::Regular;
-
-				if(ent->d_type == DT_DIR)
+				bool is_dir = (ent->d_type == DT_DIR);
+				if (ent->d_type == DT_UNKNOWN || ent->d_type == DT_LNK)
+				{
+					struct stat buffer;
+					stat(info.fullPath.c_str(), &buffer);
+					is_dir = S_ISDIR(buffer.st_mode);
+				}
+				if(is_dir)
 				{
 					if(recurse)
 					{


### PR DESCRIPTION
For some Linux filesystems, d_type isn't supported and returns DT_UNKNOWN. In this case (and when there's a symbolic link to the directory), the file type needs to be checked directly.