### PR TITLE
Minor fixes on Nautica download screen and OffsetComputer crash

### DIFF
--- a/Main/src/Audio/OffsetComputer.cpp
+++ b/Main/src/Audio/OffsetComputer.cpp
@@ -252,7 +252,7 @@ void OffsetComputer::ComputeEnergy()
 	int64 energyInd = 0;
 	
 	float prevAmp = ind < 0 ? 0 : std::hypotf(m_pcm[2*ind-2], m_pcm[2*ind-1]);
-	float currAmp = std::hypotf(m_pcm[2 * ind], m_pcm[2 * ind + 1]);
+	float currAmp = ind < 0 ? 0 : std::hypotf(m_pcm[2 * ind], m_pcm[2 * ind + 1]);
 
 	for (; ind < endInd; ++ind)
 	{
@@ -267,7 +267,7 @@ void OffsetComputer::ComputeEnergy()
 			if (energyInd >= COMPUTE_WINDOW) break;
 		}
 
-		const float nextAmp = ind + 1 >= static_cast<int64>(m_pcmCount) ? 0 : std::hypotf(m_pcm[ind*2 + 2], m_pcm[ind*2 + 3]);
+		const float nextAmp = ind < -1 || ind + 1 >= static_cast<int64>(m_pcmCount) ? 0 : std::hypotf(m_pcm[ind*2 + 2], m_pcm[ind*2 + 3]);
 
 		// Compute energy based on Newton's laws (?)
 		const float v = (nextAmp - prevAmp) / 2;

--- a/Main/src/Audio/OffsetComputer.cpp
+++ b/Main/src/Audio/OffsetComputer.cpp
@@ -251,8 +251,8 @@ void OffsetComputer::ComputeEnergy()
 
 	int64 energyInd = 0;
 	
-	float prevAmp = ind < 0 ? 0 : std::hypotf(m_pcm[2*ind-2], m_pcm[2*ind-1]);
-	float currAmp = ind < 0 ? 0 : std::hypotf(m_pcm[2 * ind], m_pcm[2 * ind + 1]);
+	float prevAmp = ind <= 0 ? 0 : std::hypotf(m_pcm[2*ind - 2], m_pcm[2*ind - 1]);
+	float currAmp = ind < 0 ? 0 : std::hypotf(m_pcm[2*ind], m_pcm[2*ind + 1]);
 
 	for (; ind < endInd; ++ind)
 	{


### PR DESCRIPTION
I think that these are "small but annoying enough" to be merged to `master`.

- Download screen (lua change only)
    - Pressing ESC no longer exits downloading screen and closes the level filter / sort menu instead, if those are active.
    - Fixes #444: when unzipping an archive, the root folder will always be `songs/nautica/{nautica-id}`, and the root folder in the archive will be found by computing the common path for all files.
- Automatic offset computation
    - Fixes crash happening when the highlight of the chart is located at the very beginning.