### PR TITLE
Add support for multiple profiles

### DIFF
--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -88,7 +88,7 @@ public:
 	// -1 if no sample exists, 0 if stopped, 1 if playing
 	int IsNamedSamplePlaying(String name);
 	void ReloadSkin();
-	bool ReloadConfig();
+	bool ReloadConfig(const String& profile = "");
 	void DisposeLua(lua_State* state);
 	void SetGaugeColor(int i, Color c);
 	void DiscordError(int errorCode, const char* message);
@@ -107,7 +107,7 @@ public:
 	Vector<String> GetUpdateAvailable();
 
 private:
-	bool m_LoadConfig();
+	bool m_LoadConfig(String profileName = "");
 	void m_UpdateConfigVersion();
 	void m_SaveConfig();
 	void m_InitDiscord();

--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -88,6 +88,7 @@ public:
 	// -1 if no sample exists, 0 if stopped, 1 if playing
 	int IsNamedSamplePlaying(String name);
 	void ReloadSkin();
+	bool ReloadConfig();
 	void DisposeLua(lua_State* state);
 	void SetGaugeColor(int i, Color c);
 	void DiscordError(int errorCode, const char* message);

--- a/Main/include/BaseGameSettingsDialog.hpp
+++ b/Main/include/BaseGameSettingsDialog.hpp
@@ -85,6 +85,8 @@ public:
     inline void Open() { assert(!m_active); m_targetActive = true; }
     inline void Close() { assert(m_active); m_targetActive = false; }
 
+    void ResetTabs();
+
     Delegate<> onClose;
 
 protected:

--- a/Main/include/ChatOverlay.hpp
+++ b/Main/include/ChatOverlay.hpp
@@ -34,6 +34,7 @@
 
 class MultiplayerScreen;
 
+// TODO(itszn) inherit BasicNuklearGui to reduce duplciated code
 class ChatOverlay: public IApplicationTickable
 {
 public:

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -163,6 +163,8 @@ DefineEnum(GameConfigKeys,
 		   GameplaySettingsDialogLastTab,
 		   TransferScoresOnChartUpdate,
 
+		   CurrentProfileName,
+
 		   // Gameplay options
 		   GaugeType,
 		   MirrorChart,

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "Shared/Config.hpp"
 #include "Input.hpp"
+#include <unordered_set>
 
 DefineEnum(GameConfigKeys,
 		   // Version of the config
@@ -169,6 +170,9 @@ DefineEnum(GameConfigKeys,
 		   GaugeType,
 		   MirrorChart,
 		   RandomizeChart)
+
+// List of settings overriden by profiles
+extern ConfigBase::KeyList GameConfigProfileSettings;
 
 DefineEnum(GaugeTypes,
 		   Normal,

--- a/Main/include/GameplaySettingsDialog.hpp
+++ b/Main/include/GameplaySettingsDialog.hpp
@@ -19,4 +19,5 @@ public:
 private:
     SongSelect* songSelectScreen = nullptr;
     Setting m_CreateSongOffsetSetting();
+    Setting m_CreateProfileSetting(const String&);
 };

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -1,0 +1,104 @@
+#pragma once
+#include "ApplicationTickable.hpp"
+#include "GameConfig.hpp"
+#include "Input.hpp"
+#include <SDL2/SDL.h>
+
+// NK imports
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+#undef NK_IMPLEMENTATION
+#ifdef EMBEDDED
+#undef NK_SDL_GLES2_IMPLEMENTATION
+#include "../third_party/nuklear/nuklear.h"
+#include "nuklear/nuklear_sdl_gles2.h"
+#else
+#undef	NK_SDL_GL3_IMPLEMENTATION
+#include "../third_party/nuklear/nuklear.h"
+#include "nuklear/nuklear_sdl_gl3.h"
+#endif
+
+#define MAX_VERTEX_MEMORY 512 * 1024
+#define MAX_ELEMENT_MEMORY 128 * 1024
+#define FULL_FONT_TEXTURE_HEIGHT 32768 //needed to load all CJK glyphs
+
+class BasicNuklearGui : public IApplicationTickable
+{
+public:
+	BasicNuklearGui() : m_nctx() {};
+	~BasicNuklearGui();
+	bool Init() override;
+	void Tick(float deltaTime) override;
+	void Render(float deltaTime) override;
+	void NKRender();
+	void UpdateNuklearInput(SDL_Event evt);
+    void ShutdownNuklear();
+    void InitNuklearIfNeeded();
+	virtual bool OnKeyPressedConsume(SDL_Scancode code) { return m_isOpen; };
+
+protected:
+	bool m_nuklearRunning = false;
+	struct nk_context* m_nctx = NULL;
+	std::queue<SDL_Event> m_eventQueue;
+	// Are we consuming text
+	bool m_isOpen = true;
+	// Background screenshot
+	bool m_backgroundFrame = true;
+	Texture m_fromTexture;
+	Mesh m_bgMesh;
+};
+
+class BasicWindow : public BasicNuklearGui
+{
+public:
+	BasicWindow(String name) : m_name(name) {};
+	void Tick(float deltaTime) override;
+	void Render(float deltaTime) override;
+	bool OnKeyPressedConsume(SDL_Scancode code) override;
+
+	void EnableInputForEdit(int editWidth, int editHeight);
+	void Close();
+
+	virtual void DrawWindow() {};
+	virtual void OnClose() {};
+
+protected:
+	// Configurable
+	int m_windowFlag = NK_WINDOW_BORDER | NK_WINDOW_MOVABLE | NK_WINDOW_TITLE | NK_WINDOW_CLOSABLE;
+	String m_name;
+	int m_width = 400;
+	int m_height = 200;
+
+	bool m_inEdit = false;
+	bool m_isFocused = false;
+};
+
+bool nk_edit_isfocused(struct nk_context* ctx);
+
+class BasicPrompt : public BasicWindow {
+public:
+	BasicPrompt(String title, String body, String submitText = "Submit")
+		: m_title(title), m_text(body), m_submitText(submitText), BasicWindow(title) { };
+	bool Init() override;
+	virtual bool OnKeyPressedConsume(SDL_Scancode code) override;
+	void DrawWindow() override;
+	void OnClose() override;
+
+	void Focus() { m_forceFocus = true; }
+
+	Delegate<bool, char*> OnResult;
+
+protected:
+	String m_title;
+	String m_text;
+	String m_submitText;
+	char m_data[255] = { 0 };
+	bool m_submitted = false;
+	bool m_forceFocus = false;
+	bool m_shrinkWindow = true;
+};

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -83,7 +83,7 @@ bool nk_edit_isfocused(struct nk_context* ctx);
 class BasicPrompt : public BasicWindow {
 public:
 	BasicPrompt(String title, String body, String submitText = "Submit")
-		: m_title(title), m_text(body), m_submitText(submitText), BasicWindow(title) { };
+		: BasicWindow(title), m_text(body), m_submitText(submitText) { };
 	bool Init() override;
 	virtual bool OnKeyPressedConsume(SDL_Scancode code) override;
 	void DrawWindow() override;
@@ -94,7 +94,6 @@ public:
 	Delegate<bool, char*> OnResult;
 
 protected:
-	String m_title;
 	String m_text;
 	String m_submitText;
 	char m_data[255] = { 0 };

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -424,6 +424,11 @@ void Application::m_unpackSkins()
 	}
 }
 
+bool Application::ReloadConfig()
+{
+	return m_LoadConfig();
+}
+
 bool Application::m_LoadConfig()
 {
 	String profileName = "Main";
@@ -449,6 +454,7 @@ bool Application::m_LoadConfig()
 	{
 		FileReader reader(configFile);
 		bool result = g_gameConfig.Load(reader);
+		g_gameConfig.Set(GameConfigKeys::CurrentProfileName, profileName);
 
 		configFile.Close();
 		return result;

--- a/Main/src/BaseGameSettingsDialog.cpp
+++ b/Main/src/BaseGameSettingsDialog.cpp
@@ -24,6 +24,18 @@ BaseGameSettingsDialog::~BaseGameSettingsDialog()
 	g_gameWindow->OnKeyPressed.RemoveAll(this);
 }
 
+void BaseGameSettingsDialog::ResetTabs()
+{
+	for (auto& tab : m_tabs)
+	{
+		tab->settings.clear();
+	}
+
+	m_tabs.clear();
+
+    InitTabs();
+}
+
 void BaseGameSettingsDialog::Tick(float deltaTime)
 {
     if (m_active != m_targetActive)

--- a/Main/src/ChatOverlay.cpp
+++ b/Main/src/ChatOverlay.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "ChatOverlay.hpp"
 #include <time.h>
+#include "GuiUtils.hpp"
 
 
 #include "MultiplayerScreen.hpp"
@@ -132,16 +133,6 @@ void ChatOverlay::Tick(float deltatime)
 void ChatOverlay::NKRender()
 {
 	nk_sdl_render(NK_ANTI_ALIASING_ON, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
-}
-
-bool
-nk_edit_isfocused(struct nk_context *ctx)
-{
-	struct nk_window *win;
-	if (!ctx || !ctx->current) return false;
-
-	win = ctx->current;
-	return win->edit.active;
 }
 
 void ChatOverlay::m_drawChatAlert()
@@ -291,7 +282,8 @@ void ChatOverlay::m_drawWindow()
 	nk_end(m_nctx);
 }
 
-void ChatOverlay::Render(float deltatime) {
+void ChatOverlay::Render(float deltatime)
+{
 	float w = Math::Min(g_resolution.y / 1.4, g_resolution.x - 5.0);
 	float x = g_resolution.x / 2 - w / 2;
 

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -213,6 +213,8 @@ void GameConfig::InitDefaults()
 
 	Set(GameConfigKeys::GameplaySettingsDialogLastTab, 0);
 	Set(GameConfigKeys::TransferScoresOnChartUpdate, true);
+
+	Set(GameConfigKeys::CurrentProfileName, "Main");
 }
 
 void GameConfig::UpdateVersion()

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -270,3 +270,82 @@ void GameConfig::UpdateVersion()
 	assert(configVersion == GameConfig::VERSION);
 	Set(GameConfigKeys::ConfigVersion, configVersion);
 }
+
+#define Key(v) static_cast<uint32>(GameConfigKeys::v)
+ConfigBase::KeyList GameConfigProfileSettings = {
+	Key(HitWindowPerfect),
+	Key(HitWindowGood),
+	Key(HitWindowHold),
+	Key(GlobalOffset),
+	Key(InputOffset),
+	Key(LaserAssistLevel),
+	Key(LaserPunish),
+	Key(LaserChangeTime),
+	Key(LaserChangeExponent),
+
+	Key(HiddenCutoff),
+	Key(HiddenFade),
+	Key(SuddenCutoff),
+	Key(SuddenFade),
+
+	Key(UseBackCombo),
+	Key(LaserInputDevice),
+	Key(ButtonInputDevice),
+	Key(Mouse_Laser0Axis),
+	Key(Mouse_Laser1Axis),
+	Key(Mouse_Sensitivity),
+
+	Key(Key_BTS),
+	Key(Key_BTSAlt),
+	Key(Key_BT0),
+	Key(Key_BT1),
+	Key(Key_BT2),
+	Key(Key_BT3),
+	Key(Key_BT0Alt),
+	Key(Key_BT1Alt),
+	Key(Key_BT2Alt),
+	Key(Key_BT3Alt),
+	Key(Key_FX0),
+	Key(Key_FX1),
+	Key(Key_FX0Alt),
+	Key(Key_FX1Alt),
+	Key(Key_Laser0Pos),
+	Key(Key_Laser0Neg),
+	Key(Key_Laser1Pos),
+	Key(Key_Laser1Neg),
+	Key(Key_Laser0PosAlt),
+	Key(Key_Laser0NegAlt),
+	Key(Key_Laser1PosAlt),
+	Key(Key_Laser1NegAlt),
+	Key(Key_Back),
+	Key(Key_BackAlt),
+	Key(Key_Sensitivity),
+	Key(Key_LaserReleaseTime),
+
+	Key(Controller_DeviceID),
+	Key(Controller_BTS),
+	Key(Controller_BT0),
+	Key(Controller_BT1),
+	Key(Controller_BT2),
+	Key(Controller_BT3),
+	Key(Controller_FX0),
+	Key(Controller_FX1),
+	Key(Controller_Back),
+	Key(Controller_Laser0Axis),
+	Key(Controller_Laser1Axis),
+	Key(Controller_Deadzone),
+	Key(Controller_DirectMode),
+	Key(Controller_Sensitivity),
+	Key(InputBounceGuard),
+	Key(SongSelSensMult),
+	Key(InvertLaserInput),
+
+	Key(RestartPlayMethod),
+	Key(RestartPlayHoldDuration),
+	Key(ExitPlayMethod),
+	Key(ExitPlayHoldDuration),
+	Key(DisableNonButtonInputsDuringPlay),
+
+	Key(MultiplayerUsername)
+};
+#undef Key

--- a/Main/src/GameplaySettingsDialog.cpp
+++ b/Main/src/GameplaySettingsDialog.cpp
@@ -81,7 +81,7 @@ void GameplaySettingsDialog::InitTabs()
     }
 	auto this_p = this;
     profileWindowTab->settings.push_back(CreateButton("Create Profile", [this_p](const auto&) {
-		BasicPrompt *w = new BasicPrompt("Create New Profile","Enter name for profile:\n(Enter existing to overwrite)","Create");
+		BasicPrompt *w = new BasicPrompt("Create New Profile","Enter name for profile:\n(Enter existing to overwrite with current settings)","Create");
         w->OnResult.AddLambda([this_p](bool valid, const char* data) {
             if (!valid || strlen(data) == 0)
                 return;
@@ -140,6 +140,11 @@ void GameplaySettingsDialog::InitTabs()
 		w->Focus();
 		g_application->AddTickable(w);
     }));
+    profileWindowTab->settings.push_back(CreateButton("Manage Profiles", [this_p](const auto&) {
+		if (!Path::IsDirectory(Path::Absolute("profiles")))
+			Path::CreateDir(Path::Absolute("profiles"));
+        Path::ShowInFileBrowser(Path::Absolute("profiles"));
+	}));
 
     AddTab(std::move(offsetTab));
     AddTab(std::move(speedTab));

--- a/Main/src/GameplaySettingsDialog.cpp
+++ b/Main/src/GameplaySettingsDialog.cpp
@@ -3,7 +3,7 @@
 #include "HitStat.hpp"
 #include "Application.hpp"
 #include "SongSelect.hpp"
-#include "shared/Files.hpp"
+#include <Shared/Files.hpp>
 #include "GuiUtils.hpp"
 
 GameplaySettingsDialog::GameplaySettingsDialog(SongSelect* songSelectScreen)

--- a/Main/src/GuiUtils.cpp
+++ b/Main/src/GuiUtils.cpp
@@ -1,0 +1,358 @@
+#include "stdafx.h"
+#include "GuiUtils.hpp"
+#include "Application.hpp"
+
+BasicNuklearGui::~BasicNuklearGui()
+{
+	ShutdownNuklear();
+}
+
+void BasicNuklearGui::UpdateNuklearInput(SDL_Event evt)
+{
+	if (!m_isOpen)
+		return;
+	m_eventQueue.push(evt);
+}
+
+void BasicNuklearGui::ShutdownNuklear()
+{
+    if (!m_nuklearRunning)
+        return;
+
+    g_gameWindow->OnAnyEvent.RemoveAll(this);
+    nk_sdl_shutdown();
+
+    m_nuklearRunning = false;
+}
+
+bool BasicNuklearGui::Init()
+{
+	if (m_backgroundFrame)
+	{
+		m_fromTexture = TextureRes::CreateFromFrameBuffer(g_gl, g_resolution);
+		m_bgMesh = MeshGenerators::Quad(g_gl, Vector2(0, g_resolution.y), Vector2(g_resolution.x, -g_resolution.y));
+	}
+    InitNuklearIfNeeded();
+    return true;
+}
+
+void BasicNuklearGui::InitNuklearIfNeeded()
+{
+    if (m_nuklearRunning) {
+        return;
+	}
+	m_nctx = nk_sdl_init((SDL_Window*)g_gameWindow->Handle());
+
+	g_gameWindow->OnAnyEvent.Add(this, &BasicNuklearGui::UpdateNuklearInput);
+	{
+		struct nk_font_atlas *atlas;
+		nk_sdl_font_stash_begin(&atlas);
+		struct nk_font *fallback = nk_font_atlas_add_from_file(atlas, Path::Normalize( Path::Absolute("fonts/settings/NotoSans-Regular.ttf")).c_str(), 24, 0);
+
+		// struct nk_font_config cfg_kr = nk_font_config(24);
+		// cfg_kr.merge_mode = nk_true;
+		// cfg_kr.range = nk_font_korean_glyph_ranges();
+
+		// NK_STORAGE const nk_rune jp_ranges[] = {
+		// 	0x0020, 0x00FF,
+		// 	0x3000, 0x303f,
+		// 	0x3040, 0x309f,
+		// 	0x30a0, 0x30ff,
+		// 	0x4e00, 0x9faf,
+		// 	0xff00, 0xffef,
+		// 	0
+		// };
+		// struct nk_font_config cfg_jp = nk_font_config(24);
+		// cfg_jp.merge_mode = nk_true;
+		// cfg_jp.range = jp_ranges;
+
+		NK_STORAGE const nk_rune cjk_ranges[] = {
+			0x0020, 0x00FF,
+			0x3000, 0x30FF,
+			0x3131, 0x3163,
+			0xAC00, 0xD79D,
+			0x31F0, 0x31FF,
+			0xFF00, 0xFFEF,
+			0x4e00, 0x9FAF,
+			0
+		};
+
+		struct nk_font_config cfg_cjk = nk_font_config(24);
+		cfg_cjk.merge_mode = nk_true;
+		cfg_cjk.range = cjk_ranges;
+
+		int maxSize;
+		glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxSize);
+		Logf("System max texture size: %d", Logger::Severity::Info, maxSize);
+		if (maxSize >= FULL_FONT_TEXTURE_HEIGHT && !g_gameConfig.GetBool(GameConfigKeys::LimitSettingsFont))
+		{
+			nk_font_atlas_add_from_file(atlas, Path::Normalize(Path::Absolute("fonts/settings/DroidSansFallback.ttf")).c_str(), 24, &cfg_cjk);
+		}
+		
+		nk_sdl_font_stash_end();
+		nk_font_atlas_cleanup(atlas);
+		//nk_style_load_all_cursors(m_nctx, atlas->cursors);
+		nk_style_set_font(m_nctx, &fallback->handle);
+	}
+	
+	m_nctx->style.text.color = nk_rgb(255, 255, 255);
+	m_nctx->style.button.border_color = nk_rgb(0, 128, 255);
+	m_nctx->style.button.padding = nk_vec2(5,5);
+	m_nctx->style.button.rounding = 0;
+	m_nctx->style.window.fixed_background = nk_style_item_color(nk_rgb(40, 40, 40));
+	m_nctx->style.slider.bar_normal = nk_rgb(20, 20, 20);
+	m_nctx->style.slider.bar_hover = nk_rgb(20, 20, 20);
+	m_nctx->style.slider.bar_active = nk_rgb(20, 20, 20);
+
+    m_nuklearRunning = true;
+}
+
+void BasicNuklearGui::Tick(float deltatime)
+{
+	nk_input_begin(m_nctx);
+	while (!m_eventQueue.empty())
+	{
+		nk_sdl_handle_event(&m_eventQueue.front());
+		m_eventQueue.pop();
+	}
+	nk_input_end(m_nctx);
+}
+
+void BasicNuklearGui::NKRender()
+{
+	nk_sdl_render(NK_ANTI_ALIASING_ON, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
+}
+
+void BasicNuklearGui::Render(float deltatime)
+{
+	if (m_backgroundFrame)
+	{
+		auto rq = g_application->GetRenderQueueBase();
+		Transform t;
+		MaterialParameterSet params;
+		params.SetParameter("mainTex", m_fromTexture);
+		params.SetParameter("color", Vector4(1.0f));
+		rq->Draw(t, m_bgMesh, g_application->GetGuiTexMaterial(), params);
+	}
+	
+	g_application->ForceRender();
+	NKRender();
+}
+
+
+void BasicWindow::Tick(float deltatime)
+{
+	BasicNuklearGui::Tick(deltatime);
+
+	if (!m_isOpen) {
+		Close();
+	}
+}
+
+bool nk_edit_isfocused(struct nk_context *ctx)
+{
+	struct nk_window *win;
+	if (!ctx || !ctx->current) return false;
+
+	win = ctx->current;
+	return win->edit.active;
+}
+
+void BasicWindow::EnableInputForEdit(int widgetWidth, int widgetHeight)
+{
+	bool isFocused = nk_edit_isfocused(m_nctx);
+	if (!m_inEdit && isFocused)
+	{
+		SDL_StartTextInput();
+
+		// XXX(itszn) idk if this works for ime input yet
+		SDL_Rect boxrect;
+
+		struct nk_vec2 textBoxPos = nk_widget_position(m_nctx);
+		boxrect.x = textBoxPos.x;
+		boxrect.y = textBoxPos.y;
+		boxrect.w = widgetWidth;
+		boxrect.h = widgetHeight;
+
+		SDL_SetTextInputRect(&boxrect);
+	}
+
+	m_isFocused |= isFocused;
+}
+
+void BasicWindow::Render(float deltatime)
+{
+	m_isFocused = false;
+
+	if (m_isOpen)
+	{
+		if (nk_begin(
+			m_nctx,
+			*m_name,
+			nk_rect(
+				g_resolution.x / 2 - m_width / 2,
+				g_resolution.y / 2 - m_height / 2,
+				m_width, m_height),
+			m_windowFlag))
+		{
+			// Window contents
+			DrawWindow();
+		}
+		else
+		{
+			m_isOpen = false;
+		}
+		nk_end(m_nctx);
+	}
+
+	if (m_inEdit && !m_isFocused)
+	{
+		SDL_StopTextInput();
+	}
+
+	m_inEdit = m_isFocused;
+
+	BasicNuklearGui::Render(deltatime);
+}
+
+void BasicWindow::Close()
+{
+	m_isOpen = false;
+	OnClose();
+
+	if (m_inEdit)
+	{
+		SDL_StopTextInput();
+		m_inEdit = false;
+	}
+
+	g_application->RemoveTickable(this);
+}
+
+bool BasicWindow::OnKeyPressedConsume(SDL_Scancode code)
+{
+	if (m_inEdit)
+		return true;
+
+	return BasicNuklearGui::OnKeyPressedConsume(code);
+}
+
+bool BasicPrompt::Init()
+{
+	if (!BasicWindow::Init())
+		return false;
+	return true;
+}
+
+bool BasicPrompt::OnKeyPressedConsume(SDL_Scancode code)
+{
+	// XXX this actually doesn't trigger while doing SDL input :think:
+	if (code == SDL_SCANCODE_ESCAPE && m_isOpen)
+	{
+		Close();
+		return true;
+	}
+
+	if (code == SDL_SCANCODE_RETURN && m_isOpen)
+	{
+		m_submitted = true;
+		Close();
+		return true;
+	}
+	return BasicWindow::OnKeyPressedConsume(code);
+}
+
+void BasicPrompt::OnClose()
+{
+	OnResult.Call(m_submitted, m_submitted ? m_data : nullptr);
+}
+
+void nk_multiline_label(struct nk_context* ctx, const char* allText, nk_text_alignment ali, float width)
+{
+	const struct nk_user_font *font = ctx->style.font;
+
+	const char* text = allText;
+	const char* end = NULL;
+	do
+	{
+		// Also split on new lines
+		const char* next = strchr(text, '\n');
+
+		end = next;
+		if (end == NULL)
+			end = text + strlen(text);
+
+		// Try to wrap text if needed
+		int textEnd = 0;
+		int maxlen = 0;
+		do
+		{
+			maxlen = end - text;
+			textEnd = maxlen;
+
+			// We are going to try to find the max length that fits
+			while (
+				font->width(font->userdata, font->height, text, textEnd) > width
+				&& textEnd > 1)
+			{
+				// Decrease the size until it fits
+				textEnd--;
+			}
+
+			// Draw that part of the text
+			nk_text(ctx, text, textEnd, ali);
+
+			// Truncate to rest of string
+			text += textEnd;
+		} while (textEnd < maxlen);
+
+		text = next;
+		if (text)
+			text++;
+	} while (text != NULL);
+}
+
+void BasicPrompt::DrawWindow()
+{
+	struct nk_vec2 start_pos = nk_widget_position(m_nctx);
+
+	nk_layout_set_min_row_height(m_nctx, 20);
+	nk_layout_row_dynamic(m_nctx, 20, 1);
+
+	nk_multiline_label(m_nctx, *m_text, NK_TEXT_LEFT, m_width - 30);
+
+	nk_layout_row_dynamic(m_nctx, 40, 1);
+
+	if (m_forceFocus)
+	{
+		nk_edit_focus(m_nctx, NK_EDIT_ALWAYS_INSERT_MODE);
+		// XXX(itszn) not ideal but works. For some reason calling only once stoped working
+		//m_forceFocus = false;
+	}
+	EnableInputForEdit(100, 40);
+
+	nk_edit_string_zero_terminated(m_nctx, NK_EDIT_FIELD, m_data, sizeof(m_data) - 1, nk_filter_default);
+
+	nk_layout_row_dynamic(m_nctx, 40, 2);
+
+	if (nk_button_label(m_nctx, "Cancel"))
+	{
+		m_isOpen = false;
+	}
+
+	if (nk_button_label(m_nctx, *m_submitText))
+	{
+		m_submitted = true;
+		m_isOpen = false;
+	}
+
+	struct nk_vec2 end_pos = nk_widget_position(m_nctx);
+
+	if (m_shrinkWindow) {
+		nk_window_set_size(m_nctx, *m_name, nk_vec2(
+			m_width,
+			end_pos.y - start_pos.y + 60
+		));
+		m_shrinkWindow = false;
+	}
+}

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -12,6 +12,7 @@
 #include "Shared/Jobs.hpp"
 #include "ScoreScreen.hpp"
 #include "Shared/Enum.hpp"
+#include "Shared/Files.hpp"
 #include "Input.hpp"
 #include <SDL2/SDL.h>
 #include "nanovg.h"
@@ -123,6 +124,10 @@ private:
 	const Vector<const char*> m_aaModes = { "Off", "2x MSAA", "4x MSAA", "8x MSAA", "16x MSAA" };
 	Vector<String> m_gamePads;
 	Vector<String> m_skins;
+	Vector<String> m_profiles;
+
+	String m_currentProfile;
+	bool m_needsProfileReboot = false;
 
 	const Vector<GameConfigKeys> m_keyboardKeys = {
 		GameConfigKeys::Key_BTS,
@@ -435,6 +440,21 @@ public:
 	{
 		m_gamePads = g_gameWindow->GetGamepadDeviceNames();	
 		m_skins = Path::GetSubDirs(Path::Normalize(Path::Absolute("skins/")));
+
+		m_currentProfile = g_gameConfig.GetString(GameConfigKeys::CurrentProfileName);
+		{
+			m_profiles.push_back("Main");
+			Vector<FileInfo> profiles = Files::ScanFiles(
+				Path::Absolute("profiles/"), "cfg", NULL);
+			for (auto& file : profiles)
+			{
+				String profileName = "";
+				String unused = Path::RemoveLast(file.fullPath, &profileName);
+				profileName = profileName.substr(0, profileName.length() - 4); // Remove .cfg
+				m_profiles.push_back(profileName);
+			}
+		}
+
 		m_nctx = nk_sdl_init((SDL_Window*)g_gameWindow->Handle());
 		g_gameWindow->OnAnyEvent.Add(this, &SettingsScreen_Impl::UpdateNuklearInput);
 		{
@@ -525,6 +545,22 @@ public:
 
 	void Tick(float deltatime)
 	{
+		if (m_needsProfileReboot)
+		{
+			String newProfile = g_gameConfig.GetString(GameConfigKeys::CurrentProfileName);
+
+			// Save old settings
+			g_gameConfig.Set(GameConfigKeys::CurrentProfileName, m_currentProfile);
+			Exit();
+			g_application->ApplySettings();
+
+			// Load in new settings
+			g_application->ReloadConfig(newProfile);
+
+			g_application->AddTickable(SettingsScreen::Create());
+			return;
+		}
+
 		nk_input_begin(m_nctx);
 		while (!eventQueue.empty())
 		{
@@ -629,6 +665,8 @@ public:
 		if (nk_tree_push(m_nctx, NK_TREE_NODE, "Input", (treesOpen & 1) ? NK_MAXIMIZED : NK_MINIMIZED))
 		{
 			g_gameConfig.Set(GameConfigKeys::SettingsTreesOpen, treesOpen | 1);
+
+
 			nk_layout_row_dynamic(m_nctx, m_buttonheight, 3);
 			if (nk_button_label(m_nctx, m_controllerLaserNames[0].c_str())) SetLL();
 			if (nk_button_label(m_nctx, m_controllerButtonNames[0].c_str())) SetBTBind((*m_activeBTKeys)[0]);
@@ -651,6 +689,14 @@ public:
 			nk_layout_row_dynamic(m_nctx, m_buttonheight, 1);
 			nk_label(m_nctx, "Back:", nk_text_alignment::NK_TEXT_LEFT);
 			if (nk_button_label(m_nctx, m_controllerButtonNames[7].c_str())) SetBTBind((*m_activeBTKeys)[7]);
+
+			if (m_profiles.size() > 0)
+			{
+				if (StringSelectionSetting(GameConfigKeys::CurrentProfileName, m_profiles, "Selected Profile:")) {
+
+					m_needsProfileReboot = true;
+				}
+			}
 
 			nk_labelf(m_nctx, nk_text_alignment::NK_TEXT_CENTERED, "_______________________");
 			nk_labelf(m_nctx, nk_text_alignment::NK_TEXT_CENTERED, " ");
@@ -733,6 +779,7 @@ public:
 	// Game settings
 	void RenderSettingsGame()
 	{
+
 		int treesOpen = g_gameConfig.GetInt(GameConfigKeys::SettingsTreesOpen);
 		if (nk_tree_push(m_nctx, NK_TREE_NODE, "Game", (treesOpen & 2) ? NK_MAXIMIZED : NK_MINIMIZED))
 		{
@@ -1073,6 +1120,7 @@ public:
 		{
 			g_application->RemoveTickable(this);
 		}
+
 	}
 
 	void Render(float deltatime)

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -442,17 +442,23 @@ public:
 		m_skins = Path::GetSubDirs(Path::Normalize(Path::Absolute("skins/")));
 
 		m_currentProfile = g_gameConfig.GetString(GameConfigKeys::CurrentProfileName);
+
+        m_profiles.push_back("Main");
+        Vector<FileInfo> profiles = Files::ScanFiles(
+            Path::Absolute("profiles/"), "cfg", NULL);
+        for (auto& file : profiles)
+        {
+            String profileName = "";
+            String unused = Path::RemoveLast(file.fullPath, &profileName);
+            profileName = profileName.substr(0, profileName.length() - 4); // Remove .cfg
+            m_profiles.push_back(profileName);
+        }
+
+		String channel = g_gameConfig.GetString(GameConfigKeys::UpdateChannel);
+
+		if (!m_channels.Contains(channel))
 		{
-			m_profiles.push_back("Main");
-			Vector<FileInfo> profiles = Files::ScanFiles(
-				Path::Absolute("profiles/"), "cfg", NULL);
-			for (auto& file : profiles)
-			{
-				String profileName = "";
-				String unused = Path::RemoveLast(file.fullPath, &profileName);
-				profileName = profileName.substr(0, profileName.length() - 4); // Remove .cfg
-				m_profiles.push_back(profileName);
-			}
+			m_channels.insert(m_channels.begin(), channel);
 		}
 
 		m_nctx = nk_sdl_init((SDL_Window*)g_gameWindow->Handle());

--- a/Shared/include/Shared/Config.hpp
+++ b/Shared/include/Shared/Config.hpp
@@ -4,6 +4,8 @@
 #include "Shared/Enum.hpp"
 #include "Shared/Unique.hpp"
 #include "Shared/BinaryStream.hpp"
+#include <unordered_set>
+
 
 /*
 	Base class used for config files
@@ -13,19 +15,23 @@
 class ConfigBase : public Unique
 {
 public:
+	typedef std::unordered_set<uint32> KeyList;
 	virtual ~ConfigBase();
 
 	// Load from text file
-	bool Load(BinaryStream& stream);
-	bool Load(const String& path);
+	bool Load(BinaryStream& stream, bool reload = true);
+	bool Load(const String& path, bool reload = true);
 	// Save to text file
-	void Save(BinaryStream& stream);
-	bool Save(const String& path);
+	void Save(BinaryStream& stream, KeyList* ignore = nullptr, KeyList* only = nullptr);
+	bool Save(const String& path, KeyList* ignore = nullptr, KeyList* only = nullptr);
 
 	bool IsDirty() const;
 
 	// Resets config back to default state
 	void Clear();
+
+	// Update this config with values from a second
+	void Update(ConfigBase& other, KeyList* ignore = nullptr, KeyList* only = nullptr);
 
 protected:
 	ConfigBase();

--- a/Shared/include/Shared/Config.hpp
+++ b/Shared/include/Shared/Config.hpp
@@ -33,6 +33,9 @@ public:
 	// Update this config with values from a second
 	void Update(ConfigBase& other, KeyList* ignore = nullptr, KeyList* only = nullptr);
 
+	// Only really useful for profiles
+	const KeyList& GetKeysInFile() { return m_entriesInFile;  }
+
 protected:
 	ConfigBase();
 	virtual void InitDefaults() = 0;
@@ -40,6 +43,8 @@ protected:
 	Map<String, uint32> m_keys;
 	Map<uint32, String> m_reverseKeys;
 	Map<uint32, IConfigEntry*> m_entries;
+	KeyList m_entriesInFile;
+	
 	bool m_dirty = false;
 };
 

--- a/Shared/src/Config.cpp
+++ b/Shared/src/Config.cpp
@@ -49,6 +49,7 @@ bool ConfigBase::Load(BinaryStream& stream, bool reset)
 				auto it1 = m_entries.find(it->second);
 				if(it1 != m_entries.end())
 				{
+					m_entriesInFile.insert(it1->first);
 					setKeys.erase(it1->first);
 					m_entries[it1->first]->FromString(v);
 				}

--- a/Shared/src/Config.cpp
+++ b/Shared/src/Config.cpp
@@ -13,18 +13,19 @@ ConfigBase::~ConfigBase()
 		delete e.second;
 	}
 }
-bool ConfigBase::Load(const String& path)
+bool ConfigBase::Load(const String& path, bool reset)
 {
     File file;
     if(!file.OpenRead(path))
         return false;
     FileReader reader(file);
-    return Load(reader);
+    return Load(reader, reset);
 }
-bool ConfigBase::Load(BinaryStream& stream)
+bool ConfigBase::Load(BinaryStream& stream, bool reset)
 {
 	// Clear and load defaults
-	Clear();
+	if (reset)
+		Clear();
 
 	Set<uint32> setKeys;
 	for(auto e : m_entries)
@@ -68,19 +69,29 @@ bool ConfigBase::Load(BinaryStream& stream)
 	}
 	return true;
 }
-bool ConfigBase::Save(const String& path)
+bool ConfigBase::Save(const String& path,
+	ConfigBase::KeyList* ignore,
+	ConfigBase::KeyList* only)
 {
     File file;
     if(!file.OpenWrite(path))
         return false;
     FileWriter reader(file);
-    Save(reader);
+    Save(reader, ignore, only);
     return true;
 }
-void ConfigBase::Save(BinaryStream& stream)
+void ConfigBase::Save(BinaryStream& stream,
+	ConfigBase::KeyList* ignore,
+	ConfigBase::KeyList* only)
 {
 	for(auto& e : m_entries)
 	{
+		if (ignore && ignore->find(e.first) != ignore->end())
+			continue;
+
+		if (only && only->find(e.first) == only->end())
+			continue;
+
 		String key = m_reverseKeys[e.first];
 		String line = key + " = " + e.second->ToString();
 		TextStream::WriteLine(stream, line);
@@ -88,6 +99,24 @@ void ConfigBase::Save(BinaryStream& stream)
 
 	// Saved
 	m_dirty = false;
+}
+void ConfigBase::Update(ConfigBase& other,
+	ConfigBase::KeyList* ignore,
+	ConfigBase::KeyList* only)
+{
+	for (auto& e : other.m_entries)
+	{
+		if (ignore && ignore->find(e.first) != ignore->end())
+			continue;
+
+		if (only && only->find(e.first) == only->end())
+			continue;
+
+		// TODO a better method of assignment than this?
+		m_entries[e.first]->FromString(e.second->ToString());
+	}
+
+	m_dirty = true;
 }
 bool ConfigBase::IsDirty() const
 {


### PR DESCRIPTION
This feature adds three things:
1. Ability to have multiple config files (each is a "profile") besides "Main.cfg". These configs live in the `profiles` directory and `profiles/selected.txt` determines which is loaded at runtime. Additionally a new `currentProfileName` key will be used as the name of the file when saving configs.
2. Ability to easily switch between profiles and create new ones from the gameplay settings dialog.
3. A new set of Nuklear GUI classes which implement basic GUI operations (for example a simple prompt for input). I think this will be useful when we need something like a prompt for an uncommon action but don't want to have to immediately deal with skinning support for the dialog. This prompt is used by the profile selector when making a new profile.

I want to add some stuff to the actual settings page later, but right now I think the gameplay dialog is good enough.