### PR TITLE
Add crash uploading option for breakpad crashes

### DIFF
--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -159,6 +159,8 @@ DefineEnum(GameConfigKeys,
 		   GameplaySettingsDialogLastTab,
 		   TransferScoresOnChartUpdate,
 
+		   ShowCrashUploadPrompt,
+
 		   // Gameplay options
 		   GaugeType,
 		   MirrorChart,

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -181,6 +181,8 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::AutoResetSettings, false);
 	Set(GameConfigKeys::AutoResetToSpeed, 400.0f);
 	Set(GameConfigKeys::SlamThicknessMultiplier, 1.0f);
+	
+	Set(GameConfigKeys::ShowCrashUploadPrompt, true);
 
 	Set(GameConfigKeys::SettingsTreesOpen, 1);
 

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -939,6 +939,7 @@ public:
 			ToggleSetting(GameConfigKeys::MuteUnfocused, "Mute the game when unfocused");
 			ToggleSetting(GameConfigKeys::CheckForUpdates, "Check for updates on startup");
 			ToggleSetting(GameConfigKeys::OnlyRelease, "Only check for new release versions");
+			ToggleSetting(GameConfigKeys::ShowCrashUploadPrompt, "Ask to upload crash dumps on crash");
 
 			EnumSetting<Logger::Enum_Severity>(GameConfigKeys::LogLevel, "Logging level");
 

--- a/Shared/include/Shared/Path.hpp
+++ b/Shared/include/Shared/Path.hpp
@@ -41,6 +41,8 @@ public:
 	static bool CopyDir(String srcFolder, String dstFolder);
 	// Go to specified path using the system default file browser
 	static bool ShowInFileBrowser(const String& path);
+	// Go to specified url using the system default web browser
+	static void OpenInBrowser(const String& url);
 	// Open external program with specified parameters (used to open charts in editor)
 	static bool Run(const String& programPath, const String& parameters);
 

--- a/Shared/src/Unix/Path.cpp
+++ b/Shared/src/Unix/Path.cpp
@@ -180,6 +180,11 @@ Vector<String> Path::GetSubDirs(const String& path)
     closedir(dir);
     return ret;
 }
+void Path::OpenInBrowser(const String& path)
+{
+    Log("Path::OpenInBrowser function not implemented yet", Logger::Severity::Error);
+    return false;
+}
 bool Path::ShowInFileBrowser(const String& path)
 {
     Log("Path::ShowInFileBrowser function not implemented yet", Logger::Severity::Error);

--- a/Shared/src/Windows/Path.cpp
+++ b/Shared/src/Windows/Path.cpp
@@ -134,6 +134,12 @@ Vector<String> Path::GetSubDirs(const String& path)
 	return res;
 }
 
+void Path::OpenInBrowser(const String& path)
+{
+	WString wpath = Utility::ConvertToWString(path);
+	ShellExecuteW(NULL, L"open", *wpath, NULL, NULL, SW_SHOWNORMAL);
+}
+
 bool Path::ShowInFileBrowser(const String& path)
 {
 	WString wpath = Utility::ConvertToWString(path);


### PR DESCRIPTION
This change adds a prompt to let the user upload a crashdump to http://uscdmp.stackchk.fail/ when USC crashes on windows. There is also now an option to turn off this prompt and just exit on crash.