### PR TITLE
Bumped up to C++17 and enabled /MP for all projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             - name: cmake
               run: cmake -DCMAKE_BUILD_TYPE=Release .
             - name: make
-              run: make
+              run: make -j
             - name: Prepare for bundling AppImage
               run: |
                 sudo apt-get install appstream
@@ -91,7 +91,7 @@ jobs:
             - name: cmake
               run: cmake . -DLibArchive_LIBRARY=/usr/local/opt/libarchive/lib/libarchive.dylib -DLibArchive_INCLUDE_DIR=/usr/local/opt/libarchive/include -DCMAKE_BUILD_TYPE=Release
             - name: make
-              run: make
+              run: make -j
             - name: Upload artifact
               uses: actions/upload-artifact@master
               with:

--- a/Audio/CMakeLists.txt
+++ b/Audio/CMakeLists.txt
@@ -60,3 +60,8 @@ target_link_libraries(Audio ${OGG_LIBRARIES})
 target_link_libraries(Audio ${Vorbis_LIBRARIES})
 
 target_link_libraries(Audio cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Audio PRIVATE /MP)
+endif(MSVC)

--- a/Beatmap/CMakeLists.txt
+++ b/Beatmap/CMakeLists.txt
@@ -24,7 +24,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${BEATMAP_SRC}" ${PCH_SRC})
 
 add_library(Beatmap ${BEATMAP_SRC} ${PCH_FILES})
-target_compile_features(Beatmap PUBLIC cxx_std_14)
+target_compile_features(Beatmap PUBLIC cxx_std_17)
 target_include_directories(Beatmap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Beatmap PRIVATE
     ${INCROOT}

--- a/Beatmap/CMakeLists.txt
+++ b/Beatmap/CMakeLists.txt
@@ -42,3 +42,8 @@ target_link_libraries(Beatmap sqlite3)
 target_link_libraries(Beatmap nlohmann_json)
 
 target_link_libraries(Beatmap cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Beatmap PRIVATE /MP)
+endif(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,5 +136,4 @@ if(MSVC)
     set_target_properties(Tests.Shared PROPERTIES FOLDER "Tests")
     set_target_properties(Tests.Game PROPERTIES FOLDER "Tests")
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,4 +136,5 @@ if(MSVC)
     set_target_properties(Tests.Shared PROPERTIES FOLDER "Tests")
     set_target_properties(Tests.Game PROPERTIES FOLDER "Tests")
 
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif(MSVC)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -37,3 +37,8 @@ target_link_libraries(GUI Graphics)
 target_link_libraries(GUI lua)
 
 target_link_libraries(GUI cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(GUI PRIVATE /MP)
+endif(MSVC)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -22,7 +22,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${GUI_SRC}" ${PCH_SRC})
 
 add_library(GUI ${GUI_SRC} ${PCH_FILES})
-target_compile_features(GUI PUBLIC cxx_std_14)
+target_compile_features(GUI PUBLIC cxx_std_17)
 target_include_directories(GUI PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(GUI PRIVATE
     ${SRCROOT}

--- a/Graphics/CMakeLists.txt
+++ b/Graphics/CMakeLists.txt
@@ -22,7 +22,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${GRAPHICS_SRC}" ${PCH_SRC})
 
 add_library(Graphics ${GRAPHICS_SRC} ${PCH_FILES})
-target_compile_features(Graphics PUBLIC cxx_std_14)
+target_compile_features(Graphics PUBLIC cxx_std_17)
 target_include_directories(Graphics PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Graphics PRIVATE
     ${INCROOT}

--- a/Graphics/CMakeLists.txt
+++ b/Graphics/CMakeLists.txt
@@ -58,3 +58,8 @@ if(UNIX)
 endif(UNIX)
 
 target_link_libraries(Graphics cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Graphics PRIVATE /MP)
+endif(MSVC)

--- a/Main/CMakeLists.txt
+++ b/Main/CMakeLists.txt
@@ -71,11 +71,13 @@ endif(GIT_FOUND)
 
 set_output_postfixes(usc-game)
 
-# Target subsystem on windows, set debugging folder
 if(MSVC)
-    set_target_properties(usc-game PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS /DEBUG")
+	# Set debugging folder
     set_target_properties(usc-game PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
-    target_compile_options(usc-game PRIVATE /EHsc)
+    target_compile_options(usc-game PRIVATE /EHsc /MP)
+	# Target subsystem on windows, enable multiprocess build and faster PDB gen
+	set_target_properties(usc-game PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:WINDOWS /DEBUG:FASTLINK")
+	set_target_properties(usc-game PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS /DEBUG:FULL")
 elseif(NOT APPLE)
     target_compile_options(usc-game PUBLIC -Wall -Wextra -Werror -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function)
 endif(MSVC)
@@ -99,13 +101,13 @@ target_include_directories(usc-game SYSTEM PRIVATE ${LibArchive_INCLUDE_DIRS})
 if(WIN32)
     target_link_libraries(usc-game
         optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/exception_handler_Release.lib
-	optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Release.lib
-	optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Release.lib
+		optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Release.lib
+		optimized ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Release.lib
     )
     target_link_libraries(usc-game
         debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/exception_handler_Debug.lib
-	debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Debug.lib
-	debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Debug.lib
+		debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/crash_generation_client_Debug.lib
+		debug ${PROJECT_SOURCE_DIR}/third_party/breakpad/common_Debug.lib
     )
     target_include_directories(usc-game PUBLIC ${PROJECT_SOURCE_DIR}/third_party/breakpad/include)
 endif()

--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -36,7 +36,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${SHARED_SRC}" ${PCH_SRC})
 
 add_library(Shared ${SHARED_SRC} ${PCH_FILES})
-target_compile_features(Shared PUBLIC cxx_std_14)
+target_compile_features(Shared PUBLIC cxx_std_17)
 target_include_directories(Shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Shared PRIVATE
     ${SRCROOT}

--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -53,3 +53,8 @@ target_link_libraries(Shared ${LibArchive_LIBRARIES})
 target_include_directories(Shared SYSTEM PRIVATE ${LibArchive_INCLUDE_DIRS})
 
 target_link_libraries(Shared cc-common)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(Shared PRIVATE /MP)
+endif(MSVC)

--- a/Shared/include/Shared/Buffer.hpp
+++ b/Shared/include/Shared/Buffer.hpp
@@ -14,9 +14,7 @@ public:
 	Buffer(Buffer&& rhs);
 	Buffer& operator=(Buffer&& rhs);
 	// Creates a new buffer from a string, without the terminating null character
-	Buffer(const char* string);
-	// Creates a new buffer with an initial size
-	Buffer(size_t initialSize);
+	explicit Buffer(const char* string);
 	// Creates a copy of this buffer
 	Buffer Copy() const;
 };

--- a/Shared/src/Buffer.cpp
+++ b/Shared/src/Buffer.cpp
@@ -1,10 +1,6 @@
 #include "stdafx.h"
 #include "Buffer.hpp"
 
-Buffer::Buffer(size_t initialSize)
-{
-	resize(initialSize);
-}
 Buffer::Buffer(const char* string)
 {
 	uint32 l = (uint32)strlen(string);

--- a/Tests.Game/CMakeLists.txt
+++ b/Tests.Game/CMakeLists.txt
@@ -18,7 +18,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${TESTS_GAME_SRC}" ${PCH_SRC})
 
 add_executable(Tests.Game ${TESTS_GAME_SRC} ${PCH_FILES})
-target_compile_features(Tests.Game PUBLIC cxx_std_14)
+target_compile_features(Tests.Game PUBLIC cxx_std_17)
 set_output_postfixes(Tests.Game)
 target_include_directories(Tests.Game PRIVATE
     ${SRCROOT}

--- a/Tests.Shared/CMakeLists.txt
+++ b/Tests.Shared/CMakeLists.txt
@@ -9,7 +9,7 @@ source_group("Sources" FILES ${SRC})
 set(MAIN_SRC ${SRC})
 
 add_executable(Tests.Shared ${MAIN_SRC})
-target_compile_features(Tests.Shared PUBLIC cxx_std_14)
+target_compile_features(Tests.Shared PUBLIC cxx_std_17)
 target_include_directories(Tests.Shared PRIVATE
     ${SRCROOT}
 )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -22,7 +22,7 @@ source_group("" FILES ${PCH_FILES})
 enable_precompiled_headers("${TESTS_SRC}" ${PCH_SRC})
 
 add_library(Tests ${TESTS_SRC} ${PCH_FILES})
-target_compile_features(Tests PUBLIC cxx_std_14)
+target_compile_features(Tests PUBLIC cxx_std_17)
 # Public include paths for library
 target_include_directories(Tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(Tests PRIVATE

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -101,3 +101,15 @@ add_library(GLEW
 # GLEW is included statically and also doesn't need GLU(Which doesn't even exist on linux)
 target_compile_definitions(GLEW PUBLIC -DGLEW_NO_GLU -DGLEW_STATIC)
 target_include_directories(GLEW PUBLIC glew/include)
+
+# Enable multiprocess compiling
+if(MSVC)
+    target_compile_options(cpr PRIVATE /MP)
+    target_compile_options(discord-rpc PRIVATE /MP)
+    target_compile_options(GLEW PRIVATE /MP)
+    target_compile_options(lua PRIVATE /MP)
+    target_compile_options(minimp3 PRIVATE /MP)
+    target_compile_options(nanovg PRIVATE /MP)
+    target_compile_options(soundtouch PRIVATE /MP)
+    target_compile_options(sqlite3 PRIVATE /MP)
+endif(MSVC)


### PR DESCRIPTION
Compile time on a 6-core 12-thread CPU (very non-scientific; ran each twice in a row and used later value to reduce deviations caused by file caching):
- Debug: **1m 23s** to **37s**
- Release: **1m 50s** to **55s**

Sadly, CI doesn't seem to be affected by this.

Forgot to add /MP for test projects but it doesn't matter a lot.