### PR TITLE
Minor fixes and improvements on settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             - name: cmake
               run: cmake -DCMAKE_BUILD_TYPE=Release .
             - name: make
-              run: make
+              run: make -j
             - name: Prepare for bundling AppImage
               run: |
                 sudo apt-get install appstream
@@ -91,7 +91,7 @@ jobs:
             - name: cmake
               run: cmake . -DLibArchive_LIBRARY=/usr/local/opt/libarchive/lib/libarchive.dylib -DLibArchive_INCLUDE_DIR=/usr/local/opt/libarchive/include -DCMAKE_BUILD_TYPE=Release
             - name: make
-              run: make
+              run: make -j
             - name: Upload artifact
               uses: actions/upload-artifact@master
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
             - name: brew update
               run: brew update
             - name: Install packages
-              run: brew install cmake freetype libvorbis sdl2 libpng jpeg libarchive
+              run: brew install freetype libvorbis sdl2 libpng jpeg libarchive
             - name: cmake
               run: cmake . -DLibArchive_LIBRARY=/usr/local/opt/libarchive/lib/libarchive.dylib -DLibArchive_INCLUDE_DIR=/usr/local/opt/libarchive/include -DCMAKE_BUILD_TYPE=Release
             - name: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,8 @@ jobs:
               uses: actions/checkout@v1
             - name: Checkout submodules
               run: git submodule update --init --recursive
+            - name: brew update
+              run: brew update
             - name: Install packages
               run: brew install cmake freetype libvorbis sdl2 libpng jpeg libarchive
             - name: cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             - name: cmake
               run: cmake -DCMAKE_BUILD_TYPE=Release .
             - name: make
-              run: make -j
+              run: make
             - name: Prepare for bundling AppImage
               run: |
                 sudo apt-get install appstream
@@ -91,7 +91,7 @@ jobs:
             - name: cmake
               run: cmake . -DLibArchive_LIBRARY=/usr/local/opt/libarchive/lib/libarchive.dylib -DLibArchive_INCLUDE_DIR=/usr/local/opt/libarchive/include -DCMAKE_BUILD_TYPE=Release
             - name: make
-              run: make -j
+              run: make
             - name: Upload artifact
               uses: actions/upload-artifact@master
               with:

--- a/Audio/CMakeLists.txt
+++ b/Audio/CMakeLists.txt
@@ -60,3 +60,8 @@ target_link_libraries(Audio ${OGG_LIBRARIES})
 target_link_libraries(Audio ${Vorbis_LIBRARIES})
 
 target_link_libraries(Audio cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Audio PRIVATE /MP)
+endif(MSVC)

--- a/Beatmap/CMakeLists.txt
+++ b/Beatmap/CMakeLists.txt
@@ -24,7 +24,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${BEATMAP_SRC}" ${PCH_SRC})
 
 add_library(Beatmap ${BEATMAP_SRC} ${PCH_FILES})
-target_compile_features(Beatmap PUBLIC cxx_std_14)
+target_compile_features(Beatmap PUBLIC cxx_std_17)
 target_include_directories(Beatmap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Beatmap PRIVATE
     ${INCROOT}
@@ -42,3 +42,8 @@ target_link_libraries(Beatmap sqlite3)
 target_link_libraries(Beatmap nlohmann_json)
 
 target_link_libraries(Beatmap cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Beatmap PRIVATE /MP)
+endif(MSVC)

--- a/Beatmap/src/MapDatabase.cpp
+++ b/Beatmap/src/MapDatabase.cpp
@@ -414,7 +414,7 @@ public:
 			if (gotVersion == 18)
 			{
 				m_database.Exec("ALTER TABLE Scores ADD COLUMN window_slam INTEGER");
-				m_database.Exec("UPDATE Scores SET window_miss=75");
+				m_database.Exec("UPDATE Scores SET window_slam=84");
 				gotVersion = 19;
 			}
 			m_database.Exec(Utility::Sprintf("UPDATE Database SET `version`=%d WHERE `rowid`=1", m_version));

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -22,7 +22,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${GUI_SRC}" ${PCH_SRC})
 
 add_library(GUI ${GUI_SRC} ${PCH_FILES})
-target_compile_features(GUI PUBLIC cxx_std_14)
+target_compile_features(GUI PUBLIC cxx_std_17)
 target_include_directories(GUI PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(GUI PRIVATE
     ${SRCROOT}
@@ -37,3 +37,8 @@ target_link_libraries(GUI Graphics)
 target_link_libraries(GUI lua)
 
 target_link_libraries(GUI cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(GUI PRIVATE /MP)
+endif(MSVC)

--- a/Graphics/CMakeLists.txt
+++ b/Graphics/CMakeLists.txt
@@ -22,7 +22,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${GRAPHICS_SRC}" ${PCH_SRC})
 
 add_library(Graphics ${GRAPHICS_SRC} ${PCH_FILES})
-target_compile_features(Graphics PUBLIC cxx_std_14)
+target_compile_features(Graphics PUBLIC cxx_std_17)
 target_include_directories(Graphics PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Graphics PRIVATE
     ${INCROOT}
@@ -58,3 +58,8 @@ if(UNIX)
 endif(UNIX)
 
 target_link_libraries(Graphics cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Graphics PRIVATE /MP)
+endif(MSVC)

--- a/Graphics/include/Graphics/Window.hpp
+++ b/Graphics/include/Graphics/Window.hpp
@@ -69,7 +69,7 @@ namespace Graphics
 		bool IsActive() const;
 		// Set window client area size
 		void SetWindowSize(const Vector2i& size);
-		void SwitchFullscreen(int w, int h, int fsw = -1, int fsh = -1, uint32 monitorID = -1, bool windowedFullscreen = false);
+		void SetFullscreen(uint32 monitorID, const Vector2i& windowSize, const Vector2i& fullscreenSize, bool fullscreen, bool windowedFullscreen);
 		bool IsFullscreen() const;
 
 		int GetDisplayIndex() const;

--- a/Graphics/include/Graphics/Window.hpp
+++ b/Graphics/include/Graphics/Window.hpp
@@ -5,13 +5,13 @@
 
 namespace Graphics
 {
-	// Windowed or bordered window style
+	/// Windowed or bordered window style
 	enum class WindowStyle
 	{
 		Windowed, Borderless
 	};
 
-	// Text input data
+	/// Text input data
 	struct TextComposition
 	{
 		String composition;
@@ -26,6 +26,39 @@ namespace Graphics
 	class Window : Unique
 	{
 	public:
+		/// Window position and size parameter
+		struct PosAndShape
+		{
+			enum class Mode { Windowed, Fullscreen, WindowedFullscreen };
+			Mode mode;
+
+			PosAndShape(bool fullscreen, bool windowedFullscreen, const Vector2i& pos, const Vector2i& size, int32 monitorId, const Vector2i& fullscreenSize)
+				: PosAndShape(FlagsToMode(fullscreen, windowedFullscreen), pos, size, monitorId, fullscreenSize) {}
+
+			PosAndShape(Mode mode, const Vector2i& pos, const Vector2i& size, int32 monitorId, const Vector2i& fullscreenSize)
+				: mode(mode), windowPos(pos), windowSize(size), monitorId(monitorId), fullscreenSize(fullscreenSize){}
+
+			inline static Mode FlagsToMode(bool fullscreen, bool windowedFullscreen)
+			{
+				return fullscreen ? windowedFullscreen ? Mode::WindowedFullscreen : Mode::Fullscreen : Mode::Windowed;
+			}
+
+			inline void SetMode(bool fullscreen, bool windowedFullscreen)
+			{
+				mode = FlagsToMode(fullscreen, windowedFullscreen);
+			}
+
+			/// Position of the window; ignored when in fullscreen mode
+			Vector2i windowPos;
+			/// Size of the window; ignored when in fullscreen mode
+			Vector2i windowSize;
+			
+			/// Monitor to use when in fullscreen; ignored when in windowed mode
+			int32 monitorId;
+			/// Only used for windowed fullscreen mode
+			Vector2i fullscreenSize;
+		};
+
 		Window(Vector2i size = Vector2i(800, 600), uint8 samplecount = 0);
 		~Window();
 		// Show the window
@@ -56,8 +89,6 @@ namespace Graphics
 
 		// Get full window position
 		Vector2i GetWindowPos() const;
-		// Set full window position
-		void SetWindowPos(const Vector2i& pos);
 
 		// Window Client area size
 		Vector2i GetWindowSize() const;
@@ -67,9 +98,9 @@ namespace Graphics
 
 		// Window is active
 		bool IsActive() const;
+		
 		// Set window client area size
-		void SetWindowSize(const Vector2i& size);
-		void SetFullscreen(uint32 monitorID, const Vector2i& windowSize, const Vector2i& fullscreenSize, bool fullscreen, bool windowedFullscreen);
+		void SetPosAndShape(const PosAndShape& posAndShape, bool ensureInBound);
 		bool IsFullscreen() const;
 
 		int GetDisplayIndex() const;
@@ -118,6 +149,7 @@ namespace Graphics
 		Delegate<const String&> OnTextInput;
 		Delegate<const TextComposition&> OnTextComposition;
 		Delegate<const Vector2i&> OnResized;
+		Delegate<const Vector2i&> OnMoved;
 		Delegate<bool> OnFocusChanged;
 
 	private:

--- a/Main/CMakeLists.txt
+++ b/Main/CMakeLists.txt
@@ -71,11 +71,13 @@ endif(GIT_FOUND)
 
 set_output_postfixes(usc-game)
 
-# Target subsystem on windows, set debugging folder
 if(MSVC)
-    set_target_properties(usc-game PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS /DEBUG")
+	# Set debugging folder
     set_target_properties(usc-game PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
-    target_compile_options(usc-game PRIVATE /EHsc)
+    target_compile_options(usc-game PRIVATE /EHsc /MP)
+	# Target subsystem on windows, enable multiprocess build and faster PDB gen
+	set_target_properties(usc-game PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:WINDOWS /DEBUG:FASTLINK")
+	set_target_properties(usc-game PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS /DEBUG:FULL")
 elseif(NOT APPLE)
     target_compile_options(usc-game PUBLIC -Wall -Wextra -Werror -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function)
 endif(MSVC)
@@ -99,13 +101,13 @@ target_include_directories(usc-game SYSTEM PRIVATE ${LibArchive_INCLUDE_DIRS})
 if(WIN32)
     target_link_libraries(usc-game
         optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/exception_handler_Release.lib
-	optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Release.lib
-	optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Release.lib
+		optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Release.lib
+		optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Release.lib
     )
     target_link_libraries(usc-game
         debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/exception_handler_Debug.lib
-	debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Debug.lib
-	debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Debug.lib
+		debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Debug.lib
+		debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Debug.lib
     )
     target_include_directories(usc-game PUBLIC ${PROJECT_SOURCE_DIR}/third_party/breakpad/include)
 endif()

--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -115,9 +115,10 @@ private:
 	void m_Cleanup();
 	void m_OnKeyPressed(SDL_Scancode code);
 	void m_OnKeyReleased(SDL_Scancode code);
-	void m_SetFullscreen();
-	void m_AdjustWindowPosition();
+	void m_UpdateWindowPosAndShape();
+	void m_UpdateWindowPosAndShape(int32 monitorId, bool fullscreen, bool ensureInBound);
 	void m_OnWindowResized(const Vector2i& newSize);
+	void m_OnWindowMoved(const Vector2i& newPos);
 	void m_OnFocusChanged(bool focused);
 	void m_unpackSkins();
 

--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -115,6 +115,8 @@ private:
 	void m_Cleanup();
 	void m_OnKeyPressed(SDL_Scancode code);
 	void m_OnKeyReleased(SDL_Scancode code);
+	void m_SetFullscreen();
+	void m_AdjustWindowPosition();
 	void m_OnWindowResized(const Vector2i& newSize);
 	void m_OnFocusChanged(bool focused);
 	void m_unpackSkins();

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -24,6 +24,8 @@ DefineEnum(GameConfigKeys,
 		   Fullscreen,
 		   FullscreenMonitorIndex,
 		   WindowedFullscreen,
+		   AdjustWindowPositionOnStartup,
+
 		   AntiAliasing,
 		   MasterVolume,
 		   VSync,

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -30,6 +30,7 @@ protected:
 
 private:
 	void InitNuklearFontAtlas();
+	void InitNuklearFontAtlasFallback(struct nk_font_atlas* atlas, float fontSize);
 };
 
 class BasicWindow : public BasicNuklearGui

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -27,6 +27,9 @@ protected:
 	bool m_backgroundFrame = true;
 	Texture m_fromTexture;
 	Mesh m_bgMesh;
+
+private:
+	void InitNuklearFontAtlas();
 };
 
 class BasicWindow : public BasicNuklearGui

--- a/Main/include/HitStat.hpp
+++ b/Main/include/HitStat.hpp
@@ -73,7 +73,7 @@ struct HitWindow
 	MapTime good = 92;
 	MapTime hold = 138;
 	MapTime miss = 250;
-	MapTime slam = 75;
+	MapTime slam = 84;
 
 	static const HitWindow NORMAL;
 	static const HitWindow HARD;

--- a/Main/include/SettingsPage.hpp
+++ b/Main/include/SettingsPage.hpp
@@ -127,11 +127,20 @@ protected:
 	nk_context* m_nctx = nullptr;
 	String m_name;
 
+	inline void UpdateLayoutMaxY() { UpdateLayoutMaxY(0.0f); }
+
+	/// Marks max-y needs to be shown
+	inline void UpdateLayoutMaxY(int offset) { UpdateLayoutMaxY(static_cast<float>(offset)); }
+	inline void UpdateLayoutMaxY(float offset) { m_layout_max_y = Math::Max(m_layout_max_y, m_nctx->current->layout->at_y + m_lineHeight + offset); };
+
 	int m_lineHeight = 30;
 	struct nk_vec2 m_comboBoxSize = nk_vec2(1050, 250);
 
 	float m_pageInnerWidth = 0.0f;
 	bool m_opened = false;
+
+private:
+	float m_layout_max_y = 0;
 };
 
 class SettingsPageCollection : public BasicNuklearGui

--- a/Main/include/SettingsPage.hpp
+++ b/Main/include/SettingsPage.hpp
@@ -6,10 +6,10 @@ class SettingsPage
 protected:
 	SettingsPage(nk_context* nctx, const std::string_view& name) : m_nctx(nctx), m_name(name) {}
 
-	/// Called when the page is opened; may be called multiple times.
+	/// Called when the page is opened; may be called multiple times, but only when the page is opening.
 	virtual void Load() = 0;
 
-	/// Called when the page is closed; may be called multiple times.
+	/// Called when the page is closed; may be called multiple times, but only when the page is closing.
 	virtual void Save() = 0;
 
 	virtual void RenderContents() = 0;
@@ -32,7 +32,7 @@ protected:
 		virtual void SaveConfig(const String& value) {}
 
 	private:
-
+		bool m_loaded = false;
 		std::array<char, BUFFER_SIZE> m_buffer;
 		int m_len = 0;
 	};
@@ -105,20 +105,18 @@ protected:
 public:
 	void Open()
 	{
-		if (!m_opened)
-		{
-			Load();
-			m_opened = true;
-		}
+		if (m_opened) return;
+
+		Load();
+		m_opened = true;
 	}
 
 	void Close()
 	{
-		if (m_opened)
-		{
-			Save();
-			m_opened = false;
-		}
+		if (!m_opened) return;
+
+		Save();
+		m_opened = false;
 	}
 
 	void Render(const struct nk_rect& rect);

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1968,7 +1968,7 @@ void Application::m_UpdateWindowPosAndShape(int32 monitorId, bool fullscreen, bo
 	const Vector2i windowSize(g_gameConfig.GetInt(GameConfigKeys::ScreenWidth), g_gameConfig.GetInt(GameConfigKeys::ScreenHeight));
 	const Vector2i fullscreenSize(g_gameConfig.GetInt(GameConfigKeys::FullScreenWidth), g_gameConfig.GetInt(GameConfigKeys::FullScreenHeight));
 
-	g_gameWindow->SetPosAndShape(Window::PosAndShape {
+	g_gameWindow->SetPosAndShape(Graphics::Window::PosAndShape {
 		fullscreen, g_gameConfig.GetBool(GameConfigKeys::WindowedFullscreen),
 		windowPos, windowSize, monitorId, fullscreenSize
 	}, ensureInBound);

--- a/Main/src/ChatOverlay.cpp
+++ b/Main/src/ChatOverlay.cpp
@@ -53,31 +53,8 @@ void ChatOverlay::InitNuklearIfNeeded()
 		nk_sdl_font_stash_begin(&atlas);
 		struct nk_font *fallback = nk_font_atlas_add_from_file(atlas, Path::Normalize( Path::Absolute("fonts/settings/NotoSans-Regular.ttf")).c_str(), 24, 0);
 
-		// struct nk_font_config cfg_kr = nk_font_config(24);
-		// cfg_kr.merge_mode = nk_true;
-		// cfg_kr.range = nk_font_korean_glyph_ranges();
-
-		// NK_STORAGE const nk_rune jp_ranges[] = {
-		// 	0x0020, 0x00FF,
-		// 	0x3000, 0x303f,
-		// 	0x3040, 0x309f,
-		// 	0x30a0, 0x30ff,
-		// 	0x4e00, 0x9faf,
-		// 	0xff00, 0xffef,
-		// 	0
-		// };
-		// struct nk_font_config cfg_jp = nk_font_config(24);
-		// cfg_jp.merge_mode = nk_true;
-		// cfg_jp.range = jp_ranges;
-
 		NK_STORAGE const nk_rune cjk_ranges[] = {
-			0x0020, 0x00FF,
-			0x3000, 0x30FF,
-			0x3131, 0x3163,
-			0xAC00, 0xD79D,
-			0x31F0, 0x31FF,
-			0xFF00, 0xFFEF,
-			0x4e00, 0x9FAF,
+			0x0E3F, 0xFFFF,
 			0
 		};
 
@@ -93,9 +70,9 @@ void ChatOverlay::InitNuklearIfNeeded()
 			nk_font_atlas_add_from_file(atlas, Path::Normalize(Path::Absolute("fonts/settings/DroidSansFallback.ttf")).c_str(), 24, &cfg_cjk);
 		}
 		
-		nk_sdl_font_stash_end();
+		usc_nk_sdl_font_stash_end();
 		nk_font_atlas_cleanup(atlas);
-		//nk_style_load_all_cursors(m_nctx, atlas->cursors);
+
 		nk_style_set_font(m_nctx, &fallback->handle);
 	}
 	

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -93,6 +93,7 @@ private:
 
 	// Map object approach speed, scaled by BPM
 	float m_hispeed = 1.0f;
+	float m_hispeedAdvance = 0.f;
 
 	// Current lane toggle status
 	bool m_hideLane = false;
@@ -778,22 +779,21 @@ public:
 		{
 			for (int i = 0; i < 2; i++)
 			{
-				float change = g_input.GetInputLaserDir(i) / 3.0f;
-				m_hispeed += change;
-				m_hispeed = Math::Clamp(m_hispeed, 0.1f, 16.f);
-				if ((m_speedMod != SpeedMods::XMod) && change != 0.0f)
+				m_hispeedAdvance += g_input.GetInputLaserDir(i) / 3.0f;
+				int hispeedSteps = static_cast<int>(truncf(m_hispeedAdvance * 10.0f));
+				m_hispeedAdvance -= 0.1f * hispeedSteps;
+				if (hispeedSteps != 0)
 				{
+					m_hispeed = static_cast<float>(static_cast<int>(m_hispeed * 10.0f) + hispeedSteps) / 10.0f;
+					m_hispeed = Math::Clamp(m_hispeed, 0.1f, 16.f);
+
 					if (m_saveSpeed)
 					{
 						g_gameConfig.Set(GameConfigKeys::ModSpeed, m_hispeed * (float)m_currentTiming->GetBPM());
 					}
 					m_modSpeed = m_hispeed * (float)m_currentTiming->GetBPM();
 					// Have to check in here so we can update m_playback
-					CheckChallengeHispeed(m_currentTiming->GetBPM());
 					m_playback.cModSpeed = m_modSpeed;
-				}
-				else
-				{
 					CheckChallengeHispeed(m_currentTiming->GetBPM());
 				}
 			}

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -63,6 +63,7 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::Fullscreen, false);
 	Set(GameConfigKeys::FullscreenMonitorIndex, 0);
 	Set(GameConfigKeys::WindowedFullscreen, false);
+	Set(GameConfigKeys::AdjustWindowPositionOnStartup, true);
 	Set(GameConfigKeys::AntiAliasing, 1);
 	Set(GameConfigKeys::MasterVolume, 1.0f);
 	Set(GameConfigKeys::ScreenX, -1);

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -921,7 +921,6 @@ void Scoring::m_UpdateGauges(ScoreHitRating rating, TickFlags flags)
 		return;
 	}
 
-
 	bool isLong = (flags & TickFlags::Hold) != TickFlags::None
 	|| ((flags & TickFlags::Laser) != TickFlags::None
 	&& (flags & TickFlags::Slam) == TickFlags::None);
@@ -1208,11 +1207,8 @@ void Scoring::m_UpdateLasers(float deltaTime)
 				}
 
 				positionDelta = laserTargetPositions[i] - laserPositions[i];
-				if (inputDir == laserDir || laserDir == 0)
-				{
-					if (fabsf(positionDelta) <= m_laserDistanceLeniency)
-						m_autoLaserTime[i] = m_autoLaserDuration;
-				}
+				if ((inputDir == laserDir || laserDir == 0) && fabsf(positionDelta) <= m_laserDistanceLeniency)
+                    m_autoLaserTime[i] = m_autoLaserDuration;
 				else
 					m_autoLaserTime[i] -= deltaTime;
 			}

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1116,6 +1116,7 @@ void Scoring::m_UpdateLasers(float deltaTime)
 {
 	MapTime mapTime = m_playback->GetLastTime() + m_inputOffset;
 	bool currentlySlamNextSegmentStraight[2] = { false };
+
 	// Check for new laser segments in laser queue
 	for (auto it = m_laserSegmentQueue.begin(); it != m_laserSegmentQueue.end();)
 	{
@@ -1181,6 +1182,7 @@ void Scoring::m_UpdateLasers(float deltaTime)
 		}
 
 		m_laserInput[i] = autoplay ? 0.0f : m_input->GetInputLaserDir(i);
+        float inputDir = Math::Sign(m_laserInput[i]);
 
 		if (currentSegment)
 		{
@@ -1188,7 +1190,6 @@ void Scoring::m_UpdateLasers(float deltaTime)
 			float positionDelta = laserTargetPositions[i] - laserPositions[i];
 			float laserDir = currentSegment->GetDirection();
 			float input = m_laserInput[i];
-			float inputDir = Math::Sign(input);
 
 			if (inputDir != 0)
 			{
@@ -1224,8 +1225,14 @@ void Scoring::m_UpdateLasers(float deltaTime)
 			timeSinceLaserUsed[i] += deltaTime;
 
 			// Always snap laser to start sections
-			if (m_GetLaserObjectWithinTwoBeats(i))
-				m_autoLaserTime[i] = m_autoLaserDuration;
+			auto incomingLaser = m_GetLaserObjectWithinTwoBeats(i);
+			if (incomingLaser)
+			{
+				laserPositions[i] = incomingLaser->points[0];
+				m_autoLaserTime[i] = inputDir == incomingLaser->GetDirection() || inputDir == 0
+									 ? m_autoLaserDuration
+									 : 0;
+			}
 		}
 		
 		if (currentlySlamNextSegmentStraight[i])

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1115,7 +1115,7 @@ bool Scoring::m_IsRoot(const HoldObjectState* hold) const
 
 void Scoring::m_UpdateLasers(float deltaTime)
 {
-	MapTime mapTime = m_playback->GetLastTime();
+	MapTime mapTime = m_playback->GetLastTime() + m_inputOffset;
 	bool currentlySlamNextSegmentStraight[2] = { false };
 	// Check for new laser segments in laser queue
 	for (auto it = m_laserSegmentQueue.begin(); it != m_laserSegmentQueue.end();)

--- a/Main/src/SettingsPage.cpp
+++ b/Main/src/SettingsPage.cpp
@@ -155,10 +155,26 @@ int SettingsPage::SelectionInput(int val, const Vector<const char*>& options, co
 {
 	assert(options.size() > 0);
 
-	Label(label);
-	
-	nk_combobox(m_nctx, const_cast<const char**>(options.data()), static_cast<int>(options.size()), &val, m_lineHeight, m_comboBoxSize);
-	UpdateLayoutMaxY((m_lineHeight + 5) * static_cast<int>(options.size()));
+	if (0 <= val && val < static_cast<int>(options.size()))
+	{
+		Label(label);
+
+		nk_combobox(m_nctx, const_cast<const char**>(options.data()), static_cast<int>(options.size()), &val, m_lineHeight, m_comboBoxSize);
+		UpdateLayoutMaxY((m_lineHeight + 5) * static_cast<int>(options.size()));
+	}
+	else
+	{
+		std::stringstream str;
+		str << std::string(label) << " [currently set to an unknown value " << val << "]";
+
+		Label(str.str().data());
+		str.clear();
+
+		if (nk_button_label(m_nctx, "Press this button to reset."))
+		{
+			val = 0;
+		}
+	}
 
 	return val;
 }
@@ -167,7 +183,7 @@ bool SettingsPage::SelectionSetting(GameConfigKeys key, const Vector<const char*
 {
 	assert(options.size() > 0);
 
-	const int value = g_gameConfig.GetInt(key) % options.size();
+	const int value = g_gameConfig.GetInt(key);
 	const int newValue = SelectionInput(value, options, label);
 
 	if (newValue != value)

--- a/Main/src/SettingsPage.cpp
+++ b/Main/src/SettingsPage.cpp
@@ -48,10 +48,13 @@ void SettingsPage::SettingTextData::Load()
 	}
 
 	std::memcpy(m_buffer.data(), str.data(), m_len + 1);
+	m_loaded = true;
 }
 
 void SettingsPage::SettingTextData::Save()
 {
+	if (!m_loaded) return;
+
 	String str = String(m_buffer.data(), m_len);
 
 	str.TrimBack('\n');

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -967,6 +967,7 @@ private:
 		if (it == m_skinConfigTextData.end())
 		{
 			it = m_skinConfigTextData.emplace_hint(it, setting.key, SkinConfigTextData { m_skinConfig, setting.key });
+			it->second.Load();
 		}
 
 		if (it == m_skinConfigTextData.end())

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -199,8 +199,8 @@ private:
 
 	inline void RenderKeyBindings()
 	{
-		const float DESIRED_BT_HEIGHT = m_lineHeight * 3;
-		const float DESIRED_BT_SPACING = m_lineHeight * 0.25F;
+		const float DESIRED_BT_HEIGHT = m_lineHeight * 3.0f;
+		const float DESIRED_BT_SPACING = m_lineHeight * 0.25f;
 
 		const float DESIRED_CONTROLLER_WIDTH = DESIRED_BT_HEIGHT*4 + DESIRED_BT_SPACING*3;
 

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -108,20 +108,12 @@ protected:
 
 		RenderKeyBindings();
 
-		SectionHeader("Offsets");
-
-		LayoutRowDynamic(2);
-		IntSetting(GameConfigKeys::GlobalOffset, "Global offset", -1000, 1000);
-		IntSetting(GameConfigKeys::InputOffset, "Input offset", -1000, 1000);
-
-		LayoutRowDynamic(1);
-		if (nk_button_label(m_nctx, "Calibrate Offsets")) {
-			CalibrationScreen* cscreen = new CalibrationScreen(m_nctx);
-			g_transition->TransitionTo(cscreen);
-			return;
-		}
-
 		SectionHeader("Input Device");
+
+		if (m_gamePads.size() > 0)
+		{
+			SelectionSetting(GameConfigKeys::Controller_DeviceID, m_gamePads, "Controller to use:");
+		}
 
 		LayoutRowDynamic(2, m_lineHeight * 6);
 
@@ -151,12 +143,6 @@ protected:
 
 			EnumSetting<Enum_LaserAxisOption>(GameConfigKeys::InvertLaserInput, "Invert directions:");
 			nk_group_end(m_nctx);
-		}
-
-		if (m_gamePads.size() > 0)
-		{
-			LayoutRowDynamic(1);
-			SelectionSetting(GameConfigKeys::Controller_DeviceID, m_gamePads, "Selected controller:");
 		}
 
 		SectionHeader("Laser Sensitivity");
@@ -440,6 +426,19 @@ protected:
 protected:
 	void RenderContents() override
 	{
+		SectionHeader("Offsets");
+
+		LayoutRowDynamic(2);
+		IntSetting(GameConfigKeys::GlobalOffset, "Global offset", -1000, 1000);
+		IntSetting(GameConfigKeys::InputOffset, "Input offset", -1000, 1000);
+
+		LayoutRowDynamic(1);
+		if (nk_button_label(m_nctx, "Calibrate Offsets")) {
+			CalibrationScreen* cscreen = new CalibrationScreen(m_nctx);
+			g_transition->TransitionTo(cscreen);
+			return;
+		}
+
 		SectionHeader("Speed Mod");
 		EnumSetting<Enum_SpeedMods>(GameConfigKeys::SpeedMod, "Speed mod type:");
 		FloatSetting(GameConfigKeys::HiSpeed, "HiSpeed", 0.25f, 20, 0.05f);
@@ -524,10 +523,10 @@ private:
 	}
 };
 
-class SettingsPage_Display : public SettingsPage
+class SettingsPage_Visual : public SettingsPage
 {
 public:
-	SettingsPage_Display(nk_context* nctx) : SettingsPage(nctx, "Display") {}
+	SettingsPage_Visual(nk_context* nctx) : SettingsPage(nctx, "Visual") {}
 
 protected:
 	void Load() override
@@ -1057,7 +1056,7 @@ protected:
 	{
 		pages.emplace_back(std::make_unique<SettingsPage_Input>(m_nctx));
 		pages.emplace_back(std::make_unique<SettingsPage_Game>(m_nctx));
-		pages.emplace_back(std::make_unique<SettingsPage_Display>(m_nctx));
+		pages.emplace_back(std::make_unique<SettingsPage_Visual>(m_nctx));
 		pages.emplace_back(std::make_unique<SettingsPage_System>(m_nctx));
 		pages.emplace_back(std::make_unique<SettingsPage_Online>(m_nctx));
 		pages.emplace_back(std::make_unique<SettingsPage_Skin>(m_nctx));
@@ -1129,7 +1128,13 @@ public:
 			if (!m_gamepad)
 			{
 				Logf("Failed to open gamepad: %d", Logger::Severity::Error, m_gamepadIndex);
-				g_gameWindow->ShowMessageBox("Warning", "Could not open selected gamepad.\nEnsure the controller is connected and in the correct mode (if applicable) and selected in the previous menu.", 1);
+				g_gameWindow->ShowMessageBox("Warning",
+					"The controller configured to use is unavailable.\n"
+					"Ensure the controller is connected, or (if applicable) set the controller in the correct mode.          \n"
+					, 1);
+				g_gameWindow->ShowMessageBox("Warning",
+					"Otherwise, select another controller to use in the settings page.          \n"
+					, 1);
 				return false;
 			}
 			if (m_knobs)
@@ -1193,7 +1198,7 @@ public:
 
 		if (m_isGamepad)
 		{
-			prompt = "Press the button";
+			prompt = "Press the controller button";
 			m_gamepad = g_gameWindow->OpenGamepad(m_gamepadIndex);
 			if (m_knobs)
 			{
@@ -1254,6 +1259,16 @@ public:
 			{
 				g_application->RemoveTickable(this);
 			}
+		}
+		
+		if (m_isGamepad && code == SDL_Scancode::SDL_SCANCODE_ESCAPE)
+		{
+			if (m_gamepad)
+			{
+				m_gamepad->OnButtonPressed.RemoveAll(this);
+			}
+
+			g_application->RemoveTickable(this);
 		}
 	}
 

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -697,7 +697,11 @@ protected:
 
 		SectionHeader("Render");
 
+		SetApply(ToggleSetting(GameConfigKeys::Fullscreen, "Fullscreen"));
 		SetApply(ToggleSetting(GameConfigKeys::WindowedFullscreen, "Use windowed fullscreen"));
+
+		ToggleSetting(GameConfigKeys::AdjustWindowPositionOnStartup, "Adjust window positions to be in-bound on startup");
+
 		SetApply(ToggleSetting(GameConfigKeys::ForcePortrait, "Force portrait (don't use if already in portrait)"));
 
 		SelectionSetting(GameConfigKeys::AntiAliasing, m_aaModes, "Anti-aliasing (requires restart):");

--- a/Main/stdafx.cpp
+++ b/Main/stdafx.cpp
@@ -27,3 +27,260 @@ static inline void sprintf_dtoa(char(&buffer)[64 /* NK_MAX_NUMBER_BUFFER */], do
 #include "../third_party/nuklear/nuklear.h"
 #include "nuklear/nuklear_sdl_gl3.h"
 #endif
+
+/// nk_font_bake_pack but with better logic for width determination
+/// from https://github.com/vurtun/nuklear/issues/738
+static inline int usc_nk_font_bake_pack(struct nk_font_baker* baker,
+    nk_size* image_memory, int* width, int* height, struct nk_recti* custom,
+    const struct nk_font_config* config_list, int count,
+    struct nk_allocator* alloc)
+{
+    NK_STORAGE const nk_size max_height = 1024 * 32;
+    const struct nk_font_config* config_iter, * it;
+    int total_glyph_count = 0;
+    int total_range_count = 0;
+    int range_count = 0;
+    int i = 0;
+
+    NK_ASSERT(image_memory);
+    NK_ASSERT(width);
+    NK_ASSERT(height);
+    NK_ASSERT(config_list);
+    NK_ASSERT(count);
+    NK_ASSERT(alloc);
+
+    int max_size = 0;
+
+    if (!image_memory || !width || !height || !config_list || !count) return nk_false;
+    for (config_iter = config_list; config_iter; config_iter = config_iter->next) {
+        it = config_iter;
+        do {
+            range_count = nk_range_count(it->range);
+            total_range_count += range_count;
+            total_glyph_count += nk_range_glyph_count(it->range, range_count);
+            if (it->size > max_size) max_size = it->size;
+        } while ((it = it->n) != config_iter);
+    }
+    /* setup font baker from temporary memory */
+    for (config_iter = config_list; config_iter; config_iter = config_iter->next) {
+        it = config_iter;
+        do {
+            if (!nk_tt_InitFont(&baker->build[i++].info, (const unsigned char*)it->ttf_blob, 0))
+                return nk_false;
+        } while ((it = it->n) != config_iter);
+    }
+    *height = 0;
+    *width = nk_round_up_pow2(static_cast<int>(max_size * sqrt(total_glyph_count)));
+    nk_tt_PackBegin(&baker->spc, 0, (int)*width, (int)max_height, 0, 1, alloc);
+    {
+        int input_i = 0;
+        int range_n = 0;
+        int rect_n = 0;
+        int char_n = 0;
+
+        if (custom) {
+            /* pack custom user data first so it will be in the upper left corner*/
+            struct nk_rp_rect custom_space;
+            nk_zero(&custom_space, sizeof(custom_space));
+            custom_space.w = (nk_rp_coord)(custom->w);
+            custom_space.h = (nk_rp_coord)(custom->h);
+
+            nk_tt_PackSetOversampling(&baker->spc, 1, 1);
+            nk_rp_pack_rects((struct nk_rp_context*)baker->spc.pack_info, &custom_space, 1);
+            *height = NK_MAX(*height, (int)(custom_space.y + custom_space.h));
+
+            custom->x = (short)custom_space.x;
+            custom->y = (short)custom_space.y;
+            custom->w = (short)custom_space.w;
+            custom->h = (short)custom_space.h;
+        }
+
+        /* first font pass: pack all glyphs */
+        for (input_i = 0, config_iter = config_list; input_i < count && config_iter;
+            config_iter = config_iter->next) {
+            it = config_iter;
+            do {
+                int n = 0;
+                int glyph_count;
+                const nk_rune* in_range;
+                const struct nk_font_config* cfg = it;
+                struct nk_font_bake_data* tmp = &baker->build[input_i++];
+
+                /* count glyphs + ranges in current font */
+                glyph_count = 0; range_count = 0;
+                for (in_range = cfg->range; in_range[0] && in_range[1]; in_range += 2) {
+                    glyph_count += (int)(in_range[1] - in_range[0]) + 1;
+                    range_count++;
+                }
+
+                /* setup ranges  */
+                tmp->ranges = baker->ranges + range_n;
+                tmp->range_count = (nk_rune)range_count;
+                range_n += range_count;
+                for (i = 0; i < range_count; ++i) {
+                    in_range = &cfg->range[i * 2];
+                    tmp->ranges[i].font_size = cfg->size;
+                    tmp->ranges[i].first_unicode_codepoint_in_range = (int)in_range[0];
+                    tmp->ranges[i].num_chars = (int)(in_range[1] - in_range[0]) + 1;
+                    tmp->ranges[i].chardata_for_range = baker->packed_chars + char_n;
+                    char_n += tmp->ranges[i].num_chars;
+                }
+
+                /* pack */
+                tmp->rects = baker->rects + rect_n;
+                rect_n += glyph_count;
+                nk_tt_PackSetOversampling(&baker->spc, cfg->oversample_h, cfg->oversample_v);
+                n = nk_tt_PackFontRangesGatherRects(&baker->spc, &tmp->info,
+                    tmp->ranges, (int)tmp->range_count, tmp->rects);
+                nk_rp_pack_rects((struct nk_rp_context*)baker->spc.pack_info, tmp->rects, (int)n);
+
+                /* texture height */
+                for (i = 0; i < n; ++i) {
+                    if (tmp->rects[i].was_packed)
+                        *height = NK_MAX(*height, tmp->rects[i].y + tmp->rects[i].h);
+                }
+            } while ((it = it->n) != config_iter);
+        }
+        NK_ASSERT(rect_n == total_glyph_count);
+        NK_ASSERT(char_n == total_glyph_count);
+        NK_ASSERT(range_n == total_range_count);
+    }
+    *height = (int)nk_round_up_pow2((nk_uint)*height);
+    *image_memory = (nk_size)(*width) * (nk_size)(*height);
+    return nk_true;
+}
+
+/// nk_font_atlas_bake but calls usc_nk_font_bake_pack
+static inline const void* usc_nk_font_atlas_bake(struct nk_font_atlas* atlas, int* width, int* height,
+    enum nk_font_atlas_format fmt)
+{
+    int i = 0;
+    void* tmp = 0;
+    nk_size tmp_size, img_size;
+    struct nk_font* font_iter;
+    struct nk_font_baker* baker;
+
+    NK_ASSERT(atlas);
+    NK_ASSERT(atlas->temporary.alloc);
+    NK_ASSERT(atlas->temporary.free);
+    NK_ASSERT(atlas->permanent.alloc);
+    NK_ASSERT(atlas->permanent.free);
+
+    NK_ASSERT(width);
+    NK_ASSERT(height);
+    if (!atlas || !width || !height ||
+        !atlas->temporary.alloc || !atlas->temporary.free ||
+        !atlas->permanent.alloc || !atlas->permanent.free)
+        return 0;
+
+#ifdef NK_INCLUDE_DEFAULT_FONT
+    /* no font added so just use default font */
+    if (!atlas->font_num)
+        atlas->default_font = nk_font_atlas_add_default(atlas, 13.0f, 0);
+#endif
+    NK_ASSERT(atlas->font_num);
+    if (!atlas->font_num) return 0;
+
+    /* allocate temporary baker memory required for the baking process */
+    nk_font_baker_memory(&tmp_size, &atlas->glyph_count, atlas->config, atlas->font_num);
+    tmp = atlas->temporary.alloc(atlas->temporary.userdata, 0, tmp_size);
+    NK_ASSERT(tmp);
+    if (!tmp) goto failed;
+
+    /* allocate glyph memory for all fonts */
+    baker = nk_font_baker(tmp, atlas->glyph_count, atlas->font_num, &atlas->temporary);
+    atlas->glyphs = (struct nk_font_glyph*)atlas->permanent.alloc(
+        atlas->permanent.userdata, 0, sizeof(struct nk_font_glyph) * (nk_size)atlas->glyph_count);
+    NK_ASSERT(atlas->glyphs);
+    if (!atlas->glyphs)
+        goto failed;
+
+    /* pack all glyphs into a tight fit space */
+    atlas->custom.w = (NK_CURSOR_DATA_W * 2) + 1;
+    atlas->custom.h = NK_CURSOR_DATA_H + 1;
+    if (!usc_nk_font_bake_pack(baker, &img_size, width, height, &atlas->custom,
+        atlas->config, atlas->font_num, &atlas->temporary))
+        goto failed;
+
+    /* allocate memory for the baked image font atlas */
+    atlas->pixel = atlas->temporary.alloc(atlas->temporary.userdata, 0, img_size);
+    NK_ASSERT(atlas->pixel);
+    if (!atlas->pixel)
+        goto failed;
+
+    /* bake glyphs and custom white pixel into image */
+    nk_font_bake(baker, atlas->pixel, *width, *height,
+        atlas->glyphs, atlas->glyph_count, atlas->config, atlas->font_num);
+    nk_font_bake_custom_data(atlas->pixel, *width, *height, atlas->custom,
+        nk_custom_cursor_data, NK_CURSOR_DATA_W, NK_CURSOR_DATA_H, '.', 'X');
+
+    if (fmt == NK_FONT_ATLAS_RGBA32) {
+        /* convert alpha8 image into rgba32 image */
+        void* img_rgba = atlas->temporary.alloc(atlas->temporary.userdata, 0,
+            (nk_size)(*width * *height * 4));
+        NK_ASSERT(img_rgba);
+        if (!img_rgba) goto failed;
+        nk_font_bake_convert(img_rgba, *width, *height, atlas->pixel);
+        atlas->temporary.free(atlas->temporary.userdata, atlas->pixel);
+        atlas->pixel = img_rgba;
+    }
+    atlas->tex_width = *width;
+    atlas->tex_height = *height;
+
+    /* initialize each font */
+    for (font_iter = atlas->fonts; font_iter; font_iter = font_iter->next) {
+        struct nk_font* font = font_iter;
+        struct nk_font_config* config = font->config;
+        nk_font_init(font, config->size, config->fallback_glyph, atlas->glyphs,
+            config->font, nk_handle_ptr(0));
+    }
+
+    /* initialize each cursor */
+    {NK_STORAGE const struct nk_vec2 nk_cursor_data[NK_CURSOR_COUNT][3] = {
+        /* Pos      Size        Offset */
+        {{ 0, 3},   {12,19},    { 0, 0}},
+        {{13, 0},   { 7,16},    { 4, 8}},
+        {{31, 0},   {23,23},    {11,11}},
+        {{21, 0},   { 9, 23},   { 5,11}},
+        {{55,18},   {23, 9},    {11, 5}},
+        {{73, 0},   {17,17},    { 9, 9}},
+        {{55, 0},   {17,17},    { 9, 9}}
+    };
+    for (i = 0; i < NK_CURSOR_COUNT; ++i) {
+        struct nk_cursor* cursor = &atlas->cursors[i];
+        cursor->img.w = (unsigned short)*width;
+        cursor->img.h = (unsigned short)*height;
+        cursor->img.region[0] = (unsigned short)(atlas->custom.x + nk_cursor_data[i][0].x);
+        cursor->img.region[1] = (unsigned short)(atlas->custom.y + nk_cursor_data[i][0].y);
+        cursor->img.region[2] = (unsigned short)nk_cursor_data[i][1].x;
+        cursor->img.region[3] = (unsigned short)nk_cursor_data[i][1].y;
+        cursor->size = nk_cursor_data[i][1];
+        cursor->offset = nk_cursor_data[i][2];
+    }}
+    /* free temporary memory */
+    atlas->temporary.free(atlas->temporary.userdata, tmp);
+    return atlas->pixel;
+
+failed:
+    /* error so cleanup all memory */
+    if (tmp) atlas->temporary.free(atlas->temporary.userdata, tmp);
+    if (atlas->glyphs) {
+        atlas->permanent.free(atlas->permanent.userdata, atlas->glyphs);
+        atlas->glyphs = 0;
+    }
+    if (atlas->pixel) {
+        atlas->temporary.free(atlas->temporary.userdata, atlas->pixel);
+        atlas->pixel = 0;
+    }
+    return 0;
+}
+
+void usc_nk_sdl_font_stash_end(void)
+{
+    const void* image; int w, h;
+    image = usc_nk_font_atlas_bake(&sdl.atlas, &w, &h, NK_FONT_ATLAS_RGBA32);
+    nk_sdl_device_upload_atlas(image, w, h);
+    nk_font_atlas_end(&sdl.atlas, nk_handle_id((int)sdl.ogl.font_tex), &sdl.ogl.null);
+    if (sdl.atlas.default_font)
+        nk_style_set_font(&sdl.ctx, &sdl.atlas.default_font->handle);
+}

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -83,7 +83,7 @@ using namespace Graphics;
 
 constexpr int MAX_VERTEX_MEMORY = 512 * 1024;
 constexpr int MAX_ELEMENT_MEMORY = 128 * 1024;
-constexpr int FULL_FONT_TEXTURE_HEIGHT = 32768; //needed to load all CJK glyphs
+constexpr int FULL_FONT_TEXTURE_HEIGHT = 8192; //needed to load all CJK glyphs
 
 #include "BasicDefinitions.hpp"
 
@@ -93,3 +93,6 @@ constexpr int FULL_FONT_TEXTURE_HEIGHT = 32768; //needed to load all CJK glyphs
 
 // Asset loading macro
 #define CheckedLoad(__stmt) if(!(__stmt)){Logf("Failed to load asset [%s]", Logger::Severity::Error, #__stmt); return false; }
+
+/// nk_sdl_font_stash_end but uses a better bake function to reduce baked font texture dimension
+void usc_nk_sdl_font_stash_end();

--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -36,7 +36,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${SHARED_SRC}" ${PCH_SRC})
 
 add_library(Shared ${SHARED_SRC} ${PCH_FILES})
-target_compile_features(Shared PUBLIC cxx_std_14)
+target_compile_features(Shared PUBLIC cxx_std_17)
 target_include_directories(Shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Shared PRIVATE
     ${SRCROOT}
@@ -53,3 +53,8 @@ target_link_libraries(Shared ${LibArchive_LIBRARIES})
 target_include_directories(Shared SYSTEM PRIVATE ${LibArchive_INCLUDE_DIRS})
 
 target_link_libraries(Shared cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Shared PRIVATE /MP)
+endif(MSVC)

--- a/Shared/include/Shared/Buffer.hpp
+++ b/Shared/include/Shared/Buffer.hpp
@@ -14,9 +14,7 @@ public:
 	Buffer(Buffer&& rhs);
 	Buffer& operator=(Buffer&& rhs);
 	// Creates a new buffer from a string, without the terminating null character
-	Buffer(const char* string);
-	// Creates a new buffer with an initial size
-	Buffer(size_t initialSize);
+	explicit Buffer(const char* string);
 	// Creates a copy of this buffer
 	Buffer Copy() const;
 };

--- a/Shared/include/Shared/Rect.hpp
+++ b/Shared/include/Shared/Rect.hpp
@@ -5,6 +5,9 @@
 	GUI space rectangle with bottom as y+height
 */
 
+template<typename T>
+class Vector;
+
 namespace Shared
 {
 	template<typename T>
@@ -90,13 +93,23 @@ namespace Shared
 			return newRect;
 		}
 
+		inline bool Contains(const RectangleBase& other) const
+		{
+			return Left() <= other.Left() && other.Right() <= Right() && Top() <= other.Top() && other.Bottom() <= Bottom();
+		}
+
+		inline bool NotSmallerThan(const VectorType& other_size) const
+		{
+			return size.x >= other_size.x && size.y >= other_size.y;
+		}
+
 		// Clamp the parameter to this rectangle
 		RectangleBase Clamp(const RectangleBase& other) const
 		{
-			float top = Math::Max(other.Top(), Top());
-			float bottom = Math::Min(other.Bottom(), Bottom());
-			float left = Math::Max(other.Left(), Left());
-			float right = Math::Min(other.Right(), Right());
+			T top = Math::Max(other.Top(), Top());
+			T bottom = Math::Min(other.Bottom(), Bottom());
+			T left = Math::Max(other.Left(), Left());
+			T right = Math::Min(other.Right(), Right());
 			if (right < left)
 				right = left;
 			if (bottom < top)

--- a/Shared/src/Buffer.cpp
+++ b/Shared/src/Buffer.cpp
@@ -1,10 +1,6 @@
 #include "stdafx.h"
 #include "Buffer.hpp"
 
-Buffer::Buffer(size_t initialSize)
-{
-	resize(initialSize);
-}
 Buffer::Buffer(const char* string)
 {
 	uint32 l = (uint32)strlen(string);

--- a/Shared/stdafx.h
+++ b/Shared/stdafx.h
@@ -12,3 +12,6 @@
 #endif
 
 #include "Shared/Types.hpp"
+
+#include <vector>
+#include <map>

--- a/Tests.Game/CMakeLists.txt
+++ b/Tests.Game/CMakeLists.txt
@@ -18,7 +18,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${TESTS_GAME_SRC}" ${PCH_SRC})
 
 add_executable(Tests.Game ${TESTS_GAME_SRC} ${PCH_FILES})
-target_compile_features(Tests.Game PUBLIC cxx_std_14)
+target_compile_features(Tests.Game PUBLIC cxx_std_17)
 set_output_postfixes(Tests.Game)
 target_include_directories(Tests.Game PRIVATE
     ${SRCROOT}

--- a/Tests.Shared/CMakeLists.txt
+++ b/Tests.Shared/CMakeLists.txt
@@ -9,7 +9,7 @@ source_group("Sources" FILES ${SRC})
 set(MAIN_SRC ${SRC})
 
 add_executable(Tests.Shared ${MAIN_SRC})
-target_compile_features(Tests.Shared PUBLIC cxx_std_14)
+target_compile_features(Tests.Shared PUBLIC cxx_std_17)
 target_include_directories(Tests.Shared PRIVATE
     ${SRCROOT}
 )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -22,7 +22,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${TESTS_SRC}" ${PCH_SRC})
 
 add_library(Tests ${TESTS_SRC} ${PCH_FILES})
-target_compile_features(Tests PUBLIC cxx_std_14)
+target_compile_features(Tests PUBLIC cxx_std_17)
 # Public include paths for library
 target_include_directories(Tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Tests PRIVATE

--- a/bin/skins/Default/scripts/songselect/background.lua
+++ b/bin/skins/Default/scripts/songselect/background.lua
@@ -7,15 +7,38 @@ TEXT_ALIGN_TOP 		= 8;
 TEXT_ALIGN_MIDDLE	= 16;
 TEXT_ALIGN_BOTTOM	= 32;
 TEXT_ALIGN_BASELINE	= 64;
-local backgroundImage = gfx.CreateSkinImage("bg.png", 1);
+local r, g, b, a = game.GetSkinSetting("col_test")
+local timer = 0.0
+local bgMesh = gfx.CreateShadedMesh("songSelBack")
+local verts = {}
+local numVerts = 10
+local vh = 1/numVerts
+local seed = math.random() * 100
+for y=0,numVerts do    
+    local yp = y / numVerts
+    for x=0,numVerts do 
+        local xp = x / numVerts
+        if y % 2 == 1 then 
+            xp = (numVerts - x) / numVerts + vh / 2
+            table.insert(verts, {{xp, yp}, {0, 0}})
+            table.insert(verts, {{xp - vh / 2, yp + vh}, {0, 0}})
+        else
+            table.insert(verts, {{xp, yp}, {0, 0}})
+            table.insert(verts, {{xp + vh / 2, yp + vh}, {0, 0}})
+        end
+    end
+end
 
-
+bgMesh:SetPrimitiveType(bgMesh.PRIM_TRISTRIP)
+bgMesh:SetBlendMode(bgMesh.BLEND_ADD)
+bgMesh:SetData(verts)
+bgMesh:SetParam("seed", seed)
+bgMesh:SetParamVec4("color", r / 255, g / 255, b / 255, a / 255)
 render = function(deltaTime)
-
-
-    resx,resy = game.GetResolution();
-    gfx.BeginPath();
-    gfx.TextAlign(TEXT_ALIGN_CENTER + TEXT_ALIGN_MIDDLE);
-    gfx.FontSize(40);
-    gfx.ImageRect(0, 0, resx, resy, backgroundImage, 1, 0);
+    timer = timer + deltaTime * 0.35
+    resx,resy = game.GetResolution()
+    bgMesh:SetParam("timer", timer)
+    bgMesh:SetParam("scale", math.max(resx, resy))
+    bgMesh:Draw()
+    gfx.ForceRender()
 end

--- a/bin/skins/Default/shaders/songSelBack.fs
+++ b/bin/skins/Default/shaders/songSelBack.fs
@@ -1,0 +1,14 @@
+#ifdef EMBEDDED
+varying vec2 fsTex;
+#else
+#extension GL_ARB_separate_shader_objects : enable
+layout(location=1) in vec2 fsTex;
+layout(location=0) out vec4 target;
+#endif
+
+uniform vec4 color;
+
+void main()
+{
+	target = color * pow(length(fsTex), 2.0) * 0.8;
+}

--- a/bin/skins/Default/shaders/songSelBack.vs
+++ b/bin/skins/Default/shaders/songSelBack.vs
@@ -1,0 +1,41 @@
+#ifdef EMBEDDED
+attribute vec2 inPos;
+attribute vec2 inTex;
+varying vec2 fsTex;
+#else
+#extension GL_ARB_separate_shader_objects : enable
+layout(location=0) in vec2 inPos;
+layout(location=1) in vec2 inTex;
+
+out gl_PerVertex
+{
+	vec4 gl_Position;
+};
+layout(location=1) out vec2 fsTex;
+#endif
+
+uniform mat4 proj;
+uniform mat4 world;
+uniform float scale;
+uniform float timer;
+uniform float seed;
+float random (vec2 st) {
+    return fract(sin(dot(st.xy,
+                         vec2(12.9898,78.233)))*
+        43758.5453123);
+}
+
+void main()
+{
+    vec2 seeded = inPos + vec2(seed);
+    float rand = random(seeded) * 1000.;
+    float rand2 = random(seeded * 2.0);
+    float rand3 = random(seeded * 3.0);
+    fsTex = vec2(pow(rand3, 0.5));
+    float offscale = scale / 1920.;
+    float size = 65. * offscale;
+    vec2 offset = vec2(cos(rand + timer * rand3 * 1.8), sin(rand + timer * rand2 * 2.)) * size;
+    //offset.x = 0.;
+    //offset.y = 0.;
+	gl_Position = proj * world * vec4(inPos.xy * scale * 1.2 + offset - size * 4.0, 0, 1);
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -101,3 +101,15 @@ add_library(GLEW
 # GLEW is included statically and also doesn't need GLU(Which doesn't even exist on linux)
 target_compile_definitions(GLEW PUBLIC -DGLEW_NO_GLU -DGLEW_STATIC)
 target_include_directories(GLEW PUBLIC glew/include)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(cpr PRIVATE /MP)
+    target_compile_options(discord-rpc PRIVATE /MP)
+    target_compile_options(GLEW PRIVATE /MP)
+    target_compile_options(lua PRIVATE /MP)
+    target_compile_options(minimp3 PRIVATE /MP)
+    target_compile_options(nanovg PRIVATE /MP)
+    target_compile_options(soundtouch PRIVATE /MP)
+    target_compile_options(sqlite3 PRIVATE /MP)
+endif(MSVC)


### PR DESCRIPTION
- Color settings and enum settings made sure not to be clipped because of insufficient scroll area
- Previously hidden fullscreen setting added to settings page
- Game window position now saved
- Window outside of monitor display region now fixed according to the setting `AdjustWindowPositionOnStartup` (on by default)
    - It works a little bit annoyingly when the window was maximized before, due to different border size, but otherwise works fine.
    - The annoying behavior is not a regression (same thing happens on `master` branch of USC)
- Settings renaming and relocations
    - "Display" renamed to "Visual" to reduce confusion between it with systems graphic settings
    - Offset settings moved from "Input" to "Game"
    - Other minor movements
- Out-of-bounds enum settings now shown to be out-of-bound (also related to the next fix)
- Fixes #439: slightly more detailed error messages
- When binding controller buttons, the escape key will cancel the binding. (It's unfortunate that the same can't be done for keyboard key binding screen...)
- Adjusted font baking algorithm so that required texture size for fallback font is reduced (32768 to 8192)
    - Any GPU supporting DirectX 10 should be able to bake the font texture now.
    - Partial baking support: if supported texture size is not big enough, only hiragana/katakana characters are baked.
        - This requires only 1024 x 1024 px texture support; any device supporting OpenGL ES 3.0 should be able to handle this.
- Same for multiplayer chat, but partial baking is not supported (not a big problem as required texture size is still reduced)