### PR TITLE
Add input offset when updating lasers

### DIFF
--- a/Beatmap/src/MapDatabase.cpp
+++ b/Beatmap/src/MapDatabase.cpp
@@ -414,7 +414,7 @@ public:
 			if (gotVersion == 18)
 			{
 				m_database.Exec("ALTER TABLE Scores ADD COLUMN window_slam INTEGER");
-				m_database.Exec("UPDATE Scores SET window_miss=75");
+				m_database.Exec("UPDATE Scores SET window_slam=84");
 				gotVersion = 19;
 			}
 			m_database.Exec(Utility::Sprintf("UPDATE Database SET `version`=%d WHERE `rowid`=1", m_version));

--- a/Main/include/HitStat.hpp
+++ b/Main/include/HitStat.hpp
@@ -73,7 +73,7 @@ struct HitWindow
 	MapTime good = 92;
 	MapTime hold = 138;
 	MapTime miss = 250;
-	MapTime slam = 75;
+	MapTime slam = 84;
 
 	static const HitWindow NORMAL;
 	static const HitWindow HARD;

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1115,7 +1115,7 @@ bool Scoring::m_IsRoot(const HoldObjectState* hold) const
 
 void Scoring::m_UpdateLasers(float deltaTime)
 {
-	MapTime mapTime = m_playback->GetLastTime();
+	MapTime mapTime = m_playback->GetLastTime() + m_inputOffset;
 	bool currentlySlamNextSegmentStraight[2] = { false };
 	// Check for new laser segments in laser queue
 	for (auto it = m_laserSegmentQueue.begin(); it != m_laserSegmentQueue.end();)


### PR DESCRIPTION
Laser logic currently assumes that ticks are aligned with the laser objects. Input offset causes this assumption to fail since input offset is applied to ticks but not laser segments.