### PR TITLE
feat(song select): Improve random chart algorithm

### DIFF
--- a/Main/CMakeLists.txt
+++ b/Main/CMakeLists.txt
@@ -54,7 +54,7 @@ target_compile_features(usc-game PUBLIC cxx_std_17)
 target_compile_definitions(usc-game PRIVATE VERSION_MINOR=${PROJECT_VERSION_MINOR})
 target_compile_definitions(usc-game PRIVATE VERSION_MAJOR=${PROJECT_VERSION_MAJOR})
 target_compile_definitions(usc-game PRIVATE VERSION_PATCH=${PROJECT_VERSION_PATCH})
-target_compile_definitions(usc-game PRIVATE GIT_COMMIT=${GIT_DATE_HASH})
+target_compile_definitions(usc-game PRIVATE GIT_COMMIT="${GIT_DATE_HASH}")
 
 set_output_postfixes(usc-game)
 

--- a/Main/include/ItemSelectionWheel.hpp
+++ b/Main/include/ItemSelectionWheel.hpp
@@ -277,6 +277,12 @@ public:
 			std::random_device random_device;
 			std::mt19937 generator(random_device());
 			std::shuffle(m_randomVec.begin(), m_randomVec.end(), generator);
+			if (m_randomVec.back() == m_lastItemIndex) {
+				m_randomVec.pop_back();
+				if (m_randomVec.size() == 0) {
+					return;
+				}
+			}
 		}
 
 		uint32 selection = m_randomVec.back();
@@ -434,6 +440,9 @@ public:
 		}
 		m_doSort();
 
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+
 		// Try to go back to selected song in new sort
 		SelectLastItemIndex(true);
 
@@ -462,6 +471,9 @@ public:
 		}
 		m_doSort();
 
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+		
 		// Try to go back to selected song in new sort
 		SelectLastItemIndex(isFiltered);
 
@@ -483,6 +495,9 @@ public:
 		}
 		m_doSort();
 
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+		
 		// Try to go back to selected song in new sort
 		SelectLastItemIndex(true);
 

--- a/Main/include/ItemSelectionWheel.hpp
+++ b/Main/include/ItemSelectionWheel.hpp
@@ -1,7 +1,4 @@
 #pragma once
-#include <algorithm>
-#include <random>
-
 #include "stdafx.h"
 #include "SongSort.hpp"
 #include "SongFilter.hpp"
@@ -271,24 +268,22 @@ public:
 			return;
 
 		// If the randomized vector of charts has not been initialized or has
-		// been exhausted, we regenerate it from the current m_sortVec
+		// been exhausted, we copy the current m_sortVec
 		if (m_randomVec.empty()) {
 			m_randomVec = m_sortVec;
-			std::random_device random_device;
-			std::mt19937 generator(random_device());
-			std::shuffle(m_randomVec.begin(), m_randomVec.end(), generator);
-			if (m_randomVec.back() == m_lastItemIndex) {
-				m_randomVec.pop_back();
-				if (m_randomVec.size() == 0) {
-					return;
-				}
-			}
 		}
 
-		uint32 selection = m_randomVec.back();
+		uint32 itemIndex;
+		if (m_randomVec.size() == 1) {
+			itemIndex = m_randomVec.back();
+		} else {
+			uint32 selection = Random::IntRange(0, (int32)m_randomVec.size() - 1);
+			itemIndex = m_randomVec.at(selection);
+			m_randomVec[selection] = m_randomVec.back();
+		}
 		m_randomVec.pop_back();
 
-		SelectItemByItemIndex(selection);
+		SelectItemByItemIndex(itemIndex);
 	}
 
 	void SelectItemByItemId(uint32 id)

--- a/Main/include/ItemSelectionWheel.hpp
+++ b/Main/include/ItemSelectionWheel.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include <algorithm>
+#include <random>
+
 #include "stdafx.h"
 #include "SongSort.hpp"
 #include "SongFilter.hpp"
@@ -104,6 +107,8 @@ protected:
 	Map<int32, ItemSelectIndex> m_items;
 	Map<int32, ItemSelectIndex> m_itemFilter;
 	Vector<uint32> m_sortVec;
+	Vector<uint32> m_randomVec;
+
 	bool m_filterSet = false;
 	IApplicationTickable *m_owner;
 
@@ -179,6 +184,9 @@ public:
 			m_SetCurrentItems();
 		}
 
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+
 		// Filter will take care of sorting and setting lua
 		OnItemsChanged.Call();
 	}
@@ -203,6 +211,9 @@ public:
 			m_SetCurrentItems();
 		}
 
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+
 		// Filter will take care of sorting and setting lua
 		OnItemsChanged.Call();
 	}
@@ -214,6 +225,10 @@ public:
 		{
 			ItemSelectIndex index(i);
 		}
+
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+
 		OnItemsChanged.Call();
 	}
 
@@ -236,6 +251,9 @@ public:
 		//set all items
 		m_SetAllItems();
 
+		// Clear the current queue of random charts
+		m_randomVec.clear();
+
 		// Filter will take care of sorting and setting lua
 		OnItemsChanged.Call();
 	}
@@ -251,8 +269,20 @@ public:
 	{
 		if (m_SourceCollection().empty())
 			return;
-		uint32 selection = Random::IntRange(0, (int32)m_sortVec.size() - 1);
-		SelectItemBySortIndex(selection);
+
+		// If the randomized vector of charts has not been initialized or has
+		// been exhausted, we regenerate it from the current m_sortVec
+		if (m_randomVec.empty()) {
+			m_randomVec = m_sortVec;
+			std::random_device random_device;
+			std::mt19937 generator(random_device());
+			std::shuffle(m_randomVec.begin(), m_randomVec.end(), generator);
+		}
+
+		uint32 selection = m_randomVec.back();
+		m_randomVec.pop_back();
+
+		SelectItemByItemIndex(selection);
 	}
 
 	void SelectItemByItemId(uint32 id)


### PR DESCRIPTION
This PR changes how USC chooses a random chart when a player presses F2. Rather than generating a random number each time, it generates a randomized list of all the charts. This list is then looped through each time the user presses F2 until it has been exhausted, at which point the list will be re-generated again. This removes the possibility of a chart being randomly picked multiple times in a short period and gives a better user experience.

An additional change in this PR is a small change to the CMake configuration. This was necessary to fix an error while building using Visual Studio.