### PR TITLE
Fix occasional crashes caused by wrong free order of font res

### DIFF
--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1190,12 +1190,15 @@ void Application::m_Cleanup()
 		delete img.second;
 	}
 
-	//clear fonts before freeing library
+	// Clear fonts before freeing library
+
 	for (auto &f : g_guiState.fontCahce)
 	{
 		f.second.reset();
 	}
 	g_guiState.currentFont.reset();
+
+	m_fonts.clear();
 
 	Discord_Shutdown();
 


### PR DESCRIPTION
#436 but on the master branch, as I believe that "false crash dumps" is harmful to users reporting a genuine, game-affecting crash.