### PR TITLE
IR Support

### DIFF
--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -3,6 +3,7 @@
 #include <Shared/Jobs.hpp>
 #include <Shared/Thread.hpp>
 #include "SkinHttp.hpp"
+#include "SkinIR.hpp"
 
 #define DISCORD_APPLICATION_ID "514489760568573952"
 
@@ -33,7 +34,7 @@ public:
 	void ApplySettings();
 	// Runs the application
 	int32 Run();
-	
+
 	void SetCommandLine(int32 argc, char** argv);
 	void SetCommandLine(const char* cmdLine);
 
@@ -134,6 +135,7 @@ private:
 	Thread m_updateThread;
 	class Beatmap* m_currentMap = nullptr;
 	SkinHttp m_skinHttp;
+	SkinIR m_skinIR;
 
 	float m_deltaTime;
 	float m_fpsTargetSleepMult = 1.0f;

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -158,6 +158,9 @@ DefineEnum(GameConfigKeys,
 		   MultiplayerPassword,
 		   MultiplayerUsername,
 
+		   IRBaseURL,
+		   IRToken,
+
 		   EnableFancyHighwayRoll,
 
 		   GameplaySettingsDialogLastTab,

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -160,6 +160,7 @@ DefineEnum(GameConfigKeys,
 
 		   IRBaseURL,
 		   IRToken,
+		   IRLowBandwidth,
 
 		   EnableFancyHighwayRoll,
 

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include "stdafx.h"
+#include <Beatmap/MapDatabase.hpp>
+
+namespace IR
+{
+    bool PostScore(ScoreIndex* score);
+}

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -20,6 +20,7 @@ namespace IR
         {"RequestFailure", 60}};
 
     cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map);
+    cpr::AsyncResponse Heartbeat();
 
     bool ValidatePostScoreReturn(nlohmann::json& json);
 }

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -16,6 +16,7 @@ namespace IR
         {"Unauthorized", 41},
         {"ChartRefused", 42},
         {"Forbidden", 43},
+        {"NotFound", 44},
         {"ServerError", 50},
         {"RequestFailure", 60}};
 
@@ -23,6 +24,7 @@ namespace IR
     cpr::AsyncResponse Heartbeat();
     cpr::AsyncResponse ChartTracked(String chartHash);
     cpr::AsyncResponse Record(String chartHash);
+    cpr::AsyncResponse PostReplay(String identifier, String replayPath);
 
     bool ValidateReturn(nlohmann::json& json);
     bool ValidatePostScoreReturn(nlohmann::json& json);

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -21,6 +21,7 @@ namespace IR
 
     cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map);
     cpr::AsyncResponse Heartbeat();
+    cpr::AsyncResponse ChartTracked(String chartHash);
 
     bool ValidatePostScoreReturn(nlohmann::json& json);
 }

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -24,6 +24,7 @@ namespace IR
     cpr::AsyncResponse Heartbeat();
     cpr::AsyncResponse ChartTracked(String chartHash);
     cpr::AsyncResponse Record(String chartHash);
+    cpr::AsyncResponse Leaderboard(String chartHash, String mode, int n);
     cpr::AsyncResponse PostReplay(String identifier, String replayPath);
 
     bool ValidateReturn(nlohmann::json& json);

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -20,13 +20,13 @@ namespace IR
         {"ServerError", 50},
         {"RequestFailure", 60}};
 
-    cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map);
+    cpr::AsyncResponse PostScore(const ScoreIndex& score, const BeatmapSettings& map);
     cpr::AsyncResponse Heartbeat();
     cpr::AsyncResponse ChartTracked(String chartHash);
     cpr::AsyncResponse Record(String chartHash);
     cpr::AsyncResponse Leaderboard(String chartHash, String mode, int n);
     cpr::AsyncResponse PostReplay(String identifier, String replayPath);
 
-    bool ValidateReturn(nlohmann::json& json);
-    bool ValidatePostScoreReturn(nlohmann::json& json);
+    bool ValidateReturn(const nlohmann::json& json);
+    bool ValidatePostScoreReturn(const nlohmann::json& json);
 }

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -1,8 +1,25 @@
 #pragma once
 #include "stdafx.h"
+#include "cpr/cpr.h"
+#include "json.hpp"
 #include <Beatmap/MapDatabase.hpp>
+#include <Beatmap/BeatmapObjects.hpp>
 
 namespace IR
 {
-    bool PostScore(ScoreIndex* score);
+    //honestly, this is really disgusting and i'd much rather have it as an enum, but this is just so much nicer to work with...
+    inline nlohmann::json const ResponseState = {
+        {"Unused", 0},
+        {"Pending", 10},
+        {"Success", 20},
+        {"BadRequest", 40},
+        {"Unauthorized", 41},
+        {"ChartRefused", 42},
+        {"Forbidden", 43},
+        {"ServerError", 50},
+        {"RequestFailure", 60}};
+
+    cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map);
+
+    bool ValidatePostScoreReturn(nlohmann::json& json);
 }

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -23,5 +23,6 @@ namespace IR
     cpr::AsyncResponse Heartbeat();
     cpr::AsyncResponse ChartTracked(String chartHash);
 
+    bool ValidateReturn(nlohmann::json& json);
     bool ValidatePostScoreReturn(nlohmann::json& json);
 }

--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -22,6 +22,7 @@ namespace IR
     cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map);
     cpr::AsyncResponse Heartbeat();
     cpr::AsyncResponse ChartTracked(String chartHash);
+    cpr::AsyncResponse Record(String chartHash);
 
     bool ValidateReturn(nlohmann::json& json);
     bool ValidatePostScoreReturn(nlohmann::json& json);

--- a/Main/include/LuaRequests.hpp
+++ b/Main/include/LuaRequests.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "stdafx.h"
+#include "lua.hpp"
+#include "cpr/cpr.h"
+
+struct AsyncRequest
+{
+	struct lua_State* L;
+	cpr::AsyncResponse r;
+	int callback;
+};
+
+struct CompleteRequest
+{
+	struct lua_State* L;
+	cpr::Response r;
+	int callback;
+};

--- a/Main/include/SkinIR.hpp
+++ b/Main/include/SkinIR.hpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "Shared/Thread.hpp"
 #include "LuaRequests.hpp"
+#include "json.hpp"
 
 //mostly based on SkinHttp, explained in .cpp
 
@@ -28,4 +29,7 @@ private:
 
 	void m_requestLoop();
 	void m_PushResponse(struct lua_State* L, const cpr::Response& r);
+    void m_PushJSON(struct lua_State* L, nlohmann::json& json);
+    void m_PushArray(struct lua_State* L, nlohmann::json& json);
+    void m_PushObject(struct lua_State* L, nlohmann::json& json);
 };

--- a/Main/include/SkinIR.hpp
+++ b/Main/include/SkinIR.hpp
@@ -3,18 +3,17 @@
 #include "Shared/Thread.hpp"
 #include "LuaRequests.hpp"
 
+//mostly based on SkinHttp, explained in .cpp
+
 //structs have been moved into shared LuaRequests header to stop IR from including Http or vice versa
 
-class SkinHttp
+class SkinIR
 {
 public:
-	SkinHttp();
-	~SkinHttp();
-	static cpr::Header HeaderFromLuaTable(struct lua_State* L, int index);
-	int lGetAsync(struct lua_State* L);
-	int lPostAsync(struct lua_State* L);
-	int lGet(struct lua_State* L);
-	int lPost(struct lua_State* L);
+	SkinIR();
+	~SkinIR();
+    int lHeartbeat(struct lua_State* L);
+    int lChartTracked(struct lua_State* L);
 	void ProcessCallbacks();
 	void PushFunctions(struct lua_State* L);
 	void ClearState(struct lua_State* L);

--- a/Main/include/SkinIR.hpp
+++ b/Main/include/SkinIR.hpp
@@ -31,7 +31,7 @@ private:
 
 	void m_requestLoop();
 	void m_PushResponse(struct lua_State* L, const cpr::Response& r);
-    void m_PushJSON(struct lua_State* L, nlohmann::json& json);
-    void m_PushArray(struct lua_State* L, nlohmann::json& json);
-    void m_PushObject(struct lua_State* L, nlohmann::json& json);
+    void m_PushJSON(struct lua_State* L, const nlohmann::json& json);
+    void m_PushArray(struct lua_State* L, const nlohmann::json& json);
+    void m_PushObject(struct lua_State* L, const nlohmann::json& json);
 };

--- a/Main/include/SkinIR.hpp
+++ b/Main/include/SkinIR.hpp
@@ -16,6 +16,7 @@ public:
     int lHeartbeat(struct lua_State* L);
     int lChartTracked(struct lua_State* L);
     int lRecord(struct lua_State* L);
+	int lLeaderboard(struct lua_State* L);
 	void ProcessCallbacks();
 	void PushFunctions(struct lua_State* L);
 	void ClearState(struct lua_State* L);

--- a/Main/include/SkinIR.hpp
+++ b/Main/include/SkinIR.hpp
@@ -15,6 +15,7 @@ public:
 	~SkinIR();
     int lHeartbeat(struct lua_State* L);
     int lChartTracked(struct lua_State* L);
+    int lRecord(struct lua_State* L);
 	void ProcessCallbacks();
 	void PushFunctions(struct lua_State* L);
 	void ClearState(struct lua_State* L);

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -23,6 +23,7 @@
 #include "SkinConfig.hpp"
 #include "SkinHttp.hpp"
 #include "ShadedMesh.hpp"
+#include "IR.hpp"
 
 #ifdef EMBEDDED
 #define NANOVG_GLES2_IMPLEMENTATION
@@ -656,7 +657,7 @@ bool Application::m_Init()
 		(const wchar_t*)nullptr,
 		&custom_info
 	);
-#endif 
+#endif
 #endif
 
 	// Must have command line
@@ -2396,6 +2397,16 @@ void Application::SetLuaBindings(lua_State *state)
 		lua_newtable(state);
 		pushFuncToTable("Absolute", lPathAbsolute);
 		lua_setglobal(state, "path");
+	}
+
+	//ir
+	{
+		lua_newtable(state);
+
+		for(auto& el : IR::ResponseState.items())
+			pushIntToTable(el.key().c_str(), el.value());
+
+		lua_setglobal(state, "ir");
 	}
 
 	//http

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -2409,10 +2409,19 @@ void Application::SetLuaBindings(lua_State *state)
 	{
 		lua_newtable(state);
 
+		lua_pushstring(state, "States");
+		lua_newtable(state);
+
 		for(auto& el : IR::ResponseState.items())
 			pushIntToTable(el.key().c_str(), el.value());
 
-		lua_setglobal(state, "IRState");
+		lua_settable(state, -3);
+
+		lua_pushstring(state, "Active");
+		lua_pushboolean(state, g_gameConfig.GetString(GameConfigKeys::IRBaseURL) != "");
+		lua_settable(state, -3);
+
+		lua_setglobal(state, "IRData");
 
 		m_skinIR.PushFunctions(state);
 	}

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -22,6 +22,7 @@
 #include "json.hpp"
 #include "SkinConfig.hpp"
 #include "SkinHttp.hpp"
+#include "SkinIR.hpp"
 #include "ShadedMesh.hpp"
 #include "IR.hpp"
 
@@ -1021,6 +1022,9 @@ void Application::m_Tick()
 	// Process async lua http callbacks
 	m_skinHttp.ProcessCallbacks();
 
+	// likewise for IR
+	m_skinIR.ProcessCallbacks();
+
 	// Tick all items
 	for (auto &tickable : g_tickables)
 	{
@@ -1434,6 +1438,7 @@ void Application::ReloadScript(const String &name, lua_State *L)
 	String commonPath = "skins/" + m_skin + "/scripts/" + "common.lua";
 	DisposeGUI(L);
 	m_skinHttp.ClearState(L);
+	m_skinIR.ClearState(L);
 	path = Path::Absolute(path);
 	commonPath = Path::Absolute(commonPath);
 	if (luaL_dofile(L, commonPath.c_str()) || luaL_dofile(L, path.c_str()))
@@ -1514,6 +1519,7 @@ void Application::DisposeLua(lua_State *state)
 {
 	DisposeGUI(state);
 	m_skinHttp.ClearState(state);
+	m_skinIR.ClearState(state);
 	lua_close(state);
 }
 void Application::SetGaugeColor(int i, Color c)
@@ -2406,7 +2412,9 @@ void Application::SetLuaBindings(lua_State *state)
 		for(auto& el : IR::ResponseState.items())
 			pushIntToTable(el.key().c_str(), el.value());
 
-		lua_setglobal(state, "ir");
+		lua_setglobal(state, "IRState");
+
+		m_skinIR.PushFunctions(state);
 	}
 
 	//http

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -206,6 +206,10 @@ void GameConfig::InitDefaults()
 
 	Set(GameConfigKeys::EnableFancyHighwayRoll, true);
 
+	// IR
+	Set(GameConfigKeys::IRBaseURL, "");
+	Set(GameConfigKeys::IRToken, "");
+
 	//Gameplay
 	Set(GameConfigKeys::RandomizeChart, false);
 	Set(GameConfigKeys::MirrorChart, false);

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -209,6 +209,7 @@ void GameConfig::InitDefaults()
 	// IR
 	Set(GameConfigKeys::IRBaseURL, "");
 	Set(GameConfigKeys::IRToken, "");
+	Set(GameConfigKeys::IRLowBandwidth, false);
 
 	//Gameplay
 	Set(GameConfigKeys::RandomizeChart, false);

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -64,6 +64,14 @@ namespace IR {
                              CommonHeader());
     }
 
+    cpr::AsyncResponse ChartTracked(String chartHash)
+    {
+        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/charts/" + chartHash;
+
+        return cpr::GetAsync(cpr::Url{host},
+                             CommonHeader());
+    }
+
     //note: this only confirms that the response is well-formed - responses other than 20 will not have most information, so this needs to be beared in mind too
     //e.g., this function returning true does not mean that body will exist, because status may not be 20.
     //it also does not validate each score's structure at this time - possible todo?

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -72,15 +72,27 @@ namespace IR {
                              CommonHeader());
     }
 
-    //note: this only confirms that the response is well-formed - responses other than 20 will not have most information, so this needs to be beared in mind too
-    //e.g., this function returning true does not mean that body will exist, because status may not be 20.
-    //it also does not validate each score's structure at this time - possible todo?
-    bool ValidatePostScoreReturn(nlohmann::json& json)
+    bool ValidateReturn(nlohmann::json& json)
     {
         if(json.find("statusCode") == json.end()) return false;
         if(json["statusCode"] < 20 || json["statusCode"] > 59) return false;
 
         if(json.find("description") == json.end()) return false;
+
+        if(json["statusCode"] == 20)
+        {
+            if(json.find("body") == json.end()) return false;
+        }
+
+        return true;
+    }
+
+    //note: this only confirms that the response is well-formed - responses other than 20 will not have most information, so this needs to be beared in mind too
+    //e.g., this function returning true does not mean that body will exist, because status may not be 20.
+    //it also does not validate each score's structure at this time - possible todo?
+    bool ValidatePostScoreReturn(nlohmann::json& json)
+    {
+        if(!ValidateReturn(json)) return false;
 
         if(json["statusCode"] == 20)
         {

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -4,8 +4,6 @@
 
 static void PopulateScoreJSON(nlohmann::json& json, ScoreIndex& score, BeatmapSettings& map)
 {
-    json["token"] = g_gameConfig.GetString(GameConfigKeys::IRToken);
-
     json["score"] = {
         {"score", score.score},
         {"crit", score.crit},
@@ -13,8 +11,7 @@ static void PopulateScoreJSON(nlohmann::json& json, ScoreIndex& score, BeatmapSe
         {"miss", score.miss},
         {"gauge", score.gauge},
         {"gameflags", score.gameflags},
-        {"timestamp", score.timestamp},
-        {"chartHash", score.chartHash},
+        {"timestamp", score.timestamp},,
         {"windows", {
             {"perfect", score.hitWindowPerfect},
             {"good", score.hitWindowGood},
@@ -24,6 +21,7 @@ static void PopulateScoreJSON(nlohmann::json& json, ScoreIndex& score, BeatmapSe
     };
 
     json["chart"] = {
+        {"chartHash", score.chartHash}, //this looks nasty in code but makes sense from a protocol perspective
         {"title", map.title},
         {"artist", map.artist},
         {"effector", map.effector},
@@ -46,8 +44,11 @@ namespace IR {
         Log(json.dump(), Logger::Severity::Warning);
 
         return cpr::PostAsync(cpr::Url{host},
-                              cpr::Body{json.dump()},
-                              cpr::Header{{"Content-Type", "application/json"}});
+                              cpr::Header{
+                                  {"Authorization", "Bearer " + g_gameConfig.GetString(GameConfigKeys::IRToken)}, //would like to use cpr::Bearer but was added in a more recent version of cpr
+                                  {"Content-Type", "application/json"}
+                              },
+                              cpr::Body{json.dump()});
     }
 
     //note: this only confirms that the response is well-formed - responses other than 20 will not have most information, so this needs to be beared in mind too

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -72,6 +72,14 @@ namespace IR {
                              CommonHeader());
     }
 
+    cpr::AsyncResponse Record(String chartHash)
+    {
+        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/charts/" + chartHash + "/record";
+
+        return cpr::GetAsync(cpr::Url{host},
+                             CommonHeader());
+    }
+
     bool ValidateReturn(nlohmann::json& json)
     {
         if(json.find("statusCode") == json.end()) return false;

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -1,0 +1,46 @@
+#include "stdafx.h"
+#include "IR.hpp"
+#include "cpr/cpr.h"
+#include "json.hpp"
+#include "GameConfig.hpp"
+
+void PopulateScoreJSON(nlohmann::json& json, ScoreIndex* score)
+{
+    json["token"] = g_gameConfig.GetString(GameConfigKeys::IRToken);
+
+    json["score"] = score->score;
+    json["crit"] = score->crit;
+    json["almost"] = score->almost;
+    json["miss"] = score->miss;
+    json["gauge"] = score->gauge;
+    json["gameflags"] = score->gameflags;
+    json["timestamp"] = score->timestamp;
+    json["chartHash"] = score->chartHash;
+
+    json["hitWindowPerfect"] = score->hitWindowPerfect;
+    json["hitWindowGood"] = score->hitWindowGood;
+    json["hitWindowHold"] = score->hitWindowHold;
+    json["hitWindowMiss"] = score->hitWindowMiss;
+}
+
+namespace IR {
+    bool PostScore(ScoreIndex* score)
+    {
+        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/score/submit";
+
+
+
+        nlohmann::json json;
+
+        PopulateScoreJSON(json, score);
+
+        auto res = cpr::Post(cpr::Url{host},
+                             cpr::Body{json.dump()});
+
+        bool success = res.status_code == 200;
+
+        if(!success) Logf("Submitting score to IR failed with code: %d", Logger::Severity::Warning, res.status_code);
+
+        return success;
+    }
+}

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -49,8 +49,6 @@ namespace IR {
 
         PopulateScoreJSON(json, score, map);
 
-        Log(json.dump(), Logger::Severity::Warning);
-
         return cpr::PostAsync(cpr::Url{host},
                               CommonHeader(),
                               cpr::Body{json.dump()});
@@ -78,6 +76,16 @@ namespace IR {
 
         return cpr::GetAsync(cpr::Url{host},
                              CommonHeader());
+    }
+
+    cpr::AsyncResponse PostReplay(String identifier, String replayPath)
+    {
+        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/replays";
+
+        return cpr::PostAsync(cpr::Url{host},
+                              cpr::Header{{"Authorization", "Bearer " + g_gameConfig.GetString(GameConfigKeys::IRToken)}}, //can't give the json header here so whatever
+                              cpr::Multipart{{"identifier", identifier},
+                                             {"replay", cpr::File{replayPath}}});
     }
 
     bool ValidateReturn(nlohmann::json& json)

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -7,8 +7,8 @@ static void PopulateScoreJSON(nlohmann::json& json, ScoreIndex& score, BeatmapSe
     json["score"] = {
         {"score", score.score},
         {"crit", score.crit},
-        {"almost", score.almost},
-        {"miss", score.miss},
+        {"near", score.almost},
+        {"error", score.miss},
         {"gauge", score.gauge},
         {"gameflags", score.gameflags},
         {"timestamp", score.timestamp},

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -1,46 +1,93 @@
 #include "stdafx.h"
 #include "IR.hpp"
-#include "cpr/cpr.h"
-#include "json.hpp"
 #include "GameConfig.hpp"
 
-void PopulateScoreJSON(nlohmann::json& json, ScoreIndex* score)
+static void PopulateScoreJSON(nlohmann::json& json, ScoreIndex& score, BeatmapSettings& map)
 {
     json["token"] = g_gameConfig.GetString(GameConfigKeys::IRToken);
 
-    json["score"] = score->score;
-    json["crit"] = score->crit;
-    json["almost"] = score->almost;
-    json["miss"] = score->miss;
-    json["gauge"] = score->gauge;
-    json["gameflags"] = score->gameflags;
-    json["timestamp"] = score->timestamp;
-    json["chartHash"] = score->chartHash;
+    json["score"] = {
+        {"score", score.score},
+        {"crit", score.crit},
+        {"almost", score.almost},
+        {"miss", score.miss},
+        {"gauge", score.gauge},
+        {"gameflags", score.gameflags},
+        {"timestamp", score.timestamp},
+        {"chartHash", score.chartHash},
+        {"windows", {
+            {"perfect", score.hitWindowPerfect},
+            {"good", score.hitWindowGood},
+            {"hold", score.hitWindowHold},
+            {"miss", score.hitWindowMiss}
+        }}
+    };
 
-    json["hitWindowPerfect"] = score->hitWindowPerfect;
-    json["hitWindowGood"] = score->hitWindowGood;
-    json["hitWindowHold"] = score->hitWindowHold;
-    json["hitWindowMiss"] = score->hitWindowMiss;
+    json["chart"] = {
+        {"title", map.title},
+        {"artist", map.artist},
+        {"effector", map.effector},
+        {"illustrator", map.illustrator},
+        {"difficulty", map.difficulty},
+        {"level", map.level},
+        {"bpm", map.bpm}
+    };
 }
 
 namespace IR {
-    bool PostScore(ScoreIndex* score)
+    cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map)
     {
         String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/score/submit";
 
-
-
         nlohmann::json json;
 
-        PopulateScoreJSON(json, score);
+        PopulateScoreJSON(json, score, map);
 
-        auto res = cpr::Post(cpr::Url{host},
-                             cpr::Body{json.dump()});
+        Log(json.dump(), Logger::Severity::Warning);
 
-        bool success = res.status_code == 200;
-
-        if(!success) Logf("Submitting score to IR failed with code: %d", Logger::Severity::Warning, res.status_code);
-
-        return success;
+        return cpr::PostAsync(cpr::Url{host},
+                              cpr::Body{json.dump()},
+                              cpr::Header{{"Content-Type", "application/json"}});
     }
+
+    //note: this only confirms that the response is well-formed - responses other than 20 will not have most information, so this needs to be beared in mind too
+    //e.g., this function returning true does not mean that body will exist, because status may not be 20.
+    //it also does not validate each score's structure at this time - possible todo?
+    bool ValidatePostScoreReturn(nlohmann::json& json)
+    {
+        if(json.find("statusCode") == json.end()) return false;
+        if(json["statusCode"] < 20 || json["statusCode"] > 59) return false;
+
+        if(json.find("description") == json.end()) return false;
+
+        if(json["statusCode"] == 20)
+        {
+            if(json.find("body") == json.end()) return false;
+
+            if(json["body"].find("adjacentAbove") == json["body"].end()) return false;
+            if(!json["body"]["adjacentAbove"].is_array()) return false;
+
+            if(json["body"].find("adjacentBelow") == json["body"].end()) return false;
+            if(!json["body"]["adjacentAbove"].is_array()) return false;
+
+            if(json["body"].find("adjacentBelow") == json["body"].end()) return false;
+            if(!json["body"]["adjacentAbove"].is_array()) return false;
+
+            if(json["body"].find("isPB") == json["body"].end()) return false;
+            if(!json["body"]["isPB"].is_boolean()) return false;
+
+            if(json["body"].find("isServerRecord") == json["body"].end()) return false;
+            if(!json["body"]["isServerRecord"].is_boolean()) return false;
+
+            if(json["body"].find("score") == json["body"].end()) return false;
+            if(!json["body"]["score"].is_object()) return false;
+
+            if(json["body"].find("serverRecord") == json["body"].end()) return false;
+            if(!json["body"]["serverRecord"].is_object()) return false;
+        }
+
+        return true;
+
+    }
+
 }

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -43,7 +43,7 @@ static cpr::Header CommonHeader()
 namespace IR {
     cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map)
     {
-        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/score/submit";
+        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/scores";
 
         nlohmann::json json;
 

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -78,6 +78,16 @@ namespace IR {
                              CommonHeader());
     }
 
+    cpr::AsyncResponse Leaderboard(String chartHash, String mode, int n)
+    {
+        String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/charts/" + chartHash + "/leaderboard";
+
+        return cpr::GetAsync(cpr::Url{host},
+                             cpr::Header{{"Authorization", "Bearer " + g_gameConfig.GetString(GameConfigKeys::IRToken)}}, //can't give the json header here so whatever
+                             cpr::Parameters{{"mode", mode},
+                                             {"n", std::to_string(n)}});
+    }
+
     cpr::AsyncResponse PostReplay(String identifier, String replayPath)
     {
         String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/replays";

--- a/Main/src/IR.cpp
+++ b/Main/src/IR.cpp
@@ -2,7 +2,7 @@
 #include "IR.hpp"
 #include "GameConfig.hpp"
 
-static void PopulateScoreJSON(nlohmann::json& json, ScoreIndex& score, BeatmapSettings& map)
+static void PopulateScoreJSON(nlohmann::json& json, const ScoreIndex& score, const BeatmapSettings& map)
 {
     json["score"] = {
         {"score", score.score},
@@ -41,7 +41,7 @@ static cpr::Header CommonHeader()
 }
 
 namespace IR {
-    cpr::AsyncResponse PostScore(ScoreIndex& score, BeatmapSettings& map)
+    cpr::AsyncResponse PostScore(const ScoreIndex& score, const BeatmapSettings& map)
     {
         String host = g_gameConfig.GetString(GameConfigKeys::IRBaseURL) + "/scores";
 
@@ -98,7 +98,7 @@ namespace IR {
                                              {"replay", cpr::File{replayPath}}});
     }
 
-    bool ValidateReturn(nlohmann::json& json)
+    bool ValidateReturn(const nlohmann::json& json)
     {
         if(json.find("statusCode") == json.end()) return false;
         if(json["statusCode"] < 20 || json["statusCode"] > 59) return false;
@@ -116,7 +116,7 @@ namespace IR {
     //note: this only confirms that the response is well-formed - responses other than 20 will not have most information, so this needs to be beared in mind too
     //e.g., this function returning true does not mean that body will exist, because status may not be 20.
     //it also does not validate each score's structure at this time - possible todo?
-    bool ValidatePostScoreReturn(nlohmann::json& json)
+    bool ValidatePostScoreReturn(const nlohmann::json& json)
     {
         if(!ValidateReturn(json)) return false;
 

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -43,6 +43,9 @@ private:
 	uint32 m_timedHits[2];
 	int m_irState = IR::ResponseState["Unused"];
 
+	//promote this to higher scope so i can use it in tick
+	String m_replayPath;
+
 	cpr::AsyncResponse m_irResponse;
 	nlohmann::json m_irResponseJson;
 
@@ -432,10 +435,10 @@ public:
 			}
 
 			Path::CreateDir(Path::Absolute("replays/" + hash));
-			String replayPath = Path::Normalize(Path::Absolute("replays/" + chart->hash + "/" + Shared::Time::Now().ToString() + ".urf"));
+			m_replayPath = Path::Normalize(Path::Absolute("replays/" + chart->hash + "/" + Shared::Time::Now().ToString() + ".urf"));
 			File replayFile;
 
-			if (replayFile.OpenWrite(replayPath))
+			if (replayFile.OpenWrite(m_replayPath))
 			{
 				FileWriter fw(replayFile);
 				fw.SerializeObject(m_simpleHitStats);
@@ -452,7 +455,7 @@ public:
 			newScore->gauge = m_finalGaugeValue;
 			newScore->gameflags = (uint32)m_flags;
 			newScore->timestamp = Shared::Time::Now().Data();
-			newScore->replayPath = replayPath;
+			newScore->replayPath = m_replayPath;
 			newScore->chartHash = hash;
 			newScore->userName = g_gameConfig.GetString(GameConfigKeys::MultiplayerUsername);
 			newScore->localScore = true;
@@ -834,6 +837,7 @@ public:
 		if (m_multiplayer)
 			m_multiplayer->GetChatOverlay()->Tick(deltaTime);
 
+		//handle ir score submission request
 		if (m_irState == IR::ResponseState["Pending"])
 		{
 			try {
@@ -853,10 +857,19 @@ public:
 						try {
 							m_irResponseJson = nlohmann::json::parse(response.text);
 
-							Log(m_irResponseJson.dump(), Logger::Severity::Error);
-
 							if(!IR::ValidatePostScoreReturn(m_irResponseJson)) m_irState = IR::ResponseState["RequestFailure"];
-							else m_irState = m_irResponseJson["statusCode"];
+							else
+							{
+								m_irState = m_irResponseJson["statusCode"];
+
+								//server wants us to send replay
+								if(m_irResponseJson["body"].find("sendReplay") != m_irResponseJson["body"].end() && m_irResponseJson["body"]["sendReplay"].is_string())
+								{
+									//don't really care about the return of this, if it fails it's not the end of the world
+									IR::PostReplay(m_irResponseJson["body"]["sendReplay"].get<String>(), m_replayPath).get();
+								}
+							}
+
 
 						} catch(nlohmann::json::parse_error& e) {
 							Log("Parsing JSON returned from IR failed.", Logger::Severity::Error);

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -42,6 +42,7 @@ private:
 	String m_jacketPath;
 	uint32 m_timedHits[2];
 	int m_irState = IR::ResponseState["Unused"];
+	String m_chartHash;
 
 	//promote this to higher scope so i can use it in tick
 	String m_replayPath;
@@ -434,6 +435,8 @@ public:
 				Log("Couldn't open the chart file for hashing, using existing hash.", Logger::Severity::Warning);
 			}
 
+			m_chartHash = hash;
+
 			Path::CreateDir(Path::Absolute("replays/" + hash));
 			m_replayPath = Path::Normalize(Path::Absolute("replays/" + chart->hash + "/" + Shared::Time::Now().ToString() + ".urf"));
 			File replayFile;
@@ -578,6 +581,7 @@ public:
 		lua_settable(m_lua, -3);
 
 		m_PushIntToTable("irState", m_irState);
+		m_PushStringToTable("chartHash", m_chartHash);
 
 		//description (for displaying any errors, etc)
 		if(m_irState >= 20)

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -509,6 +509,14 @@ public:
 		lua_pushboolean(m_lua, m_autoplay);
 		lua_settable(m_lua, -3);
 
+		lua_pushstring(m_lua, "irUsed");
+		lua_pushboolean(m_lua, m_irUsed);
+		lua_settable(m_lua, -3);
+
+		lua_pushstring(m_lua, "irSuccess");
+		lua_pushboolean(m_lua, m_irSuccess);
+		lua_settable(m_lua, -3);
+
 		m_PushFloatToTable("playbackSpeed", m_playbackSpeed);
 
 		m_PushStringToTable("mission", m_mission);

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -866,12 +866,16 @@ public:
 							{
 								m_irState = m_irResponseJson["statusCode"];
 
-								//server wants us to send replay
-								if(m_irResponseJson["body"].find("sendReplay") != m_irResponseJson["body"].end() && m_irResponseJson["body"]["sendReplay"].is_string())
+								//if we are allowed to send replays
+								if(!g_gameConfig.GetBool(GameConfigKeys::IRLowBandwidth))
 								{
-									//don't really care about the return of this, if it fails it's not the end of the world
-									IR::PostReplay(m_irResponseJson["body"]["sendReplay"].get<String>(), m_replayPath).get();
-								}
+									//and server wants us to send replay
+									if(m_irResponseJson["body"].find("sendReplay") != m_irResponseJson["body"].end() && m_irResponseJson["body"]["sendReplay"].is_string())
+									{
+										//don't really care about the return of this, if it fails it's not the end of the world
+										IR::PostReplay(m_irResponseJson["body"]["sendReplay"].get<String>(), m_replayPath).get();
+									}
+								}			
 							}
 
 

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -16,6 +16,7 @@
 #include <Beatmap/TinySHA1.hpp>
 #include "MultiplayerScreen.hpp"
 #include "ChatOverlay.hpp"
+#include "IR.hpp"
 
 class ScoreScreen_Impl : public ScoreScreen
 {
@@ -38,6 +39,8 @@ private:
 	float* m_gaugeSamples;
 	String m_jacketPath;
 	uint32 m_timedHits[2];
+	bool m_irUsed;
+	bool m_irSuccess;
 
 	HitWindow m_hitWindow = HitWindow::NORMAL;
 
@@ -352,7 +355,7 @@ public:
 				s.getDigest(digest);
 				hash = Utility::Sprintf("%08x%08x%08x%08x%08x", digest[0], digest[1], digest[2], digest[3], digest[4]);
 			}
-			else 
+			else
 			{
 				Log("Couldn't open the chart file for hashing, using existing hash.", Logger::Severity::Warning);
 			}
@@ -389,6 +392,12 @@ public:
 			newScore->hitWindowMiss = m_hitWindow.miss;
 
 			m_mapDatabase.AddScore(newScore);
+
+			if(g_gameConfig.GetString(GameConfigKeys::IRBaseURL) != "")
+			{
+				m_irUsed = true;
+				m_irSuccess = IR::PostScore(newScore);
+			}
 
 		 	chart->scores.Add(newScore);
 			chart->scores.Sort([](ScoreIndex* a, ScoreIndex* b)
@@ -609,7 +618,7 @@ public:
 			}
 			lua_settable(m_lua, -3);
 		}
-		
+
 		lua_setglobal(m_lua, "result");
 
 		lua_getglobal(m_lua, "result_set");
@@ -715,7 +724,7 @@ public:
 		}
 
 
-        
+
 
 		m_showStats = g_input.GetButton(Input::Button::FX_0);
 
@@ -806,7 +815,7 @@ public:
 			screenshot->SavePNG(screenshotPath);
 			screenshot.reset();
 		}
-		else 
+		else
 		{
 			screenshotPath = "Failed to capture screenshot";
 		}

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -1001,6 +1001,9 @@ public:
 			nk_sdl_text(nk_edit_string(m_nctx, NK_EDIT_FIELD, tokenBuffer, &m_irTokenLen, 1024, nk_filter_default));
             if (old_len < m_irTokenLen)
                         memcpy(&m_irToken[old_len], &tokenBuffer[old_len], (nk_size)(m_irTokenLen - old_len));
+
+			ToggleSetting(GameConfigKeys::IRLowBandwidth, "IR Low Bandwidth (disables sending replays)");
+			
 			nk_tree_pop(m_nctx);
 		}
 		else

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -997,13 +997,17 @@ public:
 			int i = 0;
 			int old_len = m_irTokenLen;
 			char tokenBuffer[1024];
-            for (i = 0; i < m_irTokenLen; ++i) tokenBuffer[i] = '*';
+			for (i = 0; i < m_irTokenLen; ++i) tokenBuffer[i] = '*';
+
 			nk_sdl_text(nk_edit_string(m_nctx, NK_EDIT_FIELD, tokenBuffer, &m_irTokenLen, 1024, nk_filter_default));
-            if (old_len < m_irTokenLen)
-                        memcpy(&m_irToken[old_len], &tokenBuffer[old_len], (nk_size)(m_irTokenLen - old_len));
+
+			if (old_len < m_irTokenLen)
+			{
+				memcpy(&m_irToken[old_len], &tokenBuffer[old_len], (nk_size)(m_irTokenLen - old_len));
+			}
 
 			ToggleSetting(GameConfigKeys::IRLowBandwidth, "IR Low Bandwidth (disables sending replays)");
-			
+
 			nk_tree_pop(m_nctx);
 		}
 		else

--- a/Main/src/SkinHttp.cpp
+++ b/Main/src/SkinHttp.cpp
@@ -1,12 +1,11 @@
 #include "stdafx.h"
-#include "SkinHttp.hpp"
-#include "lua.hpp"
 #include "Shared/LuaBindable.hpp"
+#include "SkinHttp.hpp"
 
 void SkinHttp::m_requestLoop()
 {
 	while (m_running)
-	{		
+	{
 		m_mutex.lock(); ///TODO: use semaphore?
 		if (m_requests.size() > 0)
 		{
@@ -87,7 +86,7 @@ void SkinHttp::m_PushResponse(lua_State * L, const cpr::Response & r)
 		pushString(i.first, i.second);
 	}
 	lua_settable(L, -3);
-	
+
 }
 
 SkinHttp::SkinHttp()

--- a/Main/src/SkinIR.cpp
+++ b/Main/src/SkinIR.cpp
@@ -179,6 +179,22 @@ int SkinIR::lRecord(struct lua_State* L)
 	return 0;
 }
 
+int SkinIR::lLeaderboard(struct lua_State* L)
+{
+    String hash = luaL_checkstring(L, 2);
+    String mode = luaL_checkstring(L, 3);
+    int n = luaL_checkinteger(L, 4);
+	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
+	AsyncRequest* r = new AsyncRequest();
+	r->r = IR::Leaderboard(hash, mode, n);
+	r->callback = callback;
+	r->L = L;
+	m_mutex.lock();
+	m_requests.push(r);
+	m_mutex.unlock();
+	return 0;
+}
+
 
 void SkinIR::ProcessCallbacks()
 {
@@ -214,6 +230,7 @@ void SkinIR::PushFunctions(lua_State * L)
 	bindable->AddFunction("Heartbeat", this, &SkinIR::lHeartbeat);
     bindable->AddFunction("ChartTracked", this, &SkinIR::lChartTracked);
     bindable->AddFunction("Record", this, &SkinIR::lRecord);
+    bindable->AddFunction("Leaderboard", this, &SkinIR::lLeaderboard);
 	bindable->Push();
 	lua_settop(L, 0);
 	m_boundStates.Add(L, bindable);

--- a/Main/src/SkinIR.cpp
+++ b/Main/src/SkinIR.cpp
@@ -87,25 +87,28 @@ void SkinIR::m_PushResponse(lua_State * L, const cpr::Response & r)
             {"description", "The request to the IR failed."}
         });
     }
-    try {
-        nlohmann::json json = nlohmann::json::parse(r.text);
+    else
+    {
+        try {
+            nlohmann::json json = nlohmann::json::parse(r.text);
 
-        if(!IR::ValidateReturn(json))
-        {
+            if(!IR::ValidateReturn(json))
+            {
+                m_PushJSON(L, nlohmann::json{
+                    {"statusCode", 60},
+                    {"description", "The IR response was malformed."}
+                });
+            }
+            else m_PushJSON(L, json);
+
+        } catch(nlohmann::json::parse_error& e) {
+            Log("Parsing JSON returned from IR failed.", Logger::Severity::Warning);
+
             m_PushJSON(L, nlohmann::json{
                 {"statusCode", 60},
                 {"description", "The IR response was malformed."}
             });
         }
-        else m_PushJSON(L, json);
-
-    } catch(nlohmann::json::parse_error& e) {
-        Log("Parsing JSON returned from IR failed.", Logger::Severity::Warning);
-
-        m_PushJSON(L, nlohmann::json{
-            {"statusCode", 60},
-            {"description", "The IR response was malformed."}
-        });
     }
 }
 

--- a/Main/src/SkinIR.cpp
+++ b/Main/src/SkinIR.cpp
@@ -162,6 +162,20 @@ int SkinIR::lChartTracked(struct lua_State* L)
 	return 0;
 }
 
+int SkinIR::lRecord(struct lua_State* L)
+{
+    String hash = luaL_checkstring(L, 2);
+	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
+	AsyncRequest* r = new AsyncRequest();
+	r->r = IR::Record(hash);
+	r->callback = callback;
+	r->L = L;
+	m_mutex.lock();
+	m_requests.push(r);
+	m_mutex.unlock();
+	return 0;
+}
+
 
 void SkinIR::ProcessCallbacks()
 {
@@ -196,6 +210,7 @@ void SkinIR::PushFunctions(lua_State * L)
 	auto bindable = new LuaBindable(L, "IR");
 	bindable->AddFunction("Heartbeat", this, &SkinIR::lHeartbeat);
     bindable->AddFunction("ChartTracked", this, &SkinIR::lChartTracked);
+    bindable->AddFunction("Record", this, &SkinIR::lRecord);
 	bindable->Push();
 	lua_settop(L, 0);
 	m_boundStates.Add(L, bindable);

--- a/Main/src/SkinIR.cpp
+++ b/Main/src/SkinIR.cpp
@@ -8,7 +8,7 @@
 //especially since that'd then require the skin to specify the authorization headers, json Content-Type, etc.
 //this approach makes it easier for the skin creator
 
-void SkinIR::m_PushArray(lua_State* L, nlohmann::json& json)
+void SkinIR::m_PushArray(lua_State* L, const nlohmann::json& json)
 {
     lua_newtable(L);
     int index = 1;
@@ -21,7 +21,7 @@ void SkinIR::m_PushArray(lua_State* L, nlohmann::json& json)
     }
 }
 
-void SkinIR::m_PushObject(lua_State* L, nlohmann::json& json)
+void SkinIR::m_PushObject(lua_State* L, const nlohmann::json& json)
 {
     lua_newtable(L);
 
@@ -34,7 +34,7 @@ void SkinIR::m_PushObject(lua_State* L, nlohmann::json& json)
     }
 }
 
-void SkinIR::m_PushJSON(lua_State* L, nlohmann::json& json)
+void SkinIR::m_PushJSON(lua_State* L, const nlohmann::json& json)
 {
     if(json.is_array()) m_PushArray(L, json);
     else if(json.is_object()) m_PushObject(L, json);

--- a/Main/src/SkinIR.cpp
+++ b/Main/src/SkinIR.cpp
@@ -1,0 +1,165 @@
+#include "stdafx.h"
+#include "Shared/LuaBindable.hpp"
+#include "SkinIR.hpp"
+#include "IR.hpp"
+
+//this file mostly based on SkinHttp
+//but it seems easier to me to have these be separate functions rather than updating the http requests to support json
+//especially since that'd then require the skin to specify the authorization headers, json Content-Type, etc.
+//this approach makes it easier for the skin creator
+
+void SkinIR::m_requestLoop()
+{
+	while (m_running)
+	{
+		m_mutex.lock(); ///TODO: use semaphore?
+		if (m_requests.size() > 0)
+		{
+			//get request
+			AsyncRequest* r = m_requests.front();
+			m_mutex.unlock();
+
+			//process request
+			CompleteRequest cr;
+			cr.L = r->L;
+			cr.callback = r->callback;
+			cr.r = r->r.get();
+
+			//push result and pop request
+			m_mutex.lock();
+			delete r;
+			m_callbackQueue.push(cr);
+			m_requests.pop();
+			m_mutex.unlock();
+		}
+		else
+		{
+			m_mutex.unlock();
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		}
+	}
+}
+
+//TODO: change
+void SkinIR::m_PushResponse(lua_State * L, const cpr::Response & r)
+{
+	auto pushString = [L](String key, String value)
+	{
+		lua_pushstring(L, *key);
+		lua_pushstring(L, *value);
+		lua_settable(L, -3);
+	};
+	auto pushNumber = [L](String key, double value)
+	{
+		lua_pushstring(L, *key);
+		lua_pushnumber(L, value);
+		lua_settable(L, -3);
+	};
+
+	lua_newtable(L);
+	pushString("url", r.url);
+	pushString("text", r.text);
+	pushNumber("status", r.status_code);
+	pushNumber("elapsed", r.elapsed);
+	pushString("error", r.error.message.c_str());
+	pushString("cookies", r.cookies.GetEncoded().c_str());
+	lua_pushstring(L, "header");
+	lua_newtable(L);
+	for (auto& i : r.header)
+	{
+		pushString(i.first, i.second);
+	}
+	lua_settable(L, -3);
+
+}
+
+
+SkinIR::SkinIR()
+{
+	m_running = true;
+	m_requestThread = Thread(&SkinIR::m_requestLoop, this);
+}
+
+SkinIR::~SkinIR()
+{
+	m_running = false;
+	if(m_requestThread.joinable())
+		m_requestThread.join();
+
+	while (!m_requests.empty())
+	{
+		delete m_requests.front();
+		m_requests.pop();
+	}
+
+	for (auto& s : m_boundStates)
+	{
+		delete s.second;
+	}
+	m_boundStates.clear();
+}
+
+int SkinIR::lHeartbeat(struct lua_State* L)
+{
+    int callback = luaL_ref(L, LUA_REGISTRYINDEX);
+    AsyncRequest* r = new AsyncRequest();
+    r->r = IR::Heartbeat();
+    r->callback = callback;
+    r->L = L;
+    m_mutex.lock();
+    m_requests.push(r);
+    m_mutex.unlock();
+    return 0;
+}
+
+int SkinIR::lChartTracked(struct lua_State* L)
+{
+    //todo
+    return 0;
+}
+
+
+void SkinIR::ProcessCallbacks()
+{
+	m_mutex.lock();
+	if (m_callbackQueue.size() > 0)
+	{
+		//get response
+		CompleteRequest& cr = m_callbackQueue.front();
+		m_mutex.unlock();
+
+		if (m_boundStates.Contains(cr.L))
+		{
+			//process response
+			lua_rawgeti(cr.L, LUA_REGISTRYINDEX, cr.callback);
+			m_PushResponse(cr.L, cr.r);
+			if (lua_pcall(cr.L, 1, 0, 0) != 0)
+			{
+				Logf("Lua error on calling IR callback: %s", Logger::Severity::Error, lua_tostring(cr.L, -1));
+			}
+			lua_settop(cr.L, 0);
+			luaL_unref(cr.L, LUA_REGISTRYINDEX, cr.callback);
+		}
+		//pop response
+		m_mutex.lock();
+		m_callbackQueue.pop();
+	}
+	m_mutex.unlock();
+}
+
+void SkinIR::PushFunctions(lua_State * L)
+{
+	auto bindable = new LuaBindable(L, "IR");
+	bindable->AddFunction("Heartbeat", this, &SkinIR::lHeartbeat);
+	bindable->Push();
+	lua_settop(L, 0);
+	m_boundStates.Add(L, bindable);
+}
+
+void SkinIR::ClearState(lua_State * L)
+{
+	if (!m_boundStates.Contains(L))
+		return;
+	delete m_boundStates.at(L);
+	m_boundStates.erase(L);
+}

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -393,7 +393,7 @@ private:
 		lua_newtable(m_lua);
 		int songIndex = 0;
 
-		
+
 		if (sorted)
 		{
 			// sortVec should only have the current maps in the collection
@@ -405,7 +405,7 @@ private:
 			}
 		}
 		else {
-			
+
 			for (auto& song : collection)
 			{
 				m_PushSongToLua(song.second, ++songIndex);
@@ -435,6 +435,7 @@ private:
 			m_PushIntToTable("level", diff->level);
 			m_PushIntToTable("difficulty", diff->diff_index);
 			m_PushIntToTable("id", diff->id);
+			m_PushStringToTable("hash", diff->hash);
 			m_PushStringToTable("effector", diff->effector.c_str());
 			m_PushStringToTable("illustrator", diff->illustrator.c_str());
 			m_PushIntToTable("topBadge", static_cast<int>(Scoring::CalculateBestBadge(diff->scores)));
@@ -1104,7 +1105,7 @@ public:
 			// Transition to game
 			g_transition->TransitionTo(game);
 		});
-		
+
 		m_settDiag.onPressPractice.AddLambda([this]() {
 			if (m_multiplayer != nullptr) return;
 

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -435,7 +435,7 @@ private:
 			m_PushIntToTable("level", diff->level);
 			m_PushIntToTable("difficulty", diff->diff_index);
 			m_PushIntToTable("id", diff->id);
-			m_PushStringToTable("hash", diff->hash);
+			m_PushStringToTable("hash", diff->hash.c_str());
 			m_PushStringToTable("effector", diff->effector.c_str());
 			m_PushStringToTable("illustrator", diff->illustrator.c_str());
 			m_PushIntToTable("topBadge", static_cast<int>(Scoring::CalculateBestBadge(diff->scores)));

--- a/bin/skins/Default/config-definitions.json
+++ b/bin/skins/Default/config-definitions.json
@@ -1,6 +1,6 @@
 {
 	"Gameplay:" : { "type" : "label" },
-	
+
 	"earlate_position": {
 		"type": "selection",
 		"label": "Early/Late display position",
@@ -12,7 +12,7 @@
 		"label" : "Display name",
 		"default" : "Guest"
 	},
-	
+
 	"separator_a" : {},
 	"Song select:" : { "type" : "label" },
 	"show_guide": {
@@ -20,7 +20,7 @@
 		"type": "bool",
 		"default": true
 	},
-	
+
 	"separator_b" : {},
 	"Result:" : { "type" : "label" },
 	"show_result_hiscore": {
@@ -50,7 +50,12 @@
 		"type": "bool",
 		"default": true
 	},
-	
+	"ir_or_hiscore": {
+		"label": "Show IR by default in place of hiscore",
+		"type": "bool",
+		"default": false
+	},
+
 	"separator_c" : {},
 	"Test objects:" : { "type" : "label" },
 	"Testing with space" : {
@@ -60,7 +65,7 @@
 		"max": 100.0,
 		"min": -100.0
 	},
-	
+
 	"Ineger_test" : {
 		"type": "int",
 		"label": "Ineger Test with range -100<->100",
@@ -68,7 +73,7 @@
 		"max": 100,
 		"min": -100
 	},
-	
+
 	"col_test" : {
 		"type": "color",
 		"label": "Color Test",

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -375,7 +375,7 @@ draw_highscores_or_ir = function(ir, full)
 end
 
 draw_ir = function(full)
-    if result.irState == IRState.Unused then return end
+    if not IRData.Active then return end
 
     gfx.FillColor(255,255,255)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT)
@@ -383,14 +383,14 @@ draw_ir = function(full)
     gfx.FontSize(30)
     gfx.Text("IR (BT-D: High Scores)",510,30)
 
-    if result.irState == IRState.Pending then
+    if result.irState == IRData.States.Pending then
         gfx.FontSize(15)
         gfx.FillColor(170, 170, 170)
         gfx.Text("Loading... please wait.", 510, 60)
         return
     end
 
-    if result.irState ~= IRState.Success then
+    if result.irState ~= IRData.States.Success then
         gfx.FontSize(15)
         gfx.FillColor(255, 0, 0)
         gfx.Text("Error:", 510, 60)
@@ -457,11 +457,13 @@ draw_highscores = function(full)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT)
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
     gfx.FontSize(30)
-    if result.irState == IRState.Unused then
+
+    if not IRData.Active then
         gfx.Text("High Scores",510,30)
     else
         gfx.Text("High Scores (BT-D: IR)",510,30)
     end
+
     gfx.StrokeWidth(1)
     for i,s in ipairs(highScores) do
         gfx.Save()
@@ -899,7 +901,7 @@ draw_mir_ran_icon = function(x, y, s)
 end
 
 draw_ir_icon = function(x, y, s)
-    if result.irState == IRState.Unused then return x end
+    if not IRData.Active then return x end
 
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
     gfx.FillColor(255, 255, 255)
@@ -911,10 +913,10 @@ draw_ir_icon = function(x, y, s)
     gfx.BeginPath()
     gfx.FontSize(20)
 
-    if result.irState == IRState.Pending then
+    if result.irState == IRData.States.Pending then
         gfx.FillColor(100, 100, 100)
         gfx.Text("...", x + s/2, y + s*0.7)
-    elseif result.irState == IRState.Success then
+    elseif result.irState == IRData.States.Success then
         gfx.FillColor(0, 255, 0)
         gfx.Text("OK", x + s/2, y + s*0.7)
     else
@@ -1221,7 +1223,7 @@ render = function(deltaTime)
     local fxLeft = game.GetButton(4)
     local fxRight = game.GetButton(5)
 
-    if result.irState ~= IRState.Unused then
+    if IRData.Active then
         local btD = game.GetButton(3)
 
         if prevBTD ~= btD then

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -74,9 +74,9 @@ local prevShowHiScore = not showHiScore
 function waveParam(period, offset)
     local t = currTime
     if offset then t = t+offset end
-    
+
     t = t / period
-    
+
     return 0.5 + 0.5*math.cos(t * math.pi * 2)
 end
 
@@ -91,21 +91,21 @@ end
 
 function drawScaledText(txt, x, y, max_width)
     local text_scale = getTextScale(txt, max_width)
-    
+
     if text_scale == 1 then
         gfx.BeginPath()
         gfx.Text(txt, x, y)
         return
     end
-    
+
     gfx.Save()
-    
+
     gfx.Translate(x, y)
     gfx.Scale(text_scale, 1)
-    
+
     gfx.BeginPath()
     gfx.Text(txt, 0, 0)
-    
+
     gfx.Restore()
 end
 
@@ -132,10 +132,10 @@ end
 result_set = function()
     highScores = { }
     currentAdded = false
-    
+
     chartTitle = result.title
     if result.realTitle ~= nil and result.playerName ~= nil then chartTitle = result.realTitle end
-    
+
     if result.duration ~= nil then
         chartDuration = result.duration
         chartDurationText = string.format("%dm %02d.%01ds", chartDuration // 60000, (chartDuration // 1000) % 60, (chartDuration // 100) % 10)
@@ -145,7 +145,7 @@ result_set = function()
         chartDurationText = ""
         hitGraphHoverScale = 10
     end
-    
+
     if result.uid == nil then --local scores
         for i,s in ipairs(result.highScores) do
             newScore = { }
@@ -167,14 +167,14 @@ result_set = function()
             newScore.xoff = 0
             if s.timestamp > 0 then
                 newScore.subtext = os.date("%Y-%m-%d %H:%M:%S", s.timestamp)
-            else 
+            else
                 newScore.subtext = ""
             end
-            
+
             if highestScore < s.score then
                 highestScore = s.score
             end
-            
+
             table.insert(highScores, newScore)
         end
 
@@ -194,7 +194,7 @@ result_set = function()
         showHiScore = true
         for i,s in ipairs(result.highScores) do
             newScore = { }
-            if s.uid == result.uid then 
+            if s.uid == result.uid then
                 newScore.color = {255, 127, 0}
             else
                 newScore.color = {0, 127, 255}
@@ -210,29 +210,29 @@ result_set = function()
             newScore.badge = s.badge
             newScore.badgeDesc = getScoreBadgeDesc(s)
             newScore.subtext = s.name
-            
+
             if highestScore < s.score then
                 highestScore = s.score
             end
-            
+
             table.insert(highScores, newScore)
         end
     end
-    
+
     if result.jacketPath ~= nil and result.jacketPath ~= "" then
         jacketImg = gfx.CreateImage(result.jacketPath, 0)
     end
-    
+
     gradeImg = gfx.CreateSkinImage(string.format("score/%s.png", result.grade), 0)
     if gradeImg ~= nil then
         local gradew, gradeh = gfx.ImageSize(gradeImg)
         gradeAR = gradew / gradeh
     end
-    
+
     if 1 <= result.badge and result.badge <= 5 then
         badgeImg = badgeImages[result.badge]
     end
-    
+
     if result.autoplay then clearTextBase = "AUTOPLAY"
     elseif result.hitWindow ~= nil and result.hitWindow.type == 0 then clearTextBase = "EXPAND JUDGE"
     elseif result.badge == 0 then clearTextBase = "NOT SAVED"
@@ -243,7 +243,7 @@ result_set = function()
     elseif result.badge == 5 then clearTextBase = "PERFECT"
     else clearTextBase = ""
     end
-    
+
     if result.playbackSpeed ~= nil and result.playbackSpeed ~= 1.00 then
         if clearTextBase == "" then clearText = string.format("x%.2f play", result.playbackSpeed)
         else clearText = string.format("%s (x%.2f play)", clearTextBase, result.playbackSpeed)
@@ -251,11 +251,11 @@ result_set = function()
     else
         clearText = clearTextBase
     end
-    
+
     if result.uid ~= nil and result.playerName ~= nil and result.isSelf ~= true then
         clearText = string.format("By %s", result.playerName)
     end
-    
+
     if result.speedModType ~= nil then
         if result.speedModType == 0 then
             speedMod = "XMOD"
@@ -276,31 +276,31 @@ result_set = function()
     end
 
     hasHitStat = result.noteHitStats ~= nil and #result.noteHitStats > 0
-    
+
     hitWindowPerfect = 46
     hitWindowGood = 92
     critText = "CRIT"
     nearText = "NEAR"
-        
+
     if result.hitWindow ~= nil then
         hitWindowPerfect = result.hitWindow.perfect
         hitWindowGood = result.hitWindow.good
-        
+
         if hitWindowPerfect ~= 46 or hitWindowGood ~= 92 then
             critText = string.format("%02dms CRIT", hitWindowPerfect)
             nearText = string.format("%02dms NEAR", hitWindowGood)
         end
     end
-    
+
     hitHistogram = {}
-    
+
     if hasHitStat then
         for i = 1, #result.noteHitStats do
             local hitStat = result.noteHitStats[i]
             if hitStat.rating == 1 or hitStat.rating == 2 then
                 if hitHistogram[hitStat.delta] == nil then hitHistogram[hitStat.delta] = 0 end
                 hitHistogram[hitStat.delta] = hitHistogram[hitStat.delta] + 1
-                
+
                 if hitStat.delta < hitMinDelta then hitMinDelta = hitStat.delta end
                 if hitStat.delta > hitMaxDelta then hitMaxDelta = hitStat.delta end
             end
@@ -341,7 +341,7 @@ draw_stat = function(x,y,w,h, name, value, format,r,g,b)
     gfx.BeginPath()
     gfx.MoveTo(0,h)
     gfx.LineTo(w,h)
-    if r then gfx.StrokeColor(r,g,b) 
+    if r then gfx.StrokeColor(r,g,b)
     else gfx.StrokeColor(200,200,200) end
     gfx.StrokeWidth(1)
     gfx.Stroke()
@@ -389,11 +389,11 @@ draw_highscores = function(full)
         gfx.FillColor(255,255,255)
         gfx.FontSize(25)
         gfx.Text(string.format("#%d",i), 5, 5)
-        
+
         if s.badge ~= nil and 1 <= s.badge and s.badge <= 5 then
             gfx.BeginPath()
             gfx.ImageRect(37, 7, 36, 36, badgeImages[s.badge], 1, 0)
-            
+
             if full then
                 gfx.BeginPath()
                 gfx.FontSize(15)
@@ -401,9 +401,9 @@ draw_highscores = function(full)
                 gfx.Text(s.badgeDesc, 55, 52)
             end
         end
-        
+
         draw_score(s.score, 55, 42, 215, 60)
-        
+
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_TOP)
         gfx.LoadSkinFont("NotoSans-Regular.ttf")
         gfx.FontSize(20)
@@ -418,21 +418,21 @@ draw_gauge_graph = function(x, y, w, h, alpha, xfocus, xscale)
         xfocus = 0
         xscale = 1
     end
-    
+
     local leftIndex = math.floor(#result.gaugeSamples/w * (-xfocus / xscale + xfocus))
     leftIndex = math.max(1, math.min(#result.gaugeSamples, leftIndex))
-    
+
     gfx.BeginPath()
     gfx.MoveTo(x, y + h - h * result.gaugeSamples[leftIndex])
-    
+
     for i = leftIndex+1, #result.gaugeSamples do
         local gaugeX = i * w / #result.gaugeSamples
         gaugeX = (gaugeX - xfocus) * xscale + xfocus
         gfx.LineTo(x + gaugeX,y + h - h * result.gaugeSamples[i])
-        
+
         if gaugeX > w then break end
     end
-    
+
     gfx.StrokeWidth(2.0)
     if result.flags & 1 ~= 0 then
         gfx.StrokeColor(255,80,0,alpha)
@@ -451,27 +451,27 @@ end
 
 draw_hit_graph_lines = function(x, y, w, h)
     local maxDispDelta = h/2 / hitDeltaScale
-    
+
     gfx.StrokeWidth(1)
-    
+
     gfx.BeginPath()
     gfx.StrokeColor(128, 255, 128, 128)
     gfx.MoveTo(x, y+h/2)
     gfx.LineTo(x+w, y+h/2)
     gfx.Stroke()
-    
+
     gfx.BeginPath()
     gfx.StrokeColor(64, 128, 64, 64)
-    
+
     for i = -math.floor(maxDispDelta / 10), math.floor(maxDispDelta / 10) do
         local lineY = y + h/2 + i*10*hitDeltaScale
-        
+
         if i ~= 0 then
             gfx.MoveTo(x, lineY)
             gfx.LineTo(x+w, lineY)
         end
     end
-    
+
     gfx.Stroke()
 end
 
@@ -479,29 +479,29 @@ draw_hit_graph = function(x, y, w, h, xfocus, xscale)
     if not hasHitStat or hitDeltaScale == 0.0 then
         return
     end
-    
+
     if xfocus == nil then xfocus = 0 end
     if xscale == nil then xscale = 1 end
-    
+
     draw_hit_graph_lines(x, y, w, h)
-    
+
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
     gfx.FontSize(12)
-    
+
     for i = 1, #result.noteHitStats do
         local hitStat = result.noteHitStats[i]
         local hitStatX = (hitStat.timeFrac*w - xfocus)*xscale + xfocus
-        
+
         if 0 <= hitStatX then
             if hitStatX > w then break end
-            
+
             local hitStatY = h/2 + hitStat.delta * hitDeltaScale
             if hitStatY < 0 then hitStatY = 0
             elseif hitStatY > h then hitStatY = h
             end
-            
+
             local hitStatSize = 1
-            
+
             if hitStat.rating == 2 then
                 hitStatSize = 1.25
                 gfx.FillColor(255, 150, 0, 160)
@@ -512,7 +512,7 @@ draw_hit_graph = function(x, y, w, h, xfocus, xscale)
                 hitStatSize = 2
                 gfx.FillColor(255, 0, 0, 128)
             end
-            
+
             gfx.BeginPath()
             if xscale > 1 then
                 gfx.Text(laneNames[hitStat.lane + 1], x+hitStatX, y+hitStatY)
@@ -528,64 +528,64 @@ draw_left_graph = function(x, y, w, h)
     local mx, my = game.GetMousePos()
     mx = mx / scale - moveX
     my = my / scale - moveY
-    
+
     local mhit = x <= mx and mx <= x+w and y <= my and my <= y+h
     local hit_xfocus = 0
     local hit_xscale = 1
-    
+
     gfx.BeginPath()
     gfx.Rect(x, y, w, h)
     gfx.FillColor(255, 255, 255, 32)
     gfx.Fill()
-    
+
     local chartDurationDisp = string.format("Duration: %s", chartDurationText)
-    
+
     if mhit then
         hit_xfocus = mx - x
         hit_xscale = hitGraphHoverScale
-        
+
         local currPos = chartDuration * ((mx - x) / w)
         chartDurationDisp = string.format("%dm %02d.%01ds / %s" , currPos // 60000, (currPos // 1000) % 60, (currPos // 100) % 10, chartDurationText)
-        
+
         drawLine(mx, y, mx, y+h, 1, 64, 96, 64)
     end
-    
+
     gfx.FontSize(17)
     gfx.FillColor(64, 128, 64, 96)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_TOP)
-    
+
     gfx.BeginPath()
     gfx.Text(chartDurationDisp, x+5, y)
-    
+
     if result.bpm ~= nil then
         gfx.BeginPath()
         gfx.Text(string.format("BPM: %s", result.bpm), x+5, y+15)
     end
-    
+
     draw_hit_graph(x, y, w, h, hit_xfocus, hit_xscale)
     if hit_xscale == 1 then
         draw_gauge_graph(x, y, w, h)
     else
         draw_gauge_graph(x, y, w, h, 64, hit_xfocus, hit_xscale)
         draw_gauge_graph(x, y, w, h)
-        
+
         local gaugeInd = math.floor(1 + #result.gaugeSamples/w * ((mx-x - hit_xfocus) / hit_xscale + hit_xfocus))
         gaugeInd = math.max(1, math.min(#result.gaugeSamples, gaugeInd))
-        
+
         local gaugeY = h - h * result.gaugeSamples[gaugeInd]
-        
+
         gfx.StrokeColor(255, 0, 0, 196)
         gfx.FillColor(255, 255, 255, 196)
         gfx.FontSize(16)
-        
+
         gfx.BeginPath()
         gfx.Circle(mx, y + gaugeY, 2)
         gfx.Stroke()
-        
+
         gfx.BeginPath()
         gfx.Text(string.format("%.1f%%", result.gaugeSamples[gaugeInd]*100), mx, y + gaugeY - 10)
     end
-    
+
     -- hitDeltaAbs is unavailable for multiplayers
     if result.uid ~= nil then
         gfx.FontSize(16)
@@ -600,26 +600,26 @@ draw_left_graph = function(x, y, w, h)
         gfx.FillColor(255, 255, 255, 128)
         gfx.Text(string.format("Mean deviation: %.1fms", result.meanHitDeltaAbs), x+4, y+h)
     end
-    
+
     -- End gauge display
     local endGauge = result.gauge
     local endGaugeY = y + h - h * endGauge
-    
+
     if endGaugeY > y+h - 10 then endGaugeY = y+h - 10
     elseif endGaugeY < y + 10 then endGaugeY = y + 10
     end
-    
+
     local gaugeText = string.format("%.1f%%", endGauge*100)
-    
+
     gfx.FontSize(20)
     gfx.TextAlign(gfx.TEXT_ALIGN_RIGHT + gfx.TEXT_ALIGN_MIDDLE)
     local x1, y1, x2, y2 = gfx.TextBounds(x+w-6, endGaugeY, gaugeText)
-    
+
     gfx.BeginPath()
     gfx.FillColor(80, 80, 80, 128)
     gfx.RoundedRect(x1-3, y1, x2-x1+6, y2-y1, 4)
     gfx.Fill()
-    
+
     gfx.BeginPath()
     gfx.LoadSkinFont("NovaMono.ttf")
     gfx.FillColor(255, 255, 255)
@@ -630,32 +630,32 @@ draw_hit_histogram = function(x, y, w, h)
     if not hasHitStat or hitDeltaScale == 0.0 then
         return
     end
-    
+
     local maxDispDelta = math.floor(h/2 / hitDeltaScale)
-    
+
     local mode = 0
     local modeCount = 0
-    
+
     for i = -maxDispDelta-1, maxDispDelta+1 do
         if hitHistogram[i] == nil then hitHistogram[i] = 0 end
     end
 
     for i = -maxDispDelta, maxDispDelta do
         local count = hitHistogram[i-1] + hitHistogram[i]*2 + hitHistogram[i+1]
-        
+
         if count > modeCount then
             mode = i
             modeCount = count
         end
     end
-    
+
     gfx.StrokeWidth(1.5)
     gfx.BeginPath()
     gfx.StrokeColor(255, 255, 128, 96)
     gfx.MoveTo(x, y)
     for i = -maxDispDelta, maxDispDelta do
         local count = hitHistogram[i-1] + hitHistogram[i]*2 + hitHistogram[i+1]
-        
+
         gfx.LineTo(x + 0.9 * w * count / modeCount, y+h/2 + i*hitDeltaScale)
     end
     gfx.LineTo(x, y+h)
@@ -666,23 +666,23 @@ draw_right_graph = function(x, y, w, h)
     if not hasHitStat or hitDeltaScale == 0.0 then
         return
     end
-    
+
     gfx.BeginPath()
     gfx.Rect(x, y, w, h)
     gfx.FillColor(64, 64, 64, 32)
     gfx.Fill()
-    
+
     draw_hit_graph_lines(x, y, w, h)
     draw_hit_histogram(x, y, w, h)
-    
+
     local meanY = h/2 + hitDeltaScale * result.meanHitDelta
     local medianY = h/2 + hitDeltaScale * result.medianHitDelta
-    
+
     drawLine(x, y+meanY, x+w, y+meanY, 1.25, 255, 0, 0, 192)
     drawLine(x, y+medianY, x+w, y+medianY, 1.25, 64, 64, 255, 192)
-    
+
     gfx.LoadSkinFont("NovaMono.ttf")
-    
+
     gfx.BeginPath()
     if meanY < medianY then
         gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
@@ -692,7 +692,7 @@ draw_right_graph = function(x, y, w, h)
     gfx.FillColor(255, 128, 128)
     gfx.FontSize(16)
     gfx.Text(string.format("Mean: %.1f ms", result.meanHitDelta), x+2, y+meanY)
-    
+
     gfx.BeginPath()
     if medianY <= meanY then
         gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
@@ -702,14 +702,14 @@ draw_right_graph = function(x, y, w, h)
     gfx.FillColor(196, 196, 255)
     gfx.FontSize(16)
     gfx.Text(string.format("Median: %d ms", result.medianHitDelta), x+2, y+medianY)
-    
+
     gfx.FillColor(255, 255, 255)
     gfx.FontSize(15)
-    
+
     gfx.BeginPath()
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_TOP)
     gfx.Text(string.format("Earliest: %d ms", hitMinDelta), x+5, y)
-    
+
     gfx.BeginPath()
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
     gfx.Text(string.format("Latest: %d ms", hitMaxDelta), x+5, y+h)
@@ -718,7 +718,7 @@ end
 draw_laser_icon = function(x, y, s)
     gfx.Save()
     gfx.Translate(x, y)
-    
+
     local r, g, b = game.GetLaserColor(0)
     gfx.BeginPath()
     gfx.FillColor(r, g, b, 96)
@@ -730,7 +730,7 @@ draw_laser_icon = function(x, y, s)
     gfx.LineTo(s*0.3, s*0.1)
     gfx.LineTo(s*0.1, s*0.1)
     gfx.Fill()
-    
+
     local r, g, b = game.GetLaserColor(1)
     gfx.BeginPath()
     gfx.FillColor(r, g, b, 96)
@@ -742,26 +742,26 @@ draw_laser_icon = function(x, y, s)
     gfx.LineTo(s*0.9, s*0.1)
     gfx.LineTo(s*0.7, s*0.1)
     gfx.Fill()
-    
+
     gfx.Restore()
-    
+
     return x - s
 end
 
 draw_speed_icon = function(x, y, s)
     if speedMod == "" then return x end
-    
+
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
     gfx.FillColor(255, 255, 255)
-    
+
     gfx.BeginPath()
     gfx.FontSize(15)
     gfx.Text(speedMod, x + s/2, y + s*0.3)
-    
+
     gfx.BeginPath()
     gfx.FontSize(20)
     gfx.Text(speedModValue, x + s/2, y + s*0.65)
-    
+
     return x - s
 end
 
@@ -769,40 +769,64 @@ draw_hidsud_icon = function(x, y, s)
     if result.hidsud == nil then
         return x
     end
-    
+
     gfx.FontSize(15)
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
     gfx.FillColor(255, 255, 255)
-    
+
     gfx.BeginPath()
     gfx.Text("SUDDEN", x + s/2, y + s*0.13)
     gfx.Text("HIDDEN", x + s/2, y + s*0.62)
-    
+
     gfx.BeginPath()
     gfx.FontSize(13)
     gfx.Text(string.format("%.2f fd %.1f", result.hidsud.suddenCutoff, result.hidsud.suddenFade), x + s/2, y + s*0.35)
     gfx.Text(string.format("%.2f fd %.1f", result.hidsud.hiddenCutoff, result.hidsud.hiddenFade), x + s/2, y + s*0.84)
-    
+
     return x - s
 end
 
 draw_mir_ran_icon = function(x, y, s)
     if result.flags & 6 == 0 then return x end
-    
+
     gfx.FontSize(20)
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
     gfx.FillColor(255, 255, 255)
-    
+
     if result.flags & 2 ~= 0 then
         gfx.BeginPath()
         gfx.Text("MIR", x + s/2, y + s*0.3)
     end
-    
+
     if result.flags & 4 ~= 0 then
         gfx.BeginPath()
         gfx.Text("RAN", x + s/2, y + s*0.7)
     end
-    
+
+    return x - s
+end
+
+draw_ir_icon = function(x, y, s)
+    if not result.irUsed then return x end
+
+    gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
+    gfx.FillColor(255, 255, 255)
+
+    gfx.BeginPath()
+    gfx.FontSize(20)
+    gfx.Text("IR", x + s/2, y + s*0.3)
+
+    gfx.BeginPath()
+    gfx.FontSize(20)
+
+    if result.irSuccess then
+        gfx.FillColor(0, 255, 0)
+        gfx.Text("OK", x + s/2, y + s*0.7)
+    else
+        gfx.FillColor(255, 0, 0)
+        gfx.Text("FAIL", x + s/2, y + s*0.7)
+    end
+
     return x - s
 end
 
@@ -812,36 +836,36 @@ end
 
 draw_title = function(x, y, w, h)
     local centerLineY = y+h*0.6
-    
+
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
-    
+
     gfx.BeginPath()
     gfx.FillColor(255, 255, 255)
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER)
-    
+
     gfx.FontSize(48)
     drawScaledText(chartTitle, x+w/2, centerLineY-18, w/2-5)
-    
+
     drawLine(x+30, centerLineY, x+w-30,centerLineY, 1, 64, 64, 64)
-    
+
     gfx.FontSize(27)
     drawScaledText(result.artist, x+w/2, centerLineY+28, w/2-5)
 end
 
 draw_chart_info = function(x, y, w, h, full)
     local jacket_size = 250
-    
+
     local jacket_y = y+40
-    
+
     if not full then
         jacket_y = y
         jacket_size = 300
     end
-    
+
     local jacket_x = x+(w-jacket_size)/2
-    
+
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
-    
+
     gfx.BeginPath()
     if jacketImg ~= nil then
         gfx.ImageRect(jacket_x, jacket_y, jacket_size, jacket_size, jacketImg, 1, 0)
@@ -850,14 +874,14 @@ draw_chart_info = function(x, y, w, h, full)
         gfx.FillColor(0, 0, 0, 128)
         gfx.Rect(jacket_x, jacket_y, jacket_size, jacket_size)
         gfx.Fill()
-        
+
         gfx.BeginPath()
         gfx.FillColor(255, 255, 255, math.floor(40+80*waveParam(4)))
         gfx.FontSize(30)
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
         gfx.Text("No Image", x+w/2, jacket_y + jacket_size/2)
     end
-    
+
     if full then
         gfx.BeginPath()
         gfx.FillColor(255, 255, 255)
@@ -868,54 +892,54 @@ draw_chart_info = function(x, y, w, h, full)
         do
             gfx.FontSize(20)
             gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
-            
+
             local level_text = string.format("%s %02d", diffNames[result.difficulty + 1], result.level)
             local _a, _b, level_text_width, _c = gfx.TextBounds(0, 0, level_text)
             local box_width = level_text_width
-            
+
             local effector_text = ""
-            
+
             if result.effector ~= nil and result.effector ~= "" then
                 effector_text = string.format("  by %s", result.effector)
-                
+
                 gfx.FontSize(16)
                 local _d, _e, effector_text_width, _f = gfx.TextBounds(0, 0, effector_text)
                 box_width = box_width + effector_text_width
             end
-            
+
             box_width = box_width + 10
             if box_width > jacket_size then box_width = jacket_size end
-            
+
             gfx.BeginPath()
             gfx.FillColor(0, 0, 0, 200)
             gfx.RoundedRectVarying(jacket_x, jacket_y, box_width, 25, 0, 0, 5, 0)
             gfx.Fill()
-            
+
             gfx.FillColor(255, 255, 255)
             gfx.BeginPath()
             gfx.FontSize(20)
             gfx.Text(level_text, jacket_x+5, jacket_y+22)
-            
+
             if effector_text ~= "" then
                 gfx.FontSize(16)
                 drawScaledText(effector_text, jacket_x+level_text_width+5, jacket_y+21, jacket_size-level_text_width-10)
             end
         end
-    
+
         local graph_height = jacket_size * 0.3
         local graph_y = jacket_y+jacket_size - graph_height
-    
+
         gfx.BeginPath()
         gfx.FillColor(0,0,0,200)
         gfx.Rect(jacket_x, graph_y, jacket_size, graph_height)
         gfx.Fill()
         draw_gauge_graph(jacket_x, graph_y, jacket_size, graph_height)
-        
+
         if gradeImg ~= nil then
             gfx.BeginPath()
             gfx.ImageRect(jacket_x+jacket_size-60*gradeAR, jacket_y+jacket_size-60, 60*gradeAR, 60, gradeImg, 1, 0)
         end
-        
+
         gfx.BeginPath()
         gfx.FillColor(255,255,255)
         gfx.FontSize(20)
@@ -923,9 +947,9 @@ draw_chart_info = function(x, y, w, h, full)
         gfx.Text(string.format("%.1f%%", result.gauge*100), jacket_x+jacket_size+10, jacket_y+jacket_size-graph_height*result.gauge)
         return
     end
-    
+
     draw_y = jacket_y + jacket_size + 27
-    
+
     if result.effector ~= nil and result.effector ~= "" then
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER)
         gfx.FillColor(255, 255, 255)
@@ -935,7 +959,7 @@ draw_chart_info = function(x, y, w, h, full)
         drawScaledText(result.effector, x+w/2, draw_y+24, w/2-5)
         draw_y = draw_y + 50
     end
-    
+
     if result.illustrator ~= nil and result.illustrator ~= "" then
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER)
         gfx.FontSize(16)
@@ -946,36 +970,36 @@ draw_chart_info = function(x, y, w, h, full)
     end
 end
 
-draw_basic_hitstat = function(x, y, w, h, full)    
+draw_basic_hitstat = function(x, y, w, h, full)
     local grade_width = 70 * gradeAR
     local stat_y = y
     local stat_gap = 15
     local stat_size = 30
     local stat_width = w-8
-    
+
     local showRetryCount = (result.retryCount ~= nil and result.retryCount > 0) or (result.mission ~= nil and result.mission ~= "")
-    
+
     if full then
         stat_gap = 6
         stat_size = 25
         stat_width = w-18
-        
+
         if not showRetryCount then
             stat_gap = 25
             stat_y = stat_y + 15
         end
-        
+
         gfx.BeginPath()
         gfx.ImageRect(x + (w-grade_width)/2 - 5, stat_y, grade_width, 70, gradeImg, 1, 0)
         stat_y = stat_y + 85
     else
         stat_y = y + 12
-    
+
         if not showRetryCount then
             stat_gap = 30
         end
     end
-    
+
     if clearTextBase ~= "" then
         if clearTextBase == "PERFECT" then gfx.FillColor(255, 255, math.floor(120+125*waveParam(2.0)))
         elseif clearTextBase == "FULL COMBO" then gfx.FillColor(255, 0, 200)
@@ -984,21 +1008,21 @@ draw_basic_hitstat = function(x, y, w, h, full)
             gfx.FillColor(255, w, w)
         else gfx.FillColor(255, 255, 255)
         end
-        
+
         gfx.BeginPath()
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER)
         gfx.FontSize(20)
         gfx.Text(clearText, x+w/2 - 5, stat_y)
     end
-    
+
     stat_y = stat_y + 50
-    
+
     if result.score == 10000000 then
         gfx.FillColor(255, 255, math.floor(120+125*waveParam(2.0)))
     else
         gfx.FillColor(255, 255, 255)
     end
-    
+
     if full then
         draw_score(result.score, x, stat_y, w, 72)
         stat_y = stat_y + 19
@@ -1008,7 +1032,7 @@ draw_basic_hitstat = function(x, y, w, h, full)
         draw_score(result.score, x, stat_y, w, 88)
         stat_y = stat_y + 19
     end
-    
+
     if highestScore > 0 then
         if highestScore > result.score then
             gfx.FillColor(255, 32, 32)
@@ -1021,34 +1045,34 @@ draw_basic_hitstat = function(x, y, w, h, full)
             draw_score(result.score - highestScore, x+w/2, stat_y, w/2, 25, "+")
         end
     end
-    
+
     stat_y = stat_y + stat_gap
-    
+
     gfx.FillColor(255, 255, 255)
-    
+
     stat_y = draw_stat(x+4, stat_y, stat_width, stat_size, critText, result.perfects, "%d", 255, 150, 0)
     stat_y = draw_stat(x+4, stat_y, stat_width, stat_size, nearText, result.goods, "%d", 255, 0, 200)
-    
+
     local early_late_width = w/2-20
     local late_x = x+stat_width-early_late_width
     draw_stat(late_x-early_late_width-10, stat_y, early_late_width, stat_size-6, "EARLY", result.earlies, "%d", 255, 0, 255)
     draw_stat(late_x, stat_y, early_late_width, stat_size-6, "LATE", result.lates, "%d", 0, 255, 255)
-    
+
     stat_y = stat_y + stat_size + 5
     stat_y = draw_stat(x+4, stat_y, stat_width, stat_size, "ERROR", result.misses, "%d", 255, 0, 0)
-    
+
     stat_y = draw_stat(x+4, stat_y+15, stat_width, stat_size, "MAX COMBO", result.maxCombo, "%d", 255, 255, 0)
-    
+
     if showRetryCount then
         local retryCount = 0
         if result.retryCount ~= nil then retryCount = result.retryCount end
-        
+
         stat_y = draw_stat(x+4, stat_y+15, stat_width, stat_size-6, "RETRY", retryCount, "%d")
-        
+
         if result.mission ~= nil and result.mission ~= "" then
             gfx.LoadSkinFont("NotoSans-Regular.ttf")
             gfx.TextAlign(gfx.TEXT_ALIGN_TOP + gfx.TEXT_ALIGN_LEFT)
-            
+
             gfx.BeginPath()
             gfx.FontSize(16)
             gfx.Text(string.format("Mission: %s", result.mission), x+4, stat_y)
@@ -1056,7 +1080,7 @@ draw_basic_hitstat = function(x, y, w, h, full)
     end
 end
 
-draw_graphs = function(x, y, w, h)    
+draw_graphs = function(x, y, w, h)
     if not hasHitStat or hitDeltaScale == 0.0 then
         draw_left_graph(x, y, w, h)
     else
@@ -1067,52 +1091,53 @@ end
 
 draw_guide = function(x, y, w, h, full)
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
-    
+
     local fxLText = "FX-L: more info"
     if full then
         fxLText = "FX-L: simple view"
     end
-    
+
     local fxRText = "FX-R: toggle hiscore"
-    
+
     gfx.FontSize(20)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
-    
+
     gfx.BeginPath()
     gfx.FillColor(255, 255, 255, 96)
     gfx.Text(string.format("%s, %s", fxLText, fxRText), x+5, y+h)
 end
 
-draw_icons = function(x, y, w, h)    
+draw_icons = function(x, y, w, h)
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
-    
+
     local icon_x = x+w-h
-    
+
     icon_x = draw_laser_icon(icon_x, y, h)
     icon_x = draw_speed_icon(icon_x, y, h)
     icon_x = draw_hidsud_icon(icon_x, y, h)
     icon_x = draw_mir_ran_icon(icon_x, y, h)
+    icon_x = draw_ir_icon(icon_x, y, h)
 end
 
 render = function(deltaTime)
     currTime = currTime + deltaTime
-    
+
     -- Note: these keys are also used for viewing other players' scores on multiplayer.
     local fxLeft = game.GetButton(4)
     local fxRight = game.GetButton(5)
-    
+
     if prevFXLeft ~= fxLeft then
         prevFXLeft = fxLeft
-        
+
         if fxLeft then
             if result.uid == nil then showStatsHit = not showStatsHit end
             game.PlaySample("menu_click")
         end
     end
-    
+
     if prevFXRight ~= fxRight then
         prevFXRight = fxRight
-        
+
         if fxRight then
             if result.uid == nil then showHiScore = not showHiScore end
             game.PlaySample("menu_click")
@@ -1120,21 +1145,21 @@ render = function(deltaTime)
     end
 
     local resx,resy = game.GetResolution()
-    
+
     if resx ~= currResX or resy ~= currResY or showHiScore ~= prevShowHiScore then
         prevShowHiScore = showHiScore
-        
+
         if showHiScore then
             desw = 770
         else
             desw = 500
         end
-        
+
         local scaleX = resx / desw
         local scaleY = resy / desh
-    
+
         scale = math.min(scaleX, scaleY)
-        
+
         if scaleX > scaleY then
             moveX = resx / (2*scale) - desw / 2
             moveY = 0
@@ -1142,31 +1167,31 @@ render = function(deltaTime)
             moveX = 0
             moveY = resy / (2*scale) - desh / 2
         end
-        
+
         currResX = resX
         currResY = resY
     end
-    
+
     -- For better screenshot display
     gfx.BeginPath()
     gfx.FillColor(0, 0, 0)
     gfx.Rect(0, 0, resx, resy)
     gfx.Fill()
-    
-    -- Background image    
+
+    -- Background image
     gfx.BeginPath()
     gfx.ImageRect(0, 0, resx, resy, backgroundImage, 0.5, 0);
     gfx.Scale(scale,scale)
     gfx.Translate(moveX,moveY)
-    
+
     gfx.BeginPath()
     gfx.Rect(0,0,500,800)
     gfx.FillColor(30,30,30,128)
     gfx.Fill()
-    
+
     -- Result
     draw_title(0, 0, 500, 110)
-    
+
     if showStatsHit then
         draw_chart_info(0, 120, 280, 420, true)
         draw_basic_hitstat(280, 120, 220, 420, true)
@@ -1175,25 +1200,25 @@ render = function(deltaTime)
         draw_chart_info(0, 120, 500, 310, false)
         draw_basic_hitstat(50, 430, 400, 400, false)
     end
-    
+
     if showGuide then
         draw_guide(0, 750, 500, 50, showStatsHit)
     end
-    
+
     if showIcons and result.isSelf ~= false then
         draw_icons(0, 750, 500, 50)
     end
-    
+
     if showHiScore then
         draw_highscores(showStatsHit)
     end
-    
+
     -- Applause SFX
     if result.badge > 1 and not played then
         game.PlaySample("applause")
         played = true
     end
-    
+
     -- Screenshot notification
     shotTimer = math.max(shotTimer - deltaTime, 0)
     if shotTimer > 1 then

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -375,7 +375,7 @@ draw_highscores_or_ir = function(ir, full)
 end
 
 draw_ir = function(full)
-    if result.irState == ir.Unused then return end
+    if result.irState == IRState.Unused then return end
 
     gfx.FillColor(255,255,255)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT)
@@ -383,14 +383,14 @@ draw_ir = function(full)
     gfx.FontSize(30)
     gfx.Text("IR (BT-D: High Scores)",510,30)
 
-    if result.irState == ir.Pending then
+    if result.irState == IRState.Pending then
         gfx.FontSize(15)
         gfx.FillColor(170, 170, 170)
         gfx.Text("Loading... please wait.", 510, 60)
         return
     end
 
-    if result.irState ~= ir.Success then
+    if result.irState ~= IRState.Success then
         gfx.FontSize(15)
         gfx.FillColor(255, 0, 0)
         gfx.Text("Error:", 510, 60)
@@ -457,7 +457,7 @@ draw_highscores = function(full)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT)
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
     gfx.FontSize(30)
-    if result.irState == ir.Unused then
+    if result.irState == IRState.Unused then
         gfx.Text("High Scores",510,30)
     else
         gfx.Text("High Scores (BT-D: IR)",510,30)
@@ -899,7 +899,7 @@ draw_mir_ran_icon = function(x, y, s)
 end
 
 draw_ir_icon = function(x, y, s)
-    if result.irState == ir.Unused then return x end
+    if result.irState == IRState.Unused then return x end
 
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
     gfx.FillColor(255, 255, 255)
@@ -911,10 +911,10 @@ draw_ir_icon = function(x, y, s)
     gfx.BeginPath()
     gfx.FontSize(20)
 
-    if result.irState == ir.Pending then
+    if result.irState == IRState.Pending then
         gfx.FillColor(100, 100, 100)
         gfx.Text("...", x + s/2, y + s*0.7)
-    elseif result.irState == ir.Success then
+    elseif result.irState == IRState.Success then
         gfx.FillColor(0, 255, 0)
         gfx.Text("OK", x + s/2, y + s*0.7)
     else
@@ -1221,7 +1221,7 @@ render = function(deltaTime)
     local fxLeft = game.GetButton(4)
     local fxRight = game.GetButton(5)
 
-    if result.irState ~= ir.Unused then
+    if result.irState ~= IRState.Unused then
         local btD = game.GetButton(3)
 
         if prevBTD ~= btD then

--- a/bin/skins/Default/scripts/songselect/background.lua
+++ b/bin/skins/Default/scripts/songselect/background.lua
@@ -8,40 +8,10 @@ TEXT_ALIGN_MIDDLE	= 16;
 TEXT_ALIGN_BOTTOM	= 32;
 TEXT_ALIGN_BASELINE	= 64;
 local backgroundImage = gfx.CreateSkinImage("bg.png", 1);
-local foo = false;
-
-function resc(res)
-    game.Log(log_table(res), game.LOGGER_ERROR)
-
-end
-
-function log_table(table)
-    str = "{"
-    for k, v in pairs(table) do
-        str = str .. k .. ": "
-
-        t = type(v)
-
-        if t == "table" then
-            str = str .. log_table(v)
-        elseif t == "string" then
-            str = str .. "\"" .. v .. "\""
-        else
-            str = str .. v
-        end
-
-        str = str .. ", "
-    end
-
-    return str .. "}"
-end
 
 
 render = function(deltaTime)
-    if not foo then
-        foo = true
-        IR.Heartbeat(resc)
-    end
+
 
     resx,resy = game.GetResolution();
     gfx.BeginPath();

--- a/bin/skins/Default/scripts/songselect/background.lua
+++ b/bin/skins/Default/scripts/songselect/background.lua
@@ -8,8 +8,41 @@ TEXT_ALIGN_MIDDLE	= 16;
 TEXT_ALIGN_BOTTOM	= 32;
 TEXT_ALIGN_BASELINE	= 64;
 local backgroundImage = gfx.CreateSkinImage("bg.png", 1);
+local foo = false;
+
+function resc(res)
+    game.Log(log_table(res), game.LOGGER_ERROR)
+
+end
+
+function log_table(table)
+    str = "{"
+    for k, v in pairs(table) do
+        str = str .. k .. ": "
+
+        t = type(v)
+
+        if t == "table" then
+            str = str .. log_table(v)
+        elseif t == "string" then
+            str = str .. "\"" .. v .. "\""
+        else
+            str = str .. v
+        end
+
+        str = str .. ", "
+    end
+
+    return str .. "}"
+end
+
 
 render = function(deltaTime)
+    if not foo then
+        foo = true
+        IR.Heartbeat(resc)
+    end
+
     resx,resy = game.GetResolution();
     gfx.BeginPath();
     gfx.TextAlign(TEXT_ALIGN_CENTER + TEXT_ALIGN_MIDDLE);

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -277,7 +277,7 @@ draw_scores_ir = function(difficulty, x, y, w, h)
                 oldheight = h/2 - 10
                 newheight =  iarr * (h/2-10)
                 centreoffset = (oldheight - newheight)/2 + 3 -- +3 is stupid but ehhh
-                gfx.ImageRect(x+xOffset, y+h/2 + centreoffset, oldheight,  newheight, v.image, 1, 0) --this is nasty but it works for me
+                gfx.ImageRect(x+xOffset+w/2, y+h/2 + centreoffset, oldheight,  newheight, v.image, 1, 0) --this is nasty but it works for me
                 break
             end
         end

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -151,8 +151,6 @@ function record_handler_factory(hash)
         else
             recordCache[hash] = {good=false, reason="Failed"}
         end
-
-            game.Log(log_table(res), game.LOGGER_ERROR)
     end)
 end
 
@@ -248,7 +246,7 @@ draw_scores_ir = function(difficulty, x, y, w, h)
 	end
 
     irRecord = get_record(difficulty.hash)
-    game.Log(log_table(irRecord), game.LOGGER_ERROR)
+
     if not irRecord.good then
         recordLabel = gfx.CreateLabel(irRecord.reason, 40, 0)
         gfx.FillColor(255, 255, 255)

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -146,6 +146,8 @@ function record_handler_factory(hash)
             recordCache[hash] = {good=false, reason="Untracked"}
         elseif res.statusCode == 20 and res.body ~= nil then
             recordCache[hash] = {good=true, record=res.body.record}
+        elseif res.statusCode == 44 then
+            recordCache[hash] = {good=true, record=nil}
         else
             recordCache[hash] = {good=false, reason="Failed"}
         end

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -266,7 +266,7 @@ draw_scores_ir = function(difficulty, x, y, w, h)
 
         if irRecord.record.lamp ~= 0 then
             gfx.BeginPath()
-            gfx.ImageRect(x+xOffset+w-h/2, y+h/2 +5, (h/2-10), h/2-10, badges[2], 1, 0)
+            gfx.ImageRect(x+xOffset+w-h/2, y+h/2 +5, (h/2-10), h/2-10, badges[irRecord.record.lamp], 1, 0)
         end
 
         for i,v in ipairs(grades) do

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -226,8 +226,11 @@ draw_scores_ir = function(difficulty, x, y, w, h)
             if v.max > highScore.score then
                 gfx.BeginPath()
                 iw,ih = gfx.ImageSize(v.image)
-                iar = iw / ih;
-                gfx.ImageRect(x+xOffset,y+h/2 +5, iar * (h/2-10),h/2-10, v.image, 1, 0)
+                iarr = ih / iw
+                oldheight = h/2 - 10
+                newheight =  iarr * (h/2-10)
+                centreoffset = (oldheight - newheight)/2 + 3 -- +3 is stupid but ehhh
+                gfx.ImageRect(x+xOffset, y+h/2 + centreoffset, oldheight,  newheight, v.image, 1, 0) --this is nasty but it works for me
                 break
             end
         end
@@ -270,8 +273,11 @@ draw_scores_ir = function(difficulty, x, y, w, h)
             if v.max > irRecord.record.score then
                 gfx.BeginPath()
                 iw,ih = gfx.ImageSize(v.image)
-                iar = iw / ih;
-                gfx.ImageRect(x+xOffset+w/2,y+h/2 +5, iar * (h/2-10),h/2-10, v.image, 1, 0)
+                iarr = ih / iw
+                oldheight = h/2 - 10
+                newheight =  iarr * (h/2-10)
+                centreoffset = (oldheight - newheight)/2 + 3 -- +3 is stupid but ehhh
+                gfx.ImageRect(x+xOffset, y+h/2 + centreoffset, oldheight,  newheight, v.image, 1, 0) --this is nasty but it works for me
                 break
             end
         end

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -51,6 +51,8 @@ local badges = {
     gfx.CreateSkinImage("badges/perfect.png", 0)
 }
 
+local recordCache = {}
+
 gfx.LoadSkinFont("NotoSans-Regular.ttf");
 
 game.LoadSkinSample("menu_click")
@@ -128,7 +130,7 @@ check_or_create_cache = function(song, loadJacket)
     if not songCache[song.id]["bpm"] then
         songCache[song.id]["bpm"] = gfx.CreateLabel(string.format("BPM: %s",song.bpm), 20, 0)
     end
-	
+
 	if not songCache[song.id]["effector"] then
         songCache[song.id]["effector"] = gfx.CreateLabel(string.format("BPM: %s",song.bpm), 20, 0)
     end
@@ -138,7 +140,153 @@ check_or_create_cache = function(song, loadJacket)
     end
 end
 
+function record_handler_factory(hash)
+    return (function(res)
+        if res.statusCode == 42 then
+            recordCache[hash] = {good=false, reason="Untracked"}
+        elseif res.statusCode == 20 and res.body ~= nil then
+            recordCache[hash] = {good=true, record=res.body.record}
+        else
+            recordCache[hash] = {good=false, reason="Failed"}
+        end
+
+            game.Log(log_table(res), game.LOGGER_ERROR)
+    end)
+end
+
+function get_record(hash)
+    if recordCache[hash] then return recordCache[hash] end
+
+    recordCache[hash] = {good=false, reason="Loading..."}
+
+    IR.Record(hash, record_handler_factory(hash))
+
+    return recordCache[hash]
+end
+
+function log_table(table)
+    str = "{"
+    for k, v in pairs(table) do
+        str = str .. k .. ": "
+
+        t = type(v)
+
+        if t == "table" then
+            str = str .. log_table(v)
+        elseif t == "string" then
+            str = str .. "\"" .. v .. "\""
+        elseif t == "boolean" then
+            if v then
+                str = str .. "true"
+            else
+                str = str .. "false"
+            end
+        else
+            str = str .. v
+        end
+
+        str = str .. ", "
+    end
+
+    return str .. "}"
+end
+
+draw_scores_ir = function(difficulty, x, y, w, h)
+    -- draw the top score for this difficulty
+    local xOffset = 5
+    local height = h/3 - 10
+    local ySpacing = h/3
+    local yOffset = h/3
+    gfx.FontSize(30);
+    gfx.TextAlign(gfx.TEXT_ALIGN_BOTTOM + gfx.TEXT_ALIGN_CENTER);
+
+    gfx.FastText("HIGH SCORE", x +(w/4), y+(h/2))
+    gfx.FastText("IR RECORD", x + (3/4 * w), y + (h/2))
+
+    gfx.BeginPath()
+    gfx.Rect(x+xOffset,y+h/2,w/2-(xOffset*2),h/2)
+    gfx.FillColor(30,30,30,10)
+    gfx.StrokeColor(0,128,255)
+    gfx.StrokeWidth(1)
+    gfx.Fill()
+    gfx.Stroke()
+
+    gfx.BeginPath()
+    gfx.Rect(x + xOffset + w/2,y+h/2,w/2-(xOffset*2),h/2)
+    gfx.FillColor(30,30,30,10)
+    gfx.StrokeColor(0,128,255)
+    gfx.StrokeWidth(1)
+    gfx.Fill()
+    gfx.Stroke()
+
+    if difficulty.scores[1] ~= nil then
+		local highScore = difficulty.scores[1]
+        scoreLabel = gfx.CreateLabel(string.format("%08d",highScore.score), 40, 0)
+        for i,v in ipairs(grades) do
+            if v.max > highScore.score then
+                gfx.BeginPath()
+                iw,ih = gfx.ImageSize(v.image)
+                iar = iw / ih;
+                gfx.ImageRect(x+xOffset,y+h/2 +5, iar * (h/2-10),h/2-10, v.image, 1, 0)
+                break
+            end
+        end
+        if difficulty.topBadge ~= 0 then
+            gfx.BeginPath()
+            gfx.ImageRect(x+xOffset+w/2-h/2, y+h/2 +5, (h/2-10), h/2-10, badges[difficulty.topBadge], 1, 0)
+        end
+
+        gfx.FillColor(255,255,255)
+    	gfx.FontSize(40);
+        gfx.TextAlign(gfx.TEXT_ALIGN_MIDDLE + gfx.TEXT_ALIGN_CENTER);
+    	gfx.DrawLabel(scoreLabel, x+(w/4),y+(h/4)*3,w/2)
+	end
+
+    irRecord = get_record(difficulty.hash)
+    game.Log(log_table(irRecord), game.LOGGER_ERROR)
+    if not irRecord.good then
+        recordLabel = gfx.CreateLabel(irRecord.reason, 40, 0)
+        gfx.FillColor(255, 255, 255)
+        gfx.FontSize(40)
+        gfx.TextAlign(gfx.TEXT_ALIGN_MIDDLE + gfx.TEXT_ALIGN_CENTER);
+    	gfx.DrawLabel(recordLabel, x+(w * 3/4),y+(h/4)*3,w/2)
+    elseif irRecord.record == nil then --record not set, but can be tracked
+        recordLabel = gfx.CreateLabel(string.format("%08d", 0), 40, 0)
+        gfx.FillColor(170, 170, 170)
+        gfx.FontSize(40)
+        gfx.TextAlign(gfx.TEXT_ALIGN_MIDDLE + gfx.TEXT_ALIGN_CENTER);
+        gfx.DrawLabel(recordLabel, x+(w * 3/4),y+(h/4)*3,w/2)
+    else
+
+        recordScoreLabel = gfx.CreateLabel(string.format("%08d", irRecord.record.score), 26, 0)
+        recordPlayerLabel = gfx.CreateLabel(irRecord.record.username, 26, 0)
+
+        if irRecord.record.lamp ~= 0 then
+            gfx.BeginPath()
+            gfx.ImageRect(x+xOffset+w-h/2, y+h/2 +5, (h/2-10), h/2-10, badges[2], 1, 0)
+        end
+
+        for i,v in ipairs(grades) do
+            if v.max > irRecord.record.score then
+                gfx.BeginPath()
+                iw,ih = gfx.ImageSize(v.image)
+                iar = iw / ih;
+                gfx.ImageRect(x+xOffset+w/2,y+h/2 +5, iar * (h/2-10),h/2-10, v.image, 1, 0)
+                break
+            end
+        end
+
+        gfx.FillColor(255, 255, 255)
+        gfx.FontSize(40)
+        gfx.TextAlign(gfx.TEXT_ALIGN_MIDDLE + gfx.TEXT_ALIGN_CENTER);
+    	gfx.DrawLabel(recordPlayerLabel, x+(w * 3/4),y+(h/4)*2.55,w/2)
+        gfx.DrawLabel(recordScoreLabel, x+(w * 3/4),y+(h/4)*3.45,w/2)
+    end
+end
+
 draw_scores = function(difficulty, x, y, w, h)
+    if IRData.Active then return draw_scores_ir(difficulty, x, y, w, h) end
+
   -- draw the top score for this difficulty
 	local xOffset = 5
   local height = h/3 - 10

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -725,6 +725,8 @@ end
 songs_changed = function(withAll)
 	if not withAll then return end
 
+    recordCache = {}
+
 	local diffs = {}
 	for i = 1, #songwheel.allSongs do
 		local song = songwheel.allSongs[i]


### PR DESCRIPTION
Hi,

I've spent some time over the past week or so implementing Internet Ranking features into USC, which follow a well-defined protocol that anyone can implement. In addition to that, I have created an example IR server, which anyone can instantly set up and run themselves, in much the same way as is possible with the multiplayer server.

The current version of the protocol, as well as a documentation of skinning changes can be found [here](https://uscir.readthedocs.io/en/latest/index.html)

The example server can be found [here](https://github.com/ereti/usc-ir-server), and I am also currently running it on [my website](https://uscir.catgirl.energy), if you would wish to view an example of it in action without having to set it up yourself. Please note that the only scores and charts that are currently uploaded to that server are the 5 second long practice charts I was using for testing. If you want to test the features of the site, I suggest searching for 'he4ven' and then selecting the MXM of the one whose title ends in 'hard bit' (with no percentage), since that one has scores from multiple users. If you want to test the IR, you can play whatever you want as it is set to accept scores on new charts.

The features which are currently implemented on the USC side:

- Setting an IR URL and token
- Submitting scores
- Submitting replays (if requested by the IR server, also can be turned off if you have poor internet or a data cap)
- Skinning support for all IR endpoints except score and replay submission (these were kept in C++ as a design choice which I spoke to Drewol about, but primarily it increases the barrier for entry of cheating and also means that scores will still submit before skins are updated)
- Added IR leaderboard to the results screen of the default skin
- Added IR record to song select of the default skin

The following features have not currently been implemented as a result of time/scope, but would be interesting to implement in the future if this PR were accepted:

- Supporting multiple IRs, so that the user does not need to choose their allegiance to a server
- Requesting replays back from the server for setting in the pacemaker during gameplay (e.g. server #1 replay)
- Integration with the newly added challenges feature for getting courses from, and submitting results of courses to, the IR

Attached below are some screenshots of my changes to the default skin. Since I'm not a skinner, they aren't particularly pretty, but they reuse other elements so they fit the current skin just fine.

![ir_demo_result](https://user-images.githubusercontent.com/43418802/102001758-874fc600-3ced-11eb-9ade-8b09667fb58b.png)
![ir_demo_select](https://user-images.githubusercontent.com/43418802/102001842-54f29880-3cee-11eb-96f3-51f1c31393be.png)



