### PR TITLE
Fix occasional crash caused by wrong free order of font-related resources.

### DIFF
--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1315,6 +1315,9 @@ void Application::m_Cleanup()
 	nvgDeleteGL3(g_guiState.vg);
 #endif
 
+	// Fonts should be freed before the library is freed.
+	m_fonts.clear();
+
 	Graphics::FontRes::FreeLibrary();
 	if (m_updateThread.joinable())
 		m_updateThread.join();


### PR DESCRIPTION
How to reproduce the crash:
1. Start USC
2. Go to Setting
3. Start laser sens calibration
4. Close USC