### PR TITLE
Fixed a bug that fb_tex didn't work properly.

### DIFF
--- a/Main/src/Background.cpp
+++ b/Main/src/Background.cpp
@@ -47,17 +47,17 @@ public:
 		rq.Process();
 	}
 
+protected:
 	RenderState renderState;
 	Mesh fullscreenMesh;
 	Material fullscreenMaterial;
 	Map<String, Texture> textures;
-	Texture frameBufferTexture;
+	Texture frameBufferTexture = nullptr;
 	MaterialParameterSet fullscreenMaterialParams;
 	float clearTransition = 0.0f;
 	float offsyncTimer = 0.0f;
 	float speedMult = 1.0f;
-	bool foreground;
-	bool hasFbTex;
+	bool foreground = false;
 	bool errored = false;
 	Vector<String> defaultBGs;
 	LuaBindable *bindable = nullptr;
@@ -81,7 +81,16 @@ private:
 
 		CheckedLoad(fullscreenMaterial = LoadBackgroundMaterial(matPath));
 		fullscreenMaterial->opaque = false;
-		hasFbTex = fullscreenMaterial->HasUniform("fb_tex");
+
+		if (fullscreenMaterial->HasUniform("texFrameBuffer"))
+		{
+			frameBufferTexture = TextureRes::CreateFromFrameBuffer(g_gl, g_resolution);
+		}
+		else
+		{
+			frameBufferTexture = nullptr;
+		}
+		
 		return true;
 	}
 
@@ -234,10 +243,10 @@ public:
 		fullscreenMaterialParams.SetParameter("tilt", tilt);
 		fullscreenMaterialParams.SetParameter("screenCenter", screenCenter);
 		fullscreenMaterialParams.SetParameter("timing", timing);
-		if (foreground && hasFbTex)
+		if (foreground && frameBufferTexture)
 		{
 			frameBufferTexture->SetFromFrameBuffer();
-			fullscreenMaterialParams.SetParameter("fb_tex", frameBufferTexture);
+			fullscreenMaterialParams.SetParameter("texFrameBuffer", frameBufferTexture);
 		}
 
 		if (foreground)

--- a/bin/skins/Default/shaders/examples/foreground/scanlines.fs
+++ b/bin/skins/Default/shaders/examples/foreground/scanlines.fs
@@ -13,7 +13,7 @@ uniform ivec2 viewport;
 uniform float objectGlow;
 // bg_texture.png
 uniform sampler2D mainTex;
-uniform sampler2D fb_tex;
+uniform sampler2D texFrameBuffer;
 uniform float tilt;
 uniform float clearTransition;
 
@@ -37,9 +37,9 @@ void main()
     float scanline = (0.5 * sin(uv.y * TWO_PI * lines) + 0.5 - gapWidth) / (2.0 - gapWidth);
     scanline = max(0., scanline);
     scanline = pow(scanline, scan_curve);
-    target.r = texture(fb_tex, uv).r * scanline * (1.0 + boost);
-    target.g = texture(fb_tex, uv - blue_green_shift).g * scanline * (1.0 + boost);
-    target.b = texture(fb_tex, uv + blue_green_shift).b * scanline * (1.0 + boost);
+    target.r = texture(texFrameBuffer, uv).r * scanline * (1.0 + boost);
+    target.g = texture(texFrameBuffer, uv - blue_green_shift).g * scanline * (1.0 + boost);
+    target.b = texture(texFrameBuffer, uv + blue_green_shift).b * scanline * (1.0 + boost);
     target.r = pow(target.r, boost_exponent);
     target.g = pow(target.g, boost_exponent);
     target.b = pow(target.b, boost_exponent);

--- a/docs/source/bgfg.rst
+++ b/docs/source/bgfg.rst
@@ -1,11 +1,13 @@
 Background & Foreground
 =======================
 How to use backgrounds and foregrounds and the functions available in the lua tables for
-background and foreground scritps.
+background and foreground scripts.
 
 Backgrounds and foregrounds work exactly the same with the exception that the foreground shader gets
-access to a texture built from the current framebuffer in the ``fb_tex`` uniform. The ``background`` and 
-``foreground`` scripts access their functions in the tables named as such but the functions are identical
+access to a texture built from the current framebuffer in the ``texFrameBuffer`` uniform.
+(For an example of a foreground shader, go to the folder `shader/examples/foreground` of the default skin.)
+
+The ``background`` and ``foreground`` scripts access their functions in the tables named as such but the functions are identical
 for both tables.
 
 To create a background you need to create a folder containing the following files::


### PR DESCRIPTION
Using `fb_tex` in the foreground shader crashed USC. This PR fixes that.

Also, changed the name to `texFrameBuffer` for clearness.