### PR TITLE
I18N support

### DIFF
--- a/Main/include/BaseGameSettingsDialog.hpp
+++ b/Main/include/BaseGameSettingsDialog.hpp
@@ -18,7 +18,7 @@ class BaseGameSettingsDialog
 public:
     typedef struct SettingData
     {
-        SettingData(const String& name, SettingType type) : name(name), type(type) {}
+        SettingData(const std::string_view& name, SettingType type) : name(name), type(type) {}
 
         String name;
         SettingType type;
@@ -93,16 +93,16 @@ protected:
     virtual void InitTabs() = 0;
     virtual void OnAdvanceTab() {};
 
-    Setting CreateBoolSetting(GameConfigKeys key, String name);
-    Setting CreateIntSetting(GameConfigKeys key, String name, Vector2i range, int step = 1);
-    Setting CreateFloatSetting(GameConfigKeys key, String name, Vector2 range, float mult = 1.0f);
+    Setting CreateBoolSetting(GameConfigKeys key, std::string_view name);
+    Setting CreateIntSetting(GameConfigKeys key, std::string_view name, Vector2i range, int step = 1);
+    Setting CreateFloatSetting(GameConfigKeys key, std::string_view name, Vector2 range, float mult = 1.0f);
 
-    Setting CreateBoolSetting(String label, bool& val);
-    Setting CreateIntSetting(String label, int& val, Vector2i range, int step = 1);
-    Setting CreateButton(String label, std::function<void(const BaseGameSettingsDialog::SettingData&)>&& callback);
+    Setting CreateBoolSetting(std::string_view label, bool& val);
+    Setting CreateIntSetting(std::string_view label, int& val, Vector2i range, int step = 1);
+    Setting CreateButton(std::string_view label, std::function<void(const BaseGameSettingsDialog::SettingData&)>&& callback);
 
     template <typename EnumClass>
-    Setting CreateEnumSetting(GameConfigKeys key, String name);
+    Setting CreateEnumSetting(GameConfigKeys key, std::string_view name);
 
     inline int GetCurrentTab() const { return m_currentTab; }
     inline void SetCurrentTab(int tabIndex) { m_currentTab = tabIndex; }
@@ -138,7 +138,7 @@ private:
 };
 
 template <typename EnumClass>
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateEnumSetting(GameConfigKeys key, String name)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateEnumSetting(GameConfigKeys key, std::string_view name)
 {
     Setting s = std::make_unique<SettingData>(name, SettingType::Enum);
 

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -177,6 +177,8 @@ DefineEnum(GameConfigKeys,
 
 		   CurrentProfileName,
 
+		   Language,
+
 		   // Gameplay options
 		   GaugeType,
 		   MirrorChart,

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -32,7 +32,7 @@ protected:
 class BasicWindow : public BasicNuklearGui
 {
 public:
-	BasicWindow(String name) : m_name(name) {};
+	BasicWindow(std::string_view name) : m_name(name) {};
 	void Tick(float deltaTime) override;
 	void Render(float deltaTime) override;
 	bool OnKeyPressedConsume(SDL_Scancode code) override;
@@ -58,7 +58,7 @@ bool nk_edit_isfocused(struct nk_context* ctx);
 
 class BasicPrompt : public BasicWindow {
 public:
-	BasicPrompt(String title, String body, String submitText = "Submit")
+	BasicPrompt(std::string_view title, std::string_view body, std::string_view submitText = "Submit")
 		: BasicWindow(title), m_text(body), m_submitText(submitText) { };
 	bool Init() override;
 	virtual bool OnKeyPressedConsume(SDL_Scancode code) override;

--- a/Main/include/SettingsPage.hpp
+++ b/Main/include/SettingsPage.hpp
@@ -92,6 +92,7 @@ protected:
 	int SelectionInput(int val, const Vector<const char*>& options, const std::string_view& label);
 	bool SelectionSetting(GameConfigKeys key, const Vector<const char*>& options, const std::string_view& label);
 	bool StringSelectionSetting(GameConfigKeys key, const Vector<String>& options, const std::string_view& label);
+	bool StringSelectionSetting(GameConfigKeys key, const Vector<String>& values, const Vector<const char*>& labels, const std::string_view& label);
 
 	int IntInput(int val, const std::string_view& label, int min, int max, int step = 1, float perPixel = 1.0f);
 	bool IntSetting(GameConfigKeys key, const std::string_view& label, int min, int max, int step = 1, float perPixel = 1.0f);

--- a/Main/include/SongSort.hpp
+++ b/Main/include/SongSort.hpp
@@ -23,7 +23,7 @@ template<class ItemIndex>
 class ItemSort
 {
 	public:
-		ItemSort(String name, bool dir) : m_name(name),m_dir(dir) {};
+		ItemSort(const std::string_view& name, bool dir) : m_name(Utility::Sprintf((dir ? _("%s v") : _("%s ^")).data(), name.data())), m_dir(dir) {};
 		virtual ~ItemSort() = default;
 
 		virtual SortType GetType() const { return NO_SORT; };
@@ -40,7 +40,8 @@ using SongSort = ItemSort<SongSelectIndex>;
 class TitleSort : public SongSort
 {
 	public:
-		TitleSort(String name, bool dir) : SongSort(name, dir) {};
+		TitleSort(bool dir) : TitleSort(_("Title"), dir) {};
+		TitleSort(const std::string_view& name, bool dir) : SongSort(name, dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				SongSelectIndex>& collection) override;
 		virtual bool CompareSongs(const SongSelectIndex& song_a,
@@ -54,7 +55,7 @@ class TitleSort : public SongSort
 class ScoreSort : public TitleSort
 {
 	public:
-		ScoreSort(String name, bool dir) : TitleSort(name, dir) {};
+		ScoreSort(bool dir) : TitleSort(_("Score"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				SongSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -68,7 +69,7 @@ class ScoreSort : public TitleSort
 class DateSort : public TitleSort
 {
 	public:
-		DateSort(String name, bool dir) : TitleSort(name, dir) {};
+		DateSort(bool dir) : TitleSort(_("Date"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				SongSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -82,7 +83,7 @@ class DateSort : public TitleSort
 class ArtistSort : public TitleSort
 {
 	public:
-		ArtistSort(String name, bool dir) : TitleSort(name, dir) {};
+		ArtistSort(bool dir) : TitleSort(_("Artist"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				SongSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -96,7 +97,7 @@ class ArtistSort : public TitleSort
 class EffectorSort : public TitleSort
 {
 	public:
-		EffectorSort(String name, bool dir) : TitleSort(name, dir) {};
+		EffectorSort(bool dir) : TitleSort(_("Effector"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				SongSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -108,7 +109,7 @@ class EffectorSort : public TitleSort
 class ClearMarkSort : public TitleSort
 {
 	public:
-		ClearMarkSort(String name, bool dir) : TitleSort(name, dir) {};
+		ClearMarkSort(bool dir) : TitleSort(_("Badge"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				SongSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -124,7 +125,8 @@ using ChallengeSort = ItemSort<ChallengeSelectIndex>;
 class ChallengeTitleSort : public ChallengeSort
 {
 	public:
-		ChallengeTitleSort(String name, bool dir) : ChallengeSort(name, dir) {};
+		ChallengeTitleSort(bool dir) : ChallengeTitleSort(_("Title"), dir) {};
+		ChallengeTitleSort(const std::string_view& name, bool dir) : ChallengeSort(name, dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				ChallengeSelectIndex>& collection) override;
 		virtual bool CompareChallenges(const ChallengeSelectIndex& song_a,
@@ -138,7 +140,7 @@ class ChallengeTitleSort : public ChallengeSort
 class ChallengeDateSort : public ChallengeTitleSort
 {
 	public:
-		ChallengeDateSort(String name, bool dir) : ChallengeTitleSort(name, dir) {};
+		ChallengeDateSort(bool dir) : ChallengeTitleSort(_("Date"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				ChallengeSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -150,7 +152,7 @@ class ChallengeDateSort : public ChallengeTitleSort
 class ChallengeScoreSort : public ChallengeTitleSort
 {
 	public:
-		ChallengeScoreSort(String name, bool dir) : ChallengeTitleSort(name, dir) {};
+		ChallengeScoreSort(bool dir) : ChallengeTitleSort(_("Score"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				ChallengeSelectIndex>& collection) override;
 		SortType GetType() const override
@@ -162,7 +164,7 @@ class ChallengeScoreSort : public ChallengeTitleSort
 class ChallengeClearMarkSort : public ChallengeTitleSort
 {
 	public:
-		ChallengeClearMarkSort(String name, bool dir) : ChallengeTitleSort(name, dir) {};
+		ChallengeClearMarkSort(bool dir) : ChallengeTitleSort(_("Clear"), dir) {};
 		void SortInplace(Vector<uint32>& vec, const Map<int32,
 				ChallengeSelectIndex>& collection) override;
 		SortType GetType() const override

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -833,9 +833,7 @@ bool Application::m_Init()
 
 	// I18N
 	I18N::Get().Initialize("./translations");
-
-	// TODO: load from the config
-	I18N::Get().SetLanguage("ko");
+	I18N::Get().SetLanguage(g_gameConfig.GetString(GameConfigKeys::Language));
 
 	// Job sheduler
 	g_jobSheduler = new JobSheduler();

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -831,6 +831,12 @@ bool Application::m_Init()
 	if (!m_LoadConfig())
 		Log("Failed to load config file", Logger::Severity::Warning);
 
+	// I18N
+	I18N::Get().Initialize("./translations");
+
+	// TODO: load from the config
+	I18N::Get().SetLanguage("ko");
+
 	// Job sheduler
 	g_jobSheduler = new JobSheduler();
 
@@ -2511,6 +2517,9 @@ void Application::SetLuaBindings(lua_State *state)
 
 	//http
 	m_skinHttp.PushFunctions(state);
+
+	// i18n
+	I18N::Get().BindLua(state);
 }
 
 bool JacketLoadingJob::Run()

--- a/Main/src/BaseGameSettingsDialog.cpp
+++ b/Main/src/BaseGameSettingsDialog.cpp
@@ -145,7 +145,7 @@ bool BaseGameSettingsDialog::IsSelectionOnPressable()
     return currentSetting->type == SettingType::Button || currentSetting->type == SettingType::Boolean;
 }
 
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateFloatSetting(GameConfigKeys key, String name, Vector2 range, float mult)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateFloatSetting(GameConfigKeys key, std::string_view name, Vector2 range, float mult)
 {
     Setting s = std::make_unique<SettingData>(name, SettingType::Floating);
 
@@ -166,7 +166,7 @@ BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateFloatSetting(GameC
     return s;
 }
 
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateBoolSetting(String label, bool& val)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateBoolSetting(std::string_view label, bool& val)
 {
     Setting s = std::make_unique<SettingData>(label, SettingType::Boolean);
     
@@ -185,7 +185,7 @@ BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateBoolSetting(String
     return s;
 }
 
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateIntSetting(String label, int& val, Vector2i range, int step)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateIntSetting(std::string_view label, int& val, Vector2i range, int step)
 {
     Setting s = std::make_unique<SettingData>(label, SettingType::Integer);
 
@@ -208,7 +208,7 @@ BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateIntSetting(String 
     return s;
 }
 
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateButton(String label, std::function<void(const BaseGameSettingsDialog::SettingData &)>&& callback)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateButton(std::string_view label, std::function<void(const BaseGameSettingsDialog::SettingData &)>&& callback)
 {
     Setting s = std::make_unique<SettingData>(label, SettingType::Button);
     s->setter.AddLambda(std::move(callback));
@@ -216,7 +216,7 @@ BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateButton(String labe
     return s;
 }
 
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateIntSetting(GameConfigKeys key, String name, Vector2i range, int step)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateIntSetting(GameConfigKeys key, std::string_view name, Vector2i range, int step)
 {
     Setting s = std::make_unique<SettingData>(name, SettingType::Integer);
 
@@ -237,7 +237,7 @@ BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateIntSetting(GameCon
     return s;
 }
 
-BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateBoolSetting(GameConfigKeys key, String name)
+BaseGameSettingsDialog::Setting BaseGameSettingsDialog::CreateBoolSetting(GameConfigKeys key, std::string_view name)
 {
     Setting s = std::make_unique<SettingData>(name, SettingType::Boolean);
 

--- a/Main/src/ChallengeSelect.cpp
+++ b/Main/src/ChallengeSelect.cpp
@@ -622,14 +622,14 @@ public:
 	{
 		if (m_sorts.size() == 0)
 		{
-			m_sorts.Add(new ChallengeTitleSort("Title ^", false));
-			m_sorts.Add(new ChallengeTitleSort("Title v", true));
-			m_sorts.Add(new ChallengeScoreSort("Score ^", false));
-			m_sorts.Add(new ChallengeScoreSort("Score v", true));
-			m_sorts.Add(new ChallengeDateSort("Date ^", false));
-			m_sorts.Add(new ChallengeDateSort("Date v", true));
-			m_sorts.Add(new ChallengeClearMarkSort("Badge ^", false));
-			m_sorts.Add(new ChallengeClearMarkSort("Badge v", true));
+			m_sorts.Add(new ChallengeTitleSort(false));
+			m_sorts.Add(new ChallengeTitleSort(true));
+			m_sorts.Add(new ChallengeScoreSort(false));
+			m_sorts.Add(new ChallengeScoreSort(true));
+			m_sorts.Add(new ChallengeDateSort(false));
+			m_sorts.Add(new ChallengeDateSort(true));
+			m_sorts.Add(new ChallengeClearMarkSort(false));
+			m_sorts.Add(new ChallengeClearMarkSort(true));
 		}
 
 		CheckedLoad(m_lua = g_application->LoadScript("songselect/sortwheel"));

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -227,6 +227,8 @@ void GameConfig::InitDefaults()
 
 	Set(GameConfigKeys::CurrentProfileName, "Main");
 	Set(GameConfigKeys::UpdateChannel, "master");
+
+	Set(GameConfigKeys::Language, I18N::GetSystemLanguage());
 }
 
 void GameConfig::UpdateVersion()

--- a/Main/src/GameplaySettingsDialog.cpp
+++ b/Main/src/GameplaySettingsDialog.cpp
@@ -8,64 +8,63 @@
 void GameplaySettingsDialog::InitTabs()
 {
     Tab offsetTab = std::make_unique<TabData>();
-    offsetTab->name = "Offsets";
-    offsetTab->settings.push_back(CreateIntSetting(GameConfigKeys::GlobalOffset, "Global Offset", { -200, 200 }));
-    offsetTab->settings.push_back(CreateIntSetting(GameConfigKeys::InputOffset, "Input Offset", { -200, 200 }));
+    offsetTab->name = String(_("Offsets"));
+    offsetTab->settings.push_back(CreateIntSetting(GameConfigKeys::GlobalOffset, _("Global Offset"), { -200, 200 }));
+    offsetTab->settings.push_back(CreateIntSetting(GameConfigKeys::InputOffset, _("Input Offset"), { -200, 200 }));
     if (m_songSelectScreen != nullptr || m_multiPlayerScreen != nullptr)
     {
         offsetTab->settings.push_back(m_CreateSongOffsetSetting());
     }
     if (m_songSelectScreen != nullptr)
     {
-        offsetTab->settings.push_back(CreateButton("Compute Song Offset", [this](const auto&) { onPressComputeSongOffset.Call(); }));
+        offsetTab->settings.push_back(CreateButton(_("Compute Song Offset"), [this](const auto&) { onPressComputeSongOffset.Call(); }));
     }
 
     Tab speedTab = std::make_unique<TabData>();
-    speedTab->name = "HiSpeed";
-    speedTab->settings.push_back(CreateEnumSetting<Enum_SpeedMods>(GameConfigKeys::SpeedMod, "Speed Mod"));
-    speedTab->settings.push_back(CreateFloatSetting(GameConfigKeys::HiSpeed, "HiSpeed", { 0.1f, 16.f }));
-    speedTab->settings.push_back(CreateFloatSetting(GameConfigKeys::ModSpeed, "ModSpeed", { 50, 1500 }, 20.0f));
+    speedTab->name = String(_("HiSpeed"));
+    speedTab->settings.push_back(CreateEnumSetting<Enum_SpeedMods>(GameConfigKeys::SpeedMod, _("Speed Mod")));
+    speedTab->settings.push_back(CreateFloatSetting(GameConfigKeys::HiSpeed, _("HiSpeed"), { 0.1f, 16.f }));
+    speedTab->settings.push_back(CreateFloatSetting(GameConfigKeys::ModSpeed, _("ModSpeed"), { 50, 1500 }, 20.0f));
 
     Tab gameTab = std::make_unique<TabData>();
-    gameTab->name = "Game";
+    gameTab->name = String(_("Game"));
     // For now we can't set these like this in mp
     if (m_multiPlayerScreen == nullptr)
     {
-        gameTab->settings.push_back(CreateEnumSetting<Enum_GaugeTypes>(GameConfigKeys::GaugeType, "Gauge"));
-		gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::BackupGauge, "Backup Gauge"));
-		gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::RandomizeChart, "Random"));
-		gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::MirrorChart, "Mirror"));
+        gameTab->settings.push_back(CreateEnumSetting<Enum_GaugeTypes>(GameConfigKeys::GaugeType, _("Gauge")));
+		gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::BackupGauge, _("Backup Gauge")));
+		gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::RandomizeChart, _("Random")));
+		gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::MirrorChart, _("Mirror")));
 	}
-    gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::DisableBackgrounds, "Hide Backgrounds"));
-    gameTab->settings.push_back(CreateEnumSetting<Enum_ScoreDisplayModes>(GameConfigKeys::ScoreDisplayMode, "Score Display"));
+    gameTab->settings.push_back(CreateBoolSetting(GameConfigKeys::DisableBackgrounds, _("Hide Backgrounds")));
+    gameTab->settings.push_back(CreateEnumSetting<Enum_ScoreDisplayModes>(GameConfigKeys::ScoreDisplayMode, _("Score Display")));
     if (m_songSelectScreen != nullptr)
     {
-        gameTab->settings.push_back(CreateButton("Autoplay", [this](const auto&) { onPressAutoplay.Call(); }));
-        gameTab->settings.push_back(CreateButton("Practice", [this](const auto&) { onPressPractice.Call(); }));
+        gameTab->settings.push_back(CreateButton(_("Autoplay"), [this](const auto&) { onPressAutoplay.Call(); }));
+        gameTab->settings.push_back(CreateButton(_("Practice"), [this](const auto&) { onPressPractice.Call(); }));
     }
 
     Tab hidsudTab = std::make_unique<TabData>();
-    hidsudTab->name = "Hid/Sud";
-    hidsudTab->settings.push_back(CreateBoolSetting(GameConfigKeys::EnableHiddenSudden, "Enable Hidden / Sudden"));
-    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::HiddenCutoff, "Hidden Cutoff", { 0.f, 1.f }));
-    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::HiddenFade, "Hidden Fade", { 0.f, 1.f }));
-    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::SuddenCutoff, "Sudden Cutoff", { 0.f, 1.f }));
-    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::SuddenFade, "Sudden Fade", { 0.f, 1.f }));
-    hidsudTab->settings.push_back(CreateBoolSetting(GameConfigKeys::ShowCover, "Show Track Cover"));
+    hidsudTab->name = String(_("Hid/Sud"));
+    hidsudTab->settings.push_back(CreateBoolSetting(GameConfigKeys::EnableHiddenSudden, _("Enable Hidden / Sudden")));
+    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::HiddenCutoff, _("Hidden Cutoff"), { 0.f, 1.f }));
+    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::HiddenFade, _("Hidden Fade"), { 0.f, 1.f }));
+    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::SuddenCutoff, _("Sudden Cutoff"), { 0.f, 1.f }));
+    hidsudTab->settings.push_back(CreateFloatSetting(GameConfigKeys::SuddenFade, _("Sudden Fade"), { 0.f, 1.f }));
+    hidsudTab->settings.push_back(CreateBoolSetting(GameConfigKeys::ShowCover, _("Show Track Cover")));
 
     Tab judgeWindowTab = std::make_unique<TabData>();
-    judgeWindowTab->name = "Judgement";
-    judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowPerfect, "Crit Window", { 0, HitWindow::NORMAL.perfect }));
-    judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowGood, "Near Window", { 0, HitWindow::NORMAL.good }));
-    judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowHold, "Hold Window", { 0, HitWindow::NORMAL.hold }));
-	judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowSlam, "Slam Window", { 0, HitWindow::NORMAL.slam }));
-    judgeWindowTab->settings.push_back(CreateButton("Set to NORMAL", [](const auto&) { HitWindow::NORMAL.SaveConfig(); }));
-    judgeWindowTab->settings.push_back(CreateButton("Set to HARD", [](const auto&) { HitWindow::HARD.SaveConfig(); }));
+    judgeWindowTab->name = String(_("Judgement"));
+    judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowPerfect, _("Crit Window"), { 0, HitWindow::NORMAL.perfect }));
+    judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowGood, _("Near Window"), { 0, HitWindow::NORMAL.good }));
+    judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowHold, _("Hold Window"), { 0, HitWindow::NORMAL.hold }));
+	judgeWindowTab->settings.push_back(CreateIntSetting(GameConfigKeys::HitWindowSlam, _("Slam Window"), { 0, HitWindow::NORMAL.slam }));
+    judgeWindowTab->settings.push_back(CreateButton(_("Set to NORMAL"), [](const auto&) { HitWindow::NORMAL.SaveConfig(); }));
+    judgeWindowTab->settings.push_back(CreateButton(_("Set to HARD"), [](const auto&) { HitWindow::HARD.SaveConfig(); }));
 
 
     Tab profileWindowTab = std::make_unique<TabData>();
-    profileWindowTab->name = "Profiles";
-
+    profileWindowTab->name = String(_("Profiles"));
 
 	profileWindowTab->settings.push_back(m_CreateProfileSetting("Main"));
 	{
@@ -87,11 +86,11 @@ void GameplaySettingsDialog::InitTabs()
     // For now we can't set these like this in mp
     if (m_multiPlayerScreen == nullptr)
     {
-        profileWindowTab->settings.push_back(CreateButton("Create Profile", [this_p](const auto&) {
+        profileWindowTab->settings.push_back(CreateButton(_("Create Profile"), [this_p](const auto&) {
             BasicPrompt* w = new BasicPrompt(
-                "Create New Profile",
-                "Enter name for profile\n(This will copy your current profile)",
-                "Create Profile");
+                _("Create New Profile"),
+                _("Enter name for profile\n(This will copy your current profile)"),
+                _("Create Profile"));
             w->OnResult.AddLambda([this_p](bool valid, const char* data) {
                 if (!valid || strlen(data) == 0)
                     return;
@@ -146,7 +145,7 @@ void GameplaySettingsDialog::InitTabs()
             w->Focus();
             g_application->AddTickable(w);
             }));
-		profileWindowTab->settings.push_back(CreateButton("Manage Profiles", [this_p](const auto&) {
+		profileWindowTab->settings.push_back(CreateButton(_("Manage Profiles"), [this_p](const auto&) {
 			if (!Path::IsDirectory(Path::Absolute("profiles")))
 				Path::CreateDir(Path::Absolute("profiles"));
 			Path::ShowInFileBrowser(Path::Absolute("profiles"));
@@ -170,8 +169,8 @@ void GameplaySettingsDialog::OnAdvanceTab()
 
 GameplaySettingsDialog::Setting GameplaySettingsDialog::m_CreateSongOffsetSetting()
 {
-    Setting songOffsetSetting = std::make_unique<SettingData>("Song Offset", SettingType::Integer);
-    songOffsetSetting->name = "Song Offset";
+    Setting songOffsetSetting = std::make_unique<SettingData>(_("Song Offset"), SettingType::Integer);
+    songOffsetSetting->name = String(_("Song Offset"));
     songOffsetSetting->type = SettingType::Integer;
     songOffsetSetting->intSetting.val = 0;
     songOffsetSetting->intSetting.min = -200;

--- a/Main/src/SettingsPage.cpp
+++ b/Main/src/SettingsPage.cpp
@@ -202,6 +202,28 @@ bool SettingsPage::StringSelectionSetting(GameConfigKeys key, const Vector<Strin
 	}
 	return false;
 }
+
+bool SettingsPage::StringSelectionSetting(GameConfigKeys key, const Vector<String>& values, const Vector<const char*>& labels, const std::string_view& label)
+{
+	assert(values.size() >= labels.size());
+
+	String value = g_gameConfig.GetString(key);
+	int selection = 0;
+
+	const auto stringSearch = std::find(values.begin(), values.end(), value);
+	if (stringSearch != values.end())
+	{
+		selection = static_cast<int>(stringSearch - values.begin());
+	}
+
+	const int newSelection = SelectionInput(selection, labels, label);
+
+	if (newSelection != selection) {
+		g_gameConfig.Set(key, values[newSelection]);
+		return true;
+	}
+	return false;
+}
 	
 int SettingsPage::IntInput(int val, const std::string_view& label, int min, int max, int step, float perPixel)
 {

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -665,6 +665,15 @@ protected:
 		{
 			m_channels.insert(m_channels.begin(), channel);
 		}
+
+		m_languages.clear();
+		m_languageNames.clear();
+
+		for (const auto& pair : I18N::SUPPORTED_LANGUAGE_NAMES)
+		{
+			m_languages.Add(pair.first);
+			m_languageNames.Add(pair.second);
+		}
 	}
 
 	void Save() override
@@ -677,6 +686,9 @@ protected:
 
 	const Vector<const char*> m_aaModes = { "Off", "2x MSAA", "4x MSAA", "8x MSAA", "16x MSAA" };
 	Vector<String> m_channels;
+
+	Vector<String> m_languages;
+	Vector<const char*> m_languageNames;
 
 protected:
 	void RenderContents() override
@@ -704,6 +716,9 @@ protected:
 		SetApply(ToggleSetting(GameConfigKeys::VSync, "VSync"));
 		SetApply(ToggleSetting(GameConfigKeys::ShowFps, "Show FPS"));
 
+		SectionHeader("Language");
+		RenderLanguageSelection();
+
 		SectionHeader("Update");
 
 		ToggleSetting(GameConfigKeys::CheckForUpdates, "Check for updates on startup");
@@ -720,6 +735,19 @@ protected:
 		if (applySettings)
 		{
 			g_application->ApplySettings();
+		}
+	}
+
+private:
+	void RenderLanguageSelection()
+	{
+		const int oldVal = I18N::GetLanguageIndexFromNamesMap(g_gameConfig.GetString(GameConfigKeys::Language));
+		const int newVal = SelectionInput(oldVal, m_languageNames, "Language:");
+		if (newVal != oldVal && newVal >= 0 && newVal < static_cast<int>(m_languages.size()))
+		{
+			const String& newLanguage = m_languages[newVal];
+			g_gameConfig.Set(GameConfigKeys::Language, newLanguage);
+			I18N::Get().SetLanguage(newLanguage);
 		}
 	}
 };

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -839,18 +839,18 @@ public:
 	{
 		if (m_sorts.size() == 0)
 		{
-			m_sorts.Add(new TitleSort("Title ^", false));
-			m_sorts.Add(new TitleSort("Title v", true));
-			m_sorts.Add(new ScoreSort("Score ^", false));
-			m_sorts.Add(new ScoreSort("Score v", true));
-			m_sorts.Add(new DateSort("Date ^", false));
-			m_sorts.Add(new DateSort("Date v", true));
-			m_sorts.Add(new ClearMarkSort("Badge ^", false));
-			m_sorts.Add(new ClearMarkSort("Badge v", true));
-			m_sorts.Add(new ArtistSort("Artist ^", false));
-			m_sorts.Add(new ArtistSort("Artist v", true));
-			m_sorts.Add(new EffectorSort("Effector ^", false));
-			m_sorts.Add(new EffectorSort("Effector v", true));
+			m_sorts.Add(new TitleSort(false));
+			m_sorts.Add(new TitleSort(true));
+			m_sorts.Add(new ScoreSort(false));
+			m_sorts.Add(new ScoreSort(true));
+			m_sorts.Add(new DateSort(false));
+			m_sorts.Add(new DateSort(true));
+			m_sorts.Add(new ClearMarkSort(false));
+			m_sorts.Add(new ClearMarkSort(true));
+			m_sorts.Add(new ArtistSort(false));
+			m_sorts.Add(new ArtistSort(true));
+			m_sorts.Add(new EffectorSort(false));
+			m_sorts.Add(new EffectorSort(true));
 		}
 
 		CheckedLoad(m_lua = g_application->LoadScript("songselect/sortwheel"));

--- a/Main/src/TitleScreen.cpp
+++ b/Main/src/TitleScreen.cpp
@@ -24,6 +24,7 @@ class TitleScreen_Impl : public TitleScreen
 private:
 	lua_State* m_lua = nullptr;
 	LuaBindable* m_luaBinds = nullptr;
+	String m_currLanguage = "";
 
 	void Exit()
 	{
@@ -148,6 +149,9 @@ public:
 		lua_settop(m_lua, 0);
 		g_gameWindow->OnMousePressed.Add(this, &TitleScreen_Impl::MousePressed);
 		g_input.OnButtonPressed.Add(this, &TitleScreen_Impl::m_OnButtonPressed);
+
+		m_currLanguage = g_gameConfig.GetString(GameConfigKeys::Language);
+
 		return true;
 	}
 	
@@ -186,16 +190,23 @@ public:
 			assert(false);
 		}
 	}
+
 	virtual void OnSuspend()
 	{
 	}
+
 	virtual void OnRestore()
 	{
 		g_gameWindow->SetCursorVisible(true);
 		g_application->DiscordPresenceMenu("Title Screen");
+
+		if (m_currLanguage != g_gameConfig.GetString(GameConfigKeys::Language))
+		{
+			m_currLanguage = g_gameConfig.GetString(GameConfigKeys::Language);
+
+			g_application->ReloadScript("titlescreen", m_lua);
+		}
 	}
-
-
 };
 
 TitleScreen* TitleScreen::Create()

--- a/Shared/include/Shared/I18N.hpp
+++ b/Shared/include/Shared/I18N.hpp
@@ -10,22 +10,29 @@ class I18N final
 public:
 	static inline I18N& Get() { return m_instance; }
 
+	static String GetSystemLanguage();
+
 	void Initialize(const String& dirPath);
 	void SetLanguage(const String& lang);
 
 	std::string_view GetText(const std::string_view& msg_id) const;
 	void BindLua(struct lua_State* L);
 
+	const static std::map<String, const char*> SUPPORTED_LANGUAGE_NAMES;
+	static int GetLanguageIndexFromNamesMap(const String& lang);
+
 private:
 	static int Lua_GetText(struct lua_State* L);
 
 	static I18N m_instance;
 
+	String GetFilePath(const String& lang) const;
+
 	Vector<POFile> m_files;
 	String m_dirPath;
 
-	Map<String, decltype(m_files)::iterator> m_filesByLanguage;
-	decltype(m_files)::iterator m_currFile;
+	Map<String, size_t> m_filesByLanguage;
+	size_t m_currFile;
 };
 
 inline std::string_view _(const std::string_view& msg_id)

--- a/Shared/include/Shared/I18N.hpp
+++ b/Shared/include/Shared/I18N.hpp
@@ -16,7 +16,7 @@ public:
 	void SetLanguage(const String& lang);
 
 	std::string_view GetText(const std::string_view& msg_id) const;
-	std::string_view GetText(const std::string_view& msg_ctxt, const std::string_view& msg_id) const;
+	std::string_view GetText(const std::string_view& msg_id, const std::string_view& msg_ctxt) const;
 
 	void BindLua(struct lua_State* L);
 
@@ -42,7 +42,7 @@ inline std::string_view _(const std::string_view& msg_id)
 	return I18N::Get().GetText(msg_id);
 }
 
-inline std::string_view _p(const std::string_view& msg_ctxt, const std::string_view& msg_id)
+inline std::string_view _(const std::string_view& msg_id, const std::string_view& msg_ctxt)
 {
-	return I18N::Get().GetText(msg_ctxt, msg_id);
+	return I18N::Get().GetText(msg_id, msg_ctxt);
 }

--- a/Shared/include/Shared/I18N.hpp
+++ b/Shared/include/Shared/I18N.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "POFile.hpp"
+#include "Map.hpp"
+#include "Vector.hpp"
+
+/// Class for managing i18n stuff
+class I18N final
+{
+public:
+	static inline I18N& Get() { return m_instance; }
+
+	void Initialize(const String& dirPath);
+	void SetLanguage(const String& lang);
+
+	std::string_view GetText(const std::string_view& msg_id) const;
+	void BindLua(struct lua_State* L);
+
+private:
+	static int Lua_GetText(struct lua_State* L);
+
+	static I18N m_instance;
+
+	Vector<POFile> m_files;
+	String m_dirPath;
+
+	Map<String, decltype(m_files)::iterator> m_filesByLanguage;
+	decltype(m_files)::iterator m_currFile;
+};
+
+inline std::string_view _(const std::string_view& msg_id)
+{
+	return I18N::Get().GetText(msg_id);
+}

--- a/Shared/include/Shared/I18N.hpp
+++ b/Shared/include/Shared/I18N.hpp
@@ -16,6 +16,8 @@ public:
 	void SetLanguage(const String& lang);
 
 	std::string_view GetText(const std::string_view& msg_id) const;
+	std::string_view GetText(const std::string_view& msg_ctxt, const std::string_view& msg_id) const;
+
 	void BindLua(struct lua_State* L);
 
 	const static std::map<String, const char*> SUPPORTED_LANGUAGE_NAMES;
@@ -38,4 +40,9 @@ private:
 inline std::string_view _(const std::string_view& msg_id)
 {
 	return I18N::Get().GetText(msg_id);
+}
+
+inline std::string_view _p(const std::string_view& msg_ctxt, const std::string_view& msg_id)
+{
+	return I18N::Get().GetText(msg_ctxt, msg_id);
 }

--- a/Shared/include/Shared/POFile.hpp
+++ b/Shared/include/Shared/POFile.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "String.hpp"
+
+/// Container for PO file (of `gettext`) contents.
+/// For the main project, do not use this; use the I18N class instead.
+class POFile
+{
+public:
+	struct Entry
+	{
+		String m_context;
+		String m_value;
+	};
+
+	POFile(const String& path);
+	POFile(class File& file);
+
+	std::string_view GetText(const std::string_view& msg_id) const;
+
+	inline const String& GetLanguage() const { return m_language; }
+
+private:
+	void Parse(class File& file);
+	void Parse(class FileReader& reader);
+
+	String m_language;
+	std::multimap<String, Entry, std::less<>> m_contents;
+};

--- a/Shared/include/Shared/POFile.hpp
+++ b/Shared/include/Shared/POFile.hpp
@@ -17,6 +17,7 @@ public:
 	POFile(class File& file);
 
 	std::string_view GetText(const std::string_view& msg_id) const;
+	std::string_view GetText(const std::string_view& msg_ctxt, const std::string_view& msg_id) const;
 
 	inline const String& GetLanguage() const { return m_language; }
 

--- a/Shared/include/Shared/POFile.hpp
+++ b/Shared/include/Shared/POFile.hpp
@@ -17,7 +17,7 @@ public:
 	POFile(class File& file);
 
 	std::string_view GetText(const std::string_view& msg_id) const;
-	std::string_view GetText(const std::string_view& msg_ctxt, const std::string_view& msg_id) const;
+	std::string_view GetText(const std::string_view& msg_id, const std::string_view& msg_ctxt) const;
 
 	inline const String& GetLanguage() const { return m_language; }
 

--- a/Shared/include/Shared/Shared.hpp
+++ b/Shared/include/Shared/Shared.hpp
@@ -33,3 +33,6 @@
 #include "Rect.hpp"
 #include "Margin.hpp"
 #include "Random.hpp"
+
+// I18N
+#include "I18N.hpp"

--- a/Shared/include/Shared/String.hpp
+++ b/Shared/include/Shared/String.hpp
@@ -38,8 +38,8 @@ public:
 	bool Split(const StringBase& delim, StringBase* l, StringBase* r) const;
 	bool SplitLast(const StringBase& delim, StringBase* l, StringBase* r) const;
 	Vector<StringBase> Explode(const StringBase& delim, bool keepEmpty = true) const;
-	void TrimFront(T c);
-	void TrimBack(T c);
+	void TrimFront(T c = ' ');
+	void TrimBack(T c = ' ');
 	void Trim(T c = ' ');
 	T* GetData();
 	const T* GetData() const;
@@ -224,8 +224,8 @@ void StringBase<T>::TrimBack(T c)
 template<typename T>
 void StringBase<T>::Trim(T c)
 {
-	TrimFront(c);
 	TrimBack(c);
+	TrimFront(c);
 }
 template<typename T>
 T* StringBase<T>::GetData()

--- a/Shared/src/I18N.cpp
+++ b/Shared/src/I18N.cpp
@@ -5,52 +5,151 @@
 
 I18N I18N::m_instance;
 
+const std::map<String, const char*> I18N::SUPPORTED_LANGUAGE_NAMES = {
+	{"en", "English"},
+	{"ko", "Korean"},
+};
+
+static constexpr char ToLower(char ch)
+{
+	return 'A' <= ch && ch <= 'Z' ? ch + ('a' - 'A') : ch;
+}
+
+static constexpr char ToUpper(char ch)
+{
+	return 'a' <= ch && ch <= 'z' ? ch - ('a' - 'A') : ch;
+}
+
+static std::map<std::string_view, String> LANG_ALIAS_MAP = {
+	{"english", "en"},
+	{"japanese", "ja"},
+	{"korean", "ko"},
+	{"swedish", "sv"},
+};
+static std::map<std::string_view, String> COUNTRY_ALIAS_MAP = {
+	{"japan", "jp"},
+	{"korea", "kr"},
+	{"south korea", "kr"},
+	{"sweden", "SE"},
+	{"united states", "us"},
+};
+
+String I18N::GetSystemLanguage()
+{
+	String currLocale = setlocale(LC_CTYPE, nullptr);
+
+	{
+		String localeTemp, encoding;
+		if (currLocale.SplitLast(".", &localeTemp, &encoding))
+		{
+			currLocale = localeTemp;
+		}
+	}
+
+	String langCode = "";
+	String countryCode = "";
+
+	if (!currLocale.Split("_", &langCode, &countryCode) && !currLocale.Split("-", &langCode, &countryCode))
+	{
+		langCode = currLocale;
+		countryCode = "";
+	}
+
+	std::transform(langCode.begin(), langCode.end(), langCode.begin(), ToLower);
+	std::transform(countryCode.begin(), countryCode.end(), countryCode.begin(), ToLower);
+
+	auto langIt = LANG_ALIAS_MAP.find(langCode);
+	if (langIt != LANG_ALIAS_MAP.end())
+	{
+		langCode = langIt->second;
+	}
+	auto countryIt = LANG_ALIAS_MAP.find(countryCode);
+	if (countryIt != LANG_ALIAS_MAP.end())
+	{
+		countryCode = countryIt->second;
+	}
+
+	std::transform(countryCode.begin(), countryCode.end(), countryCode.begin(), ToUpper);
+
+	if (countryCode.empty()) return langCode;
+	else return langCode + "-" + countryCode;
+}
+
 void I18N::Initialize(const String& dirPath)
 {
 	m_filesByLanguage.clear();
 	m_files.clear();
-	m_currFile = m_files.end();
+	m_currFile = 0;
 
 	m_dirPath = Path::Absolute(dirPath);
 }
 
 void I18N::SetLanguage(const String& lang)
 {
-	if (auto* fileIt = m_filesByLanguage.Find(lang))
+	if (auto* fileInd = m_filesByLanguage.Find(lang))
 	{
-		m_currFile = *fileIt;
+		m_currFile = *fileInd;
 		return;
 	}
 
-	const String filePath = m_dirPath + Path::sep + lang + ".po";
-
-	POFile poFile(filePath);
+	POFile poFile(GetFilePath(lang));
 	if (poFile.GetLanguage().empty())
 	{
 		return;
 	}
 
+	const size_t ind = m_files.size();
 	m_files.emplace_back(std::move(poFile));
-	auto it = std::prev(m_files.end());
 
-	m_filesByLanguage.emplace(poFile.GetLanguage(), it);
-	m_currFile = it;
+	m_filesByLanguage.emplace(poFile.GetLanguage(), ind);
+	m_currFile = ind;
 }
 
 std::string_view I18N::GetText(const std::string_view& msg_id) const
 {
-	if (m_currFile == m_files.end())
+	if (m_currFile >= m_files.size())
 	{
 		return msg_id;
 	}
 
-	return m_currFile->GetText(msg_id);
+	return m_files[m_currFile].GetText(msg_id);
 }
 
 void I18N::BindLua(lua_State* L)
 {
 	lua_pushcfunction(L, I18N::Lua_GetText);
 	lua_setglobal(L, "_");
+}
+
+int I18N::GetLanguageIndexFromNamesMap(const String& lang)
+{
+	auto it = SUPPORTED_LANGUAGE_NAMES.find(lang);
+	if (it != SUPPORTED_LANGUAGE_NAMES.end())
+	{
+		return (int) std::distance(SUPPORTED_LANGUAGE_NAMES.begin(), it);
+	}
+
+	String l, c;
+	if (lang.Split("-", &l, &c))
+	{
+		it = SUPPORTED_LANGUAGE_NAMES.find(l);
+		if (it != SUPPORTED_LANGUAGE_NAMES.end())
+		{
+			return (int) std::distance(SUPPORTED_LANGUAGE_NAMES.begin(), it);
+		}
+	}
+	else
+	{
+		l = lang;
+	}
+
+	it = SUPPORTED_LANGUAGE_NAMES.lower_bound(l);
+	if (it->first.substr(0, l.size()) == l)
+	{
+		return (int)std::distance(SUPPORTED_LANGUAGE_NAMES.begin(), it);
+	}
+
+	return -1;
 }
 
 int I18N::Lua_GetText(lua_State* L)
@@ -64,4 +163,19 @@ int I18N::Lua_GetText(lua_State* L)
 	{
 		return 0;
 	}
+}
+
+String I18N::GetFilePath(const String& lang) const
+{
+	String filePath = m_dirPath + Path::sep + lang + ".po";
+	if (Path::FileExists(filePath) == false)
+	{
+		String x, y;
+		if (lang.Split("-", &x, &y))
+		{
+			filePath = m_dirPath + Path::sep + x + ".po";
+		}
+	}
+
+	return filePath;
 }

--- a/Shared/src/I18N.cpp
+++ b/Shared/src/I18N.cpp
@@ -1,0 +1,67 @@
+#include "stdafx.h"
+#include "I18N.hpp"
+
+#include "Path.hpp"
+
+I18N I18N::m_instance;
+
+void I18N::Initialize(const String& dirPath)
+{
+	m_filesByLanguage.clear();
+	m_files.clear();
+	m_currFile = m_files.end();
+
+	m_dirPath = Path::Absolute(dirPath);
+}
+
+void I18N::SetLanguage(const String& lang)
+{
+	if (auto* fileIt = m_filesByLanguage.Find(lang))
+	{
+		m_currFile = *fileIt;
+		return;
+	}
+
+	const String filePath = m_dirPath + Path::sep + lang + ".po";
+
+	POFile poFile(filePath);
+	if (poFile.GetLanguage().empty())
+	{
+		return;
+	}
+
+	m_files.emplace_back(std::move(poFile));
+	auto it = std::prev(m_files.end());
+
+	m_filesByLanguage.emplace(poFile.GetLanguage(), it);
+	m_currFile = it;
+}
+
+std::string_view I18N::GetText(const std::string_view& msg_id) const
+{
+	if (m_currFile == m_files.end())
+	{
+		return msg_id;
+	}
+
+	return m_currFile->GetText(msg_id);
+}
+
+void I18N::BindLua(lua_State* L)
+{
+	lua_pushcfunction(L, I18N::Lua_GetText);
+	lua_setglobal(L, "_");
+}
+
+int I18N::Lua_GetText(lua_State* L)
+{
+	if (const char* msg_id = luaL_checkstring(L, 1))
+	{
+		lua_pushstring(L, I18N::Get().GetText(msg_id).data());
+		return 1;
+	}
+	else
+	{
+		return 0;
+	}
+}

--- a/Shared/src/I18N.cpp
+++ b/Shared/src/I18N.cpp
@@ -122,7 +122,7 @@ std::string_view I18N::GetText(const std::string_view& msg_ctxt, const std::stri
 		return msg_id;
 	}
 
-	return m_files[m_currFile].GetText(msg_ctxt, msg_id);
+	return m_files[m_currFile].GetText(msg_id, msg_ctxt);
 }
 
 void I18N::BindLua(lua_State* L)
@@ -164,15 +164,35 @@ int I18N::GetLanguageIndexFromNamesMap(const String& lang)
 
 int I18N::Lua_GetText(lua_State* L)
 {
-	if (const char* msg_id = luaL_checkstring(L, 1))
+	switch (lua_gettop(L))
 	{
-		lua_pushstring(L, I18N::Get().GetText(msg_id).data());
-		return 1;
-	}
-	else
+	case 1:
 	{
-		return 0;
+		const char* msg_id = luaL_checkstring(L, 1);
+		if (msg_id)
+		{
+			lua_pushstring(L, I18N::Get().GetText(msg_id).data());
+			return 1;
+		}
 	}
+		break;
+	case 2:
+	{
+		const char* msg_id = luaL_checkstring(L, 1);
+		const char* msg_ctxt = luaL_checkstring(L, 1);
+		if (msg_id && msg_ctxt)
+		{
+			lua_pushstring(L, I18N::Get().GetText(msg_id, msg_ctxt).data());
+			return 1;
+		}
+	}
+		break;
+	default:
+		return luaL_error(L, "expecting 1 or 2 string arguments");
+		break;
+	}
+
+	return luaL_error(L, "unknown error");
 }
 
 String I18N::GetFilePath(const String& lang) const

--- a/Shared/src/I18N.cpp
+++ b/Shared/src/I18N.cpp
@@ -115,6 +115,16 @@ std::string_view I18N::GetText(const std::string_view& msg_id) const
 	return m_files[m_currFile].GetText(msg_id);
 }
 
+std::string_view I18N::GetText(const std::string_view& msg_ctxt, const std::string_view& msg_id) const
+{
+	if (m_currFile >= m_files.size())
+	{
+		return msg_id;
+	}
+
+	return m_files[m_currFile].GetText(msg_ctxt, msg_id);
+}
+
 void I18N::BindLua(lua_State* L)
 {
 	lua_pushcfunction(L, I18N::Lua_GetText);

--- a/Shared/src/POFile.cpp
+++ b/Shared/src/POFile.cpp
@@ -26,14 +26,9 @@ POFile::POFile(File& file)
 
 std::string_view POFile::GetText(const std::string_view& msg_id) const
 {
-	auto range = m_contents.equal_range(msg_id);
-	
-	for (auto it = range.first; it != range.second; ++it)
-	{
-		return it->second.m_value;
-	}
-	
-	return msg_id;
+	auto it = m_contents.find(msg_id);
+	if (it != m_contents.end()) return it->second.m_value;
+	else return msg_id;
 }
 
 static inline size_t LongestMatch(const std::string_view& x, const std::string_view& y)
@@ -48,7 +43,7 @@ static inline size_t LongestMatch(const std::string_view& x, const std::string_v
 	return i;
 }
 
-std::string_view POFile::GetText(const std::string_view& msg_ctxt, const std::string_view& msg_id) const
+std::string_view POFile::GetText(const std::string_view& msg_id, const std::string_view& msg_ctxt) const
 {
 	auto range = m_contents.equal_range(msg_id);
 	auto longest_match = range.first;

--- a/Shared/src/POFile.cpp
+++ b/Shared/src/POFile.cpp
@@ -1,0 +1,189 @@
+#include "stdafx.h"
+#include "POFile.hpp"
+
+#include "File.hpp"
+#include "FileStream.hpp"
+#include "TextStream.hpp"
+
+#include "Timer.hpp"
+#include "Log.hpp"
+#include "Profiling.hpp"
+
+POFile::POFile(const String& path)
+{
+	File file;
+	if (!file.OpenRead(path))
+	{
+		return;
+	}
+	Parse(file);
+}
+
+POFile::POFile(File& file)
+{
+	Parse(file);
+}
+
+std::string_view POFile::GetText(const std::string_view& msg_id) const
+{
+	auto range = m_contents.equal_range(msg_id);
+	
+	for (auto it = range.first; it != range.second; ++it)
+	{
+		return it->second.m_value;
+	}
+	
+	return msg_id;
+}
+
+void POFile::Parse(File& file)
+{
+	FileReader reader(file);
+	Parse(reader);
+}
+
+static inline String unquote(String str)
+{
+	std::stringstream ss;
+
+	bool in_quote = false;
+	bool escaped = false;
+
+	for (char c : str)
+	{
+		if (escaped)
+		{
+			switch (c)
+			{
+			case 'n': ss << '\n'; break;
+			case 'r': ss << '\r'; break;
+			case 't': ss << '\t'; break;
+			case '\\':
+			case '"':
+			case '\'':
+			default: ss << c; break;
+			}
+
+			escaped = false;
+		}
+		else if (in_quote)
+		{
+			switch (c)
+			{
+			case '"':
+				in_quote = false;
+				break;
+			case '\\':
+				escaped = true;
+				break;
+			default:
+				ss << c;
+				break;
+			}
+		}
+		else
+		{
+			switch (c)
+			{
+			case '"':
+				in_quote = true;
+				break;
+			case ' ':
+			case '\n':
+			case '\r':
+			case '\t':
+				break;
+			default:
+				in_quote = true;
+				ss << c;
+				break;
+			}
+		}
+	}
+
+	return ss.str();
+}
+
+void POFile::Parse(FileReader& reader)
+{
+	ProfilerScope $("Load POFile");
+
+	String line;
+	
+	String curr_msgctxt;
+	String curr_msgid;
+	String curr_msgstr;
+
+	String metadata;
+
+	bool curr_id_seen = false;
+
+	auto push_curr_msg = [&]() {
+		if (curr_id_seen)
+		{
+			if (curr_msgid.empty() && curr_msgctxt.empty())
+			{
+				metadata = curr_msgstr;
+			}
+			else
+			{
+				m_contents.emplace(curr_msgid, Entry{ curr_msgctxt, curr_msgstr });
+			}
+		}
+
+		curr_msgctxt.clear();
+		curr_msgid.clear();
+		curr_msgstr.clear();
+
+		curr_id_seen = false;
+	};
+	
+	while (TextStream::ReadLine(reader, line))
+	{
+		line.Trim();
+		if (line.empty()) continue;
+
+		if (line[0] == '#') continue;
+
+		if (line.substr(0, 3).compare("msg") != 0)
+		{
+			if (line[0] == '"') curr_msgstr += unquote(line);
+			continue;
+		}
+
+		// msgid
+		if (line.substr(3, 3).compare("id ") == 0)
+		{
+			push_curr_msg();
+			curr_id_seen = true;
+			curr_msgid = unquote(line.substr(6));
+		}
+
+		// msgstr
+		else if (line.substr(3, 4).compare("str ") == 0)
+		{
+			curr_msgstr += unquote(line.substr(7));
+		}
+
+		// msgctxt
+		else if (line.substr(3, 5).compare("ctxt ") == 0)
+		{
+			push_curr_msg();
+			curr_msgctxt = unquote(line.substr(8));
+		}
+	}
+
+	push_curr_msg();
+
+	// Parse metadata
+	for (String line : metadata.Explode("\n", false))
+	{
+		String key, value;
+		line.Split(": ", &key, &value);
+
+		if (key == "Language")
+		{
+			m_language = value;
+		}
+	}
+}

--- a/Shared/stdafx.h
+++ b/Shared/stdafx.h
@@ -11,4 +11,11 @@
 #include <windows.h>
 #endif
 
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include "Shared/Types.hpp"
+
+#include "Lua.hpp"

--- a/Shared/stdafx.h
+++ b/Shared/stdafx.h
@@ -11,6 +11,7 @@
 #include <windows.h>
 #endif
 
+#include <algorithm>
 #include <map>
 #include <sstream>
 #include <string>

--- a/bin/skins/Default/scripts/downloadscreen.lua
+++ b/bin/skins/Default/scripts/downloadscreen.lua
@@ -2,6 +2,11 @@ json = require "json"
 local header = {}
 header["user-agent"] = "unnamed_sdvx_clone"
 
+-- For I18N song status
+_("Downloaded")
+_("Downloading...")
+_("Playing")
+
 local jacketFallback = gfx.CreateSkinImage("song_select/loading.png", 0)
 local diffColors = {{50,50,127}, {50,127,50}, {127,50,50}, {127, 50, 127}}
 local entryW = 770
@@ -120,7 +125,7 @@ function render_song(song, x,y)
         gfx.FillColor(255,255,255)
         gfx.FontSize(40)
         gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_MIDDLE)
-        gfx.Text(string.format("%d Effected by %s", diff.level, diff.effector), 255, diffY + 250 / 8)
+        gfx.Text(string.format(_("%d Effected by %s"), diff.level, diff.effector), 255, diffY + 250 / 8)
     end
     if downloaded[song.id] then
         gfx.BeginPath()
@@ -130,7 +135,7 @@ function render_song(song, x,y)
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
         gfx.FontSize(60)
         gfx.FillColor(255,255,255)
-        gfx.Text(downloaded[song.id], 375, 150)
+        gfx.Text(_(downloaded[song.id]), 375, 150)
     elseif song.status then
         gfx.BeginPath()
         gfx.Rect(0,0,750,300)
@@ -139,7 +144,7 @@ function render_song(song, x,y)
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
         gfx.FontSize(60)
         gfx.FillColor(255,255,255)
-        gfx.Text(song.status, 375, 150)
+        gfx.Text(_(song.status), 375, 150)
     end
     gfx.ResetScissor()
     gfx.Restore()
@@ -177,7 +182,7 @@ function render_loading()
     gfx.FillColor(255,255,255)
     gfx.TextAlign(gfx.TEXT_ALIGN_RIGHT, gfx.TEXT_ALIGN_BOTTOM)
     gfx.FontSize(70)
-    gfx.Text("LOADING...", resX - 20, resY - 3)
+    gfx.Text(_("LOADING..."), resX - 20, resY - 3)
     gfx.Restore()
 end
 
@@ -191,9 +196,9 @@ function render_hotkeys()
     gfx.FontSize(30)
     gfx.FillColor(255,255,255)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT, gfx.TEXT_ALIGN_BOTTOM)
-    gfx.Text("FXR: Sorting", resX/2 + 20, resY - 10)
+    gfx.Text(_("FX-R: Sorting"), resX/2 + 20, resY - 10)
     gfx.TextAlign(gfx.TEXT_ALIGN_RIGHT, gfx.TEXT_ALIGN_BOTTOM)
-    gfx.Text("FXL: Levels", resX/2 - 20, resY - 10)
+    gfx.Text(_("FX-L: Levels"), resX/2 - 20, resY - 10)
     gfx.Restore()
 end
 
@@ -386,7 +391,7 @@ function render_level_filters()
     gfx.FillColor(255,255,255)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_TOP)
     gfx.FontSize(60)
-    gfx.Text("Level filters:", 10, 10)
+    gfx.Text(_("Level filters:"), 10, 10)
     gfx.BeginPath()
     gfx.Rect(resX/2 - 30, resY/2 - 22, 60, 44)
     gfx.StrokeColor(255,128,0)
@@ -412,7 +417,7 @@ function render_sorting_selection()
     gfx.FillColor(255,255,255)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_TOP)
     gfx.FontSize(60)
-    gfx.Text("Sorting method:", 10, 10)
+    gfx.Text(_("Sorting method:"), 10, 10)
     gfx.BeginPath()
     gfx.Rect(resX/2 - 75, resY/2 - 22, 150, 44)
     gfx.StrokeColor(255,128,0)

--- a/bin/skins/Default/scripts/gamesettingsdialog.lua
+++ b/bin/skins/Default/scripts/gamesettingsdialog.lua
@@ -74,8 +74,8 @@ function render(deltaTime, visible)
 
     local posX = SettingsDiag.posX or 0.5
     local posY = SettingsDiag.posY or 0.5
-    local message_1 = "Press both FXs to open/close. Use the Start button to press buttons."
-    local message_2 = "Use FX keys to navigate tabs. Use arrow keys to navigate and modify settings."
+    local message_1 = _("Press both FXs to open/close. Use the Start button to press buttons.")
+    local message_2 = _("Use FX keys to navigate tabs. Use arrow keys to navigate and modify settings.")
 
     resX, resY = game.GetResolution()
     local scale = resY / 1080

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -140,7 +140,7 @@ result_set = function()
 
     if result.duration ~= nil then
         chartDuration = result.duration
-        chartDurationText = string.format("%dm %02d.%01ds", chartDuration // 60000, (chartDuration // 1000) % 60, (chartDuration // 100) % 10)
+        chartDurationText = string.format(_("%dm %02d.%01ds"), chartDuration // 60000, (chartDuration // 1000) % 60, (chartDuration // 100) % 10)
         hitGraphHoverScale = math.max(chartDuration / 10000, 5)
     else
         chartDuration = 0
@@ -247,15 +247,15 @@ result_set = function()
     end
 
     if result.playbackSpeed ~= nil and result.playbackSpeed ~= 1.00 then
-        if clearTextBase == "" then clearText = string.format("x%.2f play", result.playbackSpeed)
-        else clearText = string.format("%s (x%.2f play)", clearTextBase, result.playbackSpeed)
+        if clearTextBase == "" then clearText = string.format(_("x%.2f play"), result.playbackSpeed)
+        else clearText = string.format(_("%s (x%.2f play)"), clearTextBase, result.playbackSpeed)
         end
     else
         clearText = clearTextBase
     end
 
     if result.uid ~= nil and result.playerName ~= nil and result.isSelf ~= true then
-        clearText = string.format("By %s", result.playerName)
+        clearText = string.format(_("By %s"), result.playerName)
     end
 
     if result.speedModType ~= nil then
@@ -289,8 +289,8 @@ result_set = function()
         hitWindowGood = result.hitWindow.good
 
         if hitWindowPerfect ~= 46 or hitWindowGood ~= 92 then
-            critText = string.format("%02dms CRIT", hitWindowPerfect)
-            nearText = string.format("%02dms NEAR", hitWindowGood)
+            critText = string.format(_("%02dms CRIT"), hitWindowPerfect)
+            nearText = string.format(_("%02dms NEAR"), hitWindowGood)
         end
     end
 
@@ -323,7 +323,7 @@ draw_shotnotif = function(x,y)
     gfx.Stroke()
     gfx.FillColor(255,255,255)
     gfx.FontSize(15)
-    gfx.Text("Screenshot saved to:", 3,5)
+    gfx.Text(_("Screenshot saved to:"), 3,5)
     gfx.Text(shotPath, 3,20)
     gfx.Restore()
 end
@@ -381,12 +381,12 @@ draw_ir = function(full)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT)
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
     gfx.FontSize(30)
-    gfx.Text("IR (BT-D: High Scores)",510,30)
+    gfx.Text(_("IR (BT-D: High Scores)"),510,30)
 
     if result.irState == IRData.States.Pending then
         gfx.FontSize(15)
         gfx.FillColor(170, 170, 170)
-        gfx.Text("Loading... please wait.", 510, 60)
+        gfx.Text(_("Loading... please wait."), 510, 60)
         return
     end
 
@@ -443,11 +443,14 @@ draw_ir = function(full)
         gfx.LoadSkinFont("NotoSans-Regular.ttf")
         gfx.FontSize(20)
 
+        local timeStr = ""
         if s.yours and s.justSet then
-            gfx.Text(string.format("%s, Now", s.username), 130, 45)
+            timeStr = _("Now")
         else
-            gfx.Text(string.format("%s, %s", s.username, os.date("%Y-%m-%d %H:%M:%S", s.timestamp)), 130, 45)
+            timeStr = os.date("%Y-%m-%d %H:%M:%S", s.timestamp)
         end
+        
+        gfx.Text(string.format("%s, %s", s.username, timeStr), 130, 45)
         gfx.Restore()
     end
 end
@@ -459,9 +462,9 @@ draw_highscores = function(full)
     gfx.FontSize(30)
 
     if not IRData.Active then
-        gfx.Text("High Scores",510,30)
+        gfx.Text(_("High Scores"),510,30)
     else
-        gfx.Text("High Scores (BT-D: IR)",510,30)
+        gfx.Text(_("High Scores (BT-D: IR)"),510,30)
     end
 
     gfx.StrokeWidth(1)
@@ -632,7 +635,7 @@ draw_left_graph = function(x, y, w, h)
     gfx.FillColor(255, 255, 255, 32)
     gfx.Fill()
 
-    local chartDurationDisp = string.format("Duration: %s", chartDurationText)
+    local chartDurationDisp = string.format(_("Duration: %s"), chartDurationText)
 
     if mhit then
         hit_xfocus = mx - x
@@ -653,7 +656,7 @@ draw_left_graph = function(x, y, w, h)
 
     if result.bpm ~= nil then
         gfx.BeginPath()
-        gfx.Text(string.format("BPM: %s", result.bpm), x+5, y+15)
+        gfx.Text(string.format(_("BPM: %s"), result.bpm), x+5, y+15)
     end
 
     draw_hit_graph(x, y, w, h, hit_xfocus, hit_xscale)
@@ -686,13 +689,13 @@ draw_left_graph = function(x, y, w, h)
         gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
         gfx.BeginPath()
         gfx.FillColor(255, 255, 255, 128)
-        gfx.Text(string.format("Mean: %.1f ms, Median: %d ms", result.meanHitDelta, result.medianHitDelta), x+4, y+h)
+        gfx.Text(string.format(_("Mean: %.1f ms, Median: %d ms"), result.meanHitDelta, result.medianHitDelta), x+4, y+h)
     elseif hasHitStat then
         gfx.FontSize(16)
         gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
         gfx.BeginPath()
         gfx.FillColor(255, 255, 255, 128)
-        gfx.Text(string.format("Mean deviation: %.1fms", result.meanHitDeltaAbs), x+4, y+h)
+        gfx.Text(string.format(_("Mean deviation: %.1fms"), result.meanHitDeltaAbs), x+4, y+h)
     end
 
     -- End gauge display
@@ -785,7 +788,7 @@ draw_right_graph = function(x, y, w, h)
     end
     gfx.FillColor(255, 128, 128)
     gfx.FontSize(16)
-    gfx.Text(string.format("Mean: %.1f ms", result.meanHitDelta), x+2, y+meanY)
+    gfx.Text(string.format(_("Mean: %.1f ms"), result.meanHitDelta), x+2, y+meanY)
 
     gfx.BeginPath()
     if medianY <= meanY then
@@ -795,18 +798,18 @@ draw_right_graph = function(x, y, w, h)
     end
     gfx.FillColor(196, 196, 255)
     gfx.FontSize(16)
-    gfx.Text(string.format("Median: %d ms", result.medianHitDelta), x+2, y+medianY)
+    gfx.Text(string.format(_("Median: %d ms"), result.medianHitDelta), x+2, y+medianY)
 
     gfx.FillColor(255, 255, 255)
     gfx.FontSize(15)
 
     gfx.BeginPath()
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_TOP)
-    gfx.Text(string.format("Earliest: %d ms", hitMinDelta), x+5, y)
+    gfx.Text(string.format(_("Earliest: %d ms"), hitMinDelta), x+5, y)
 
     gfx.BeginPath()
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
-    gfx.Text(string.format("Latest: %d ms", hitMaxDelta), x+5, y+h)
+    gfx.Text(string.format(_("Latest: %d ms"), hitMaxDelta), x+5, y+h)
 end
 
 draw_laser_icon = function(x, y, s)
@@ -976,7 +979,7 @@ draw_chart_info = function(x, y, w, h, full)
         gfx.FillColor(255, 255, 255, math.floor(40+80*waveParam(4)))
         gfx.FontSize(30)
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE)
-        gfx.Text("No Image", x+w/2, jacket_y + jacket_size/2)
+        gfx.Text(_("No Image"), x+w/2, jacket_y + jacket_size/2)
     end
 
     if full then
@@ -997,7 +1000,7 @@ draw_chart_info = function(x, y, w, h, full)
             local effector_text = ""
 
             if result.effector ~= nil and result.effector ~= "" then
-                effector_text = string.format("  by %s", result.effector)
+                effector_text = string.format(_("  by %s"), result.effector)
 
                 gfx.FontSize(16)
                 local _d, _e, effector_text_width, _f = gfx.TextBounds(0, 0, effector_text)
@@ -1051,7 +1054,7 @@ draw_chart_info = function(x, y, w, h, full)
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER)
         gfx.FillColor(255, 255, 255)
         gfx.FontSize(16)
-        gfx.Text("Effected by", x+w/2, draw_y)
+        gfx.Text(_("Effected by"), x+w/2, draw_y)
         gfx.FontSize(27)
         drawScaledText(result.effector, x+w/2, draw_y+24, w/2-5)
         draw_y = draw_y + 50
@@ -1060,7 +1063,7 @@ draw_chart_info = function(x, y, w, h, full)
     if result.illustrator ~= nil and result.illustrator ~= "" then
         gfx.TextAlign(gfx.TEXT_ALIGN_CENTER)
         gfx.FontSize(16)
-        gfx.Text("Illustrated by", x+w/2, draw_y)
+        gfx.Text(_("Illustrated by"), x+w/2, draw_y)
         gfx.FontSize(27)
         drawScaledText(result.illustrator, x+w/2, draw_y+24, w/2-5)
         draw_y = draw_y + 50
@@ -1172,7 +1175,7 @@ draw_basic_hitstat = function(x, y, w, h, full)
 
             gfx.BeginPath()
             gfx.FontSize(16)
-            gfx.Text(string.format("Mission: %s", result.mission), x+4, stat_y)
+            gfx.Text(string.format(_("Mission: %s"), result.mission), x+4, stat_y)
         end
     end
 end
@@ -1189,12 +1192,12 @@ end
 draw_guide = function(x, y, w, h, full)
     gfx.LoadSkinFont("NotoSans-Regular.ttf")
 
-    local fxLText = "FX-L: more info"
+    local fxLText = _("FX-L: more info")
     if full then
-        fxLText = "FX-L: simple view"
+        fxLText = _("FX-L: simple view")
     end
 
-    local fxRText = "FX-R: toggle hiscore"
+    local fxRText = _("FX-R: toggle hiscore")
 
     gfx.FontSize(20)
     gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)

--- a/bin/skins/Default/scripts/songselect/songwheel.lua
+++ b/bin/skins/Default/scripts/songselect/songwheel.lua
@@ -23,12 +23,12 @@ local searchIndex = 1
 local jacketFallback = gfx.CreateSkinImage("song_select/loading.png", 0)
 local showGuide = game.GetSkinSetting("show_guide")
 local legendTable = {
-  {["labelSingleLine"] =  gfx.CreateLabel("DIFFICULTY SELECT",16, 0), ["labelMultiLine"] =  gfx.CreateLabel("DIFFICULTY\nSELECT",16, 0), ["image"] = gfx.CreateSkinImage("legend/knob-left.png", 0)},
-  {["labelSingleLine"] =  gfx.CreateLabel("MUSIC SELECT",16, 0),      ["labelMultiLine"] =  gfx.CreateLabel("MUSIC\nSELECT",16, 0),      ["image"] = gfx.CreateSkinImage("legend/knob-right.png", 0)},
-  {["labelSingleLine"] =  gfx.CreateLabel("FILTER MUSIC",16, 0),      ["labelMultiLine"] =  gfx.CreateLabel("FILTER\nMUSIC",16, 0),      ["image"] = gfx.CreateSkinImage("legend/FX-L.png", 0)},
-  {["labelSingleLine"] =  gfx.CreateLabel("SORT MUSIC",16, 0),        ["labelMultiLine"] =  gfx.CreateLabel("SORT\nMUSIC",16, 0),        ["image"] = gfx.CreateSkinImage("legend/FX-R.png", 0)},
-  {["labelSingleLine"] =  gfx.CreateLabel("MUSIC MODS",16, 0),        ["labelMultiLine"] =  gfx.CreateLabel("MUSIC\nMODS",16, 0),        ["image"] = gfx.CreateSkinImage("legend/FX-LR.png", 0)},
-  {["labelSingleLine"] =  gfx.CreateLabel("PLAY",16, 0),              ["labelMultiLine"] =  gfx.CreateLabel("PLAY",16, 0),               ["image"] = gfx.CreateSkinImage("legend/start.png", 0)}
+  {["labelSingleLine"] =  gfx.CreateLabel(_("DIFFICULTY SELECT"),16, 0), ["labelMultiLine"] =  gfx.CreateLabel(_("DIFFICULTY\nSELECT"),16, 0), ["image"] = gfx.CreateSkinImage("legend/knob-left.png", 0)},
+  {["labelSingleLine"] =  gfx.CreateLabel(_("MUSIC SELECT"),16, 0),      ["labelMultiLine"] =  gfx.CreateLabel(_("MUSIC\nSELECT"),16, 0),      ["image"] = gfx.CreateSkinImage("legend/knob-right.png", 0)},
+  {["labelSingleLine"] =  gfx.CreateLabel(_("FILTER MUSIC"),16, 0),      ["labelMultiLine"] =  gfx.CreateLabel(_("FILTER\nMUSIC"),16, 0),      ["image"] = gfx.CreateSkinImage("legend/FX-L.png", 0)},
+  {["labelSingleLine"] =  gfx.CreateLabel(_("SORT MUSIC"),16, 0),        ["labelMultiLine"] =  gfx.CreateLabel(_("SORT\nMUSIC"),16, 0),        ["image"] = gfx.CreateSkinImage("legend/FX-R.png", 0)},
+  {["labelSingleLine"] =  gfx.CreateLabel(_("PLAY MODS"),16, 0),         ["labelMultiLine"] =  gfx.CreateLabel(_("PLAY\nMODS"),16, 0),         ["image"] = gfx.CreateSkinImage("legend/FX-LR.png", 0)},
+  {["labelSingleLine"] =  gfx.CreateLabel(_("PLAY"),16, 0),              ["labelMultiLine"] =  gfx.CreateLabel(_("PLAY"),16, 0),               ["image"] = gfx.CreateSkinImage("legend/start.png", 0)}
 }
 local grades = {
   {["max"] = 6999999, ["image"] = gfx.CreateSkinImage("score/D.png", 0)},
@@ -157,7 +157,7 @@ end
 function get_record(hash)
     if recordCache[hash] then return recordCache[hash] end
 
-    recordCache[hash] = {good=false, reason="Loading..."}
+    recordCache[hash] = {good=false, reason=_("Loading...")}
 
     IR.Record(hash, record_handler_factory(hash))
 
@@ -200,8 +200,8 @@ draw_scores_ir = function(difficulty, x, y, w, h)
     gfx.FontSize(30);
     gfx.TextAlign(gfx.TEXT_ALIGN_BOTTOM + gfx.TEXT_ALIGN_CENTER);
 
-    gfx.FastText("HIGH SCORE", x +(w/4), y+(h/2))
-    gfx.FastText("IR RECORD", x + (3/4 * w), y + (h/2))
+    gfx.FastText(_("HIGH SCORE"), x +(w/4), y+(h/2))
+    gfx.FastText(_("IR RECORD"), x + (3/4 * w), y + (h/2))
 
     gfx.BeginPath()
     gfx.Rect(x+xOffset,y+h/2,w/2-(xOffset*2),h/2)
@@ -300,7 +300,7 @@ draw_scores = function(difficulty, x, y, w, h)
 	local yOffset = h/3
   gfx.FontSize(30);
   gfx.TextAlign(gfx.TEXT_ALIGN_BOTTOM + gfx.TEXT_ALIGN_CENTER);
-  gfx.FastText("HIGH SCORE", x +(w/2), y+(h/2))
+  gfx.FastText(_("HIGH SCORE"), x +(w/2), y+(h/2))
   gfx.BeginPath()
   gfx.Rect(x+xOffset,y+h/2,w-(xOffset*2),h/2)
   gfx.FillColor(30,30,30,10)
@@ -485,7 +485,7 @@ draw_selected = function(song, x, y, w, h)
       gfx.DrawLabel(songCache[song.id]["artist"], xpos+xPadding+imageSize+3, y+yMargin+yPadding + 45, width-imageSize-20)
       gfx.FontSize(20)
       gfx.DrawLabel(songCache[song.id]["bpm"], xpos+xPadding+imageSize+3, y+yMargin+yPadding + 85, width-imageSize-20)
-      gfx.FastText(string.format("Effector: %s", diff.effector), xpos+xPadding+imageSize+3, y+yMargin+yPadding + 115)
+      gfx.FastText(string.format(_("Effector: %s"), diff.effector), xpos+xPadding+imageSize+3, y+yMargin+yPadding + 115)
     else
       gfx.FontSize(40)
       gfx.TextAlign(gfx.TEXT_ALIGN_TOP + gfx.TEXT_ALIGN_LEFT)
@@ -495,7 +495,7 @@ draw_selected = function(song, x, y, w, h)
       gfx.FillColor(255,255,255)
       gfx.FontSize(20)
       gfx.DrawLabel(songCache[song.id]["bpm"], xpos+10, (height/10)*6 + 85)
-      gfx.FastText(string.format("Effector: %s", diff.effector),xpos+10, (height/10)*6 + 115)
+      gfx.FastText(string.format(_("Effector: %s"), diff.effector),xpos+10, (height/10)*6 + 115)
     end
     if aspectRatio == "PortraitWidescreen" then
       draw_scores(diff, xpos+xPadding+imageSize+3,  (height/3)*2, width-imageSize-20, (height/3)-yPadding)
@@ -590,7 +590,7 @@ draw_search = function(x,y,w,h)
   gfx.Fill()
   gfx.ForceRender()
   local xpos = x + (searchIndex + soffset)*w
-  gfx.UpdateLabel(searchText ,string.format("Search: %s",songwheel.searchText), 30, 0)
+  gfx.UpdateLabel(searchText ,string.format(_("Search: %s"),songwheel.searchText), 30, 0)
   gfx.BeginPath()
   gfx.RoundedRect(xpos,y,w,h,h/2)
   gfx.FillColor(30,30,30)
@@ -657,7 +657,7 @@ render = function(deltaTime)
 		gfx.FillColor(255,255,255)
 		gfx.FontSize(20);
 		gfx.TextAlign(gfx.TEXT_ALIGN_LEFT + gfx.TEXT_ALIGN_BOTTOM)
-		local forceText = string.format("Force: %.2f", totalForce)
+		local forceText = string.format(_("Force: %.2f"), totalForce)
 		gfx.Text(forceText, 0, fullY)
 	end
     gfx.LoadSkinFont("NotoSans-Regular.ttf");

--- a/bin/skins/Default/scripts/titlescreen.lua
+++ b/bin/skins/Default/scripts/titlescreen.lua
@@ -72,12 +72,12 @@ end
 function setButtons()
 	if buttons == nil then
 		buttons = {}
-		buttons[1] = {"Start", Menu.Start}
-		buttons[2] = {"Multiplayer", Menu.Multiplayer}
-        buttons[3] = {"Challenges", Menu.Challenges}
-		buttons[4] = {"Get Songs", Menu.DLScreen}
-		buttons[5] = {"Settings", Menu.Settings}
-		buttons[6] = {"Exit", Menu.Exit}
+		buttons[1] = {_("Start"), Menu.Start}
+		buttons[2] = {_("Multiplayer"), Menu.Multiplayer}
+        buttons[3] = {_("Challenges"), Menu.Challenges}
+		buttons[4] = {_("Get Songs"), Menu.DLScreen}
+		buttons[5] = {_("Settings"), Menu.Settings}
+		buttons[6] = {_("Exit"), Menu.Exit}
 	end
 end
 
@@ -165,7 +165,7 @@ render = function(deltaTime)
 	cursorGet = 1
     buttonY = resy / 2;
     hovered = nil;
-	
+    
     gfx.LoadSkinFont("NotoSans-Regular.ttf");
 	
 	for i=1,#buttons do
@@ -184,7 +184,7 @@ render = function(deltaTime)
     gfx.FillColor(255,255,255);
     gfx.FontSize(120);
     if label == -1 then
-        label = gfx.CreateLabel("unnamed_sdvx_clone", 120, 0);
+        label = gfx.CreateLabel(_("unnamed_sdvx_clone"), 120, 0);
     end
     gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_MIDDLE);
     gfx.DrawLabel(label, resx / 2, resy / 2 - 200, resx-40);
@@ -193,9 +193,9 @@ render = function(deltaTime)
        gfx.BeginPath()
        gfx.TextAlign(gfx.TEXT_ALIGN_BOTTOM + gfx.TEXT_ALIGN_LEFT)
        gfx.FontSize(30)
-       gfx.Text(string.format("Version %s is now available", updateVersion), 5, resy - buttonHeight - 10)
-       draw_button({"View", view_update}, buttonWidth / 2 + 5, resy - buttonHeight / 2 - 5);
-       draw_button({"Update", Menu.Update}, buttonWidth * 1.5 + 15, resy - buttonHeight / 2 - 5)
+       gfx.Text(string.format(_("Version %s is now available"), updateVersion), 5, resy - buttonHeight - 10)
+       draw_button({_("View"), view_update}, buttonWidth / 2 + 5, resy - buttonHeight / 2 - 5);
+       draw_button({_("Update"), Menu.Update}, buttonWidth * 1.5 + 15, resy - buttonHeight / 2 - 5)
     end
 end;
 

--- a/bin/translations/en.po
+++ b/bin/translations/en.po
@@ -1,0 +1,59 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: unnamed sdvx clone\n"
+"POT-Creation-Date: 2021-04-14 19:18+0900\n"
+"PO-Revision-Date: 2021-04-14 19:18+0900\n"
+"Last-Translator: \n"
+"Language-Team: https://github.com/Drewol/unnamed-sdvx-clone\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.2\n"
+"X-Poedit-Basepath: ../..\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-KeywordsList: _p:1c,2\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-SearchPath-0: bin/skins/Default\n"
+"X-Poedit-SearchPath-1: Main/src\n"
+
+#: bin/skins/Default/scripts/titlescreen.lua:75
+msgid "Start"
+msgstr "Start"
+
+#: bin/skins/Default/scripts/titlescreen.lua:76
+msgid "Multiplayer"
+msgstr "Multiplayer"
+
+#: bin/skins/Default/scripts/titlescreen.lua:77
+msgid "Challenges"
+msgstr "Challenges"
+
+#: bin/skins/Default/scripts/titlescreen.lua:78
+msgid "Get Songs"
+msgstr "Get Songs"
+
+#: bin/skins/Default/scripts/titlescreen.lua:79
+msgid "Settings"
+msgstr "Settings"
+
+#: bin/skins/Default/scripts/titlescreen.lua:80
+msgid "Exit"
+msgstr "Exit"
+
+#: bin/skins/Default/scripts/titlescreen.lua:187
+msgid "unnamed_sdvx_clone"
+msgstr "unnamed_sdvx_clone"
+
+#: bin/skins/Default/scripts/titlescreen.lua:196
+#, lua-format
+msgid "Version %s is now available"
+msgstr "Version %s is now available"
+
+#: bin/skins/Default/scripts/titlescreen.lua:197
+msgid "View"
+msgstr "View"
+
+#: bin/skins/Default/scripts/titlescreen.lua:198
+msgid "Update"
+msgstr "Update"

--- a/bin/translations/ko.po
+++ b/bin/translations/ko.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: unnamed sdvx clone\n"
-"POT-Creation-Date: 2021-04-14 22:07+0900\n"
-"PO-Revision-Date: 2021-04-14 22:07+0900\n"
+"POT-Creation-Date: 2021-04-14 23:48+0900\n"
+"PO-Revision-Date: 2021-04-14 23:48+0900\n"
 "Last-Translator: \n"
 "Language-Team: https://github.com/Drewol/unnamed-sdvx-clone\n"
 "Language: ko\n"
@@ -12,7 +12,7 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-Basepath: ../..\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Poedit-KeywordsList: ;_p:1c,2;_:1\n"
+"X-Poedit-KeywordsList: ;_:1,2c;_:1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: bin/skins/Default\n"
 "X-Poedit-SearchPath-1: Main/src\n"
@@ -114,6 +114,8 @@ msgid "Score Display"
 msgstr "스코어 표시"
 
 #: Main/src/GameplaySettingsDialog.cpp:43
+#, fuzzy
+#| msgid "Autoplay"
 msgid "Autoplay"
 msgstr "오토플레이"
 

--- a/bin/translations/ko.po
+++ b/bin/translations/ko.po
@@ -1,0 +1,59 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: unnamed sdvx clone\n"
+"POT-Creation-Date: 2021-04-13 23:09+0900\n"
+"PO-Revision-Date: 2021-04-14 03:03+0900\n"
+"Last-Translator: \n"
+"Language-Team: https://github.com/Drewol/unnamed-sdvx-clone\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.2\n"
+"X-Poedit-Basepath: ../..\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Poedit-KeywordsList: _p:1c,2\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-SearchPath-0: bin/skins/Default\n"
+"X-Poedit-SearchPath-1: Main/src\n"
+
+#: bin/skins/Default/scripts/titlescreen.lua:75
+msgid "Start"
+msgstr "시작"
+
+#: bin/skins/Default/scripts/titlescreen.lua:76
+msgid "Multiplayer"
+msgstr "멀티플레이"
+
+#: bin/skins/Default/scripts/titlescreen.lua:77
+msgid "Challenges"
+msgstr "코스 플레이"
+
+#: bin/skins/Default/scripts/titlescreen.lua:78
+msgid "Get Songs"
+msgstr "곡 내려받기"
+
+#: bin/skins/Default/scripts/titlescreen.lua:79
+msgid "Settings"
+msgstr "설정"
+
+#: bin/skins/Default/scripts/titlescreen.lua:80
+msgid "Exit"
+msgstr "종료"
+
+#: bin/skins/Default/scripts/titlescreen.lua:187
+msgid "unnamed_sdvx_clone"
+msgstr "이름 없는 사볼 구동기"
+
+#: bin/skins/Default/scripts/titlescreen.lua:196
+#, lua-format
+msgid "Version %s is now available"
+msgstr "버전 %s 이용 가능"
+
+#: bin/skins/Default/scripts/titlescreen.lua:197
+msgid "View"
+msgstr "보기"
+
+#: bin/skins/Default/scripts/titlescreen.lua:198
+msgid "Update"
+msgstr "업데이트"

--- a/bin/translations/ko.po
+++ b/bin/translations/ko.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: unnamed sdvx clone\n"
-"POT-Creation-Date: 2021-04-13 23:09+0900\n"
-"PO-Revision-Date: 2021-04-14 03:03+0900\n"
+"POT-Creation-Date: 2021-04-14 22:07+0900\n"
+"PO-Revision-Date: 2021-04-14 22:07+0900\n"
 "Last-Translator: \n"
 "Language-Team: https://github.com/Drewol/unnamed-sdvx-clone\n"
 "Language: ko\n"
@@ -12,10 +12,461 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-Basepath: ../..\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Poedit-KeywordsList: _p:1c,2\n"
+"X-Poedit-KeywordsList: ;_p:1c,2;_:1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: bin/skins/Default\n"
 "X-Poedit-SearchPath-1: Main/src\n"
+"X-Poedit-SearchPath-2: Main/include\n"
+
+#: Main/include/SongSort.hpp:26
+#, c-format
+msgid "%s v"
+msgstr "%s v"
+
+#: Main/include/SongSort.hpp:26
+#, c-format
+msgid "%s ^"
+msgstr "%s ^"
+
+#: Main/include/SongSort.hpp:43 Main/include/SongSort.hpp:128
+msgid "Title"
+msgstr "제목"
+
+#: Main/include/SongSort.hpp:58 Main/include/SongSort.hpp:155
+msgid "Score"
+msgstr "점수"
+
+#: Main/include/SongSort.hpp:72 Main/include/SongSort.hpp:143
+msgid "Date"
+msgstr "날짜"
+
+#: Main/include/SongSort.hpp:86
+msgid "Artist"
+msgstr "작곡가"
+
+#: Main/include/SongSort.hpp:100
+msgid "Effector"
+msgstr "이펙터"
+
+#: Main/include/SongSort.hpp:112
+msgid "Badge"
+msgstr "클리어 마크"
+
+#: Main/include/SongSort.hpp:167
+msgid "Clear"
+msgstr "클리어 마크"
+
+#: Main/src/GameplaySettingsDialog.cpp:11
+msgid "Offsets"
+msgstr "오프셋"
+
+#: Main/src/GameplaySettingsDialog.cpp:12
+msgid "Global Offset"
+msgstr "글로벌 오프셋"
+
+#: Main/src/GameplaySettingsDialog.cpp:13
+msgid "Input Offset"
+msgstr "입력 오프셋"
+
+#: Main/src/GameplaySettingsDialog.cpp:20
+msgid "Compute Song Offset"
+msgstr "곡 오프셋 계산하기"
+
+#: Main/src/GameplaySettingsDialog.cpp:24
+#: Main/src/GameplaySettingsDialog.cpp:26
+msgid "HiSpeed"
+msgstr "HiSpeed"
+
+#: Main/src/GameplaySettingsDialog.cpp:25
+msgid "Speed Mod"
+msgstr "배속 모드"
+
+#: Main/src/GameplaySettingsDialog.cpp:27
+msgid "ModSpeed"
+msgstr "ModSpeed"
+
+#: Main/src/GameplaySettingsDialog.cpp:30
+msgid "Game"
+msgstr "게임"
+
+#: Main/src/GameplaySettingsDialog.cpp:34
+msgid "Gauge"
+msgstr "게이지"
+
+#: Main/src/GameplaySettingsDialog.cpp:35
+msgid "Backup Gauge"
+msgstr "백업 게이지"
+
+#: Main/src/GameplaySettingsDialog.cpp:36
+msgid "Random"
+msgstr "랜덤"
+
+#: Main/src/GameplaySettingsDialog.cpp:37
+msgid "Mirror"
+msgstr "미러"
+
+#: Main/src/GameplaySettingsDialog.cpp:39
+msgid "Hide Backgrounds"
+msgstr "배경 숨기기"
+
+#: Main/src/GameplaySettingsDialog.cpp:40
+msgid "Score Display"
+msgstr "스코어 표시"
+
+#: Main/src/GameplaySettingsDialog.cpp:43
+msgid "Autoplay"
+msgstr "오토플레이"
+
+#: Main/src/GameplaySettingsDialog.cpp:44
+msgid "Practice"
+msgstr "연습하기"
+
+#: Main/src/GameplaySettingsDialog.cpp:48
+msgid "Hid/Sud"
+msgstr "히든/서든"
+
+#: Main/src/GameplaySettingsDialog.cpp:49
+msgid "Enable Hidden / Sudden"
+msgstr "히든/서든 활성화"
+
+#: Main/src/GameplaySettingsDialog.cpp:50
+msgid "Hidden Cutoff"
+msgstr "히든 위치"
+
+#: Main/src/GameplaySettingsDialog.cpp:51
+msgid "Hidden Fade"
+msgstr "히든 페이드"
+
+#: Main/src/GameplaySettingsDialog.cpp:52
+msgid "Sudden Cutoff"
+msgstr "서든 위치"
+
+#: Main/src/GameplaySettingsDialog.cpp:53
+msgid "Sudden Fade"
+msgstr "서든 페이드"
+
+#: Main/src/GameplaySettingsDialog.cpp:54
+msgid "Show Track Cover"
+msgstr "트랙 커버 표시"
+
+#: Main/src/GameplaySettingsDialog.cpp:57
+msgid "Judgement"
+msgstr "판정"
+
+#: Main/src/GameplaySettingsDialog.cpp:58
+msgid "Crit Window"
+msgstr "크리티컬 범위"
+
+#: Main/src/GameplaySettingsDialog.cpp:59
+msgid "Near Window"
+msgstr "니어 범위"
+
+#: Main/src/GameplaySettingsDialog.cpp:60
+msgid "Hold Window"
+msgstr "롱노트 범위"
+
+#: Main/src/GameplaySettingsDialog.cpp:61
+msgid "Slam Window"
+msgstr "직각 노브 범위"
+
+#: Main/src/GameplaySettingsDialog.cpp:62
+msgid "Set to NORMAL"
+msgstr "NORMAL로 설정"
+
+#: Main/src/GameplaySettingsDialog.cpp:63
+msgid "Set to HARD"
+msgstr "HARD로 설정"
+
+#: Main/src/GameplaySettingsDialog.cpp:67
+msgid "Profiles"
+msgstr "프로필"
+
+#: Main/src/GameplaySettingsDialog.cpp:89
+#: Main/src/GameplaySettingsDialog.cpp:93
+msgid "Create Profile"
+msgstr "프로필 만들기"
+
+#: Main/src/GameplaySettingsDialog.cpp:91
+msgid "Create New Profile"
+msgstr "새 프로필 만들기"
+
+#: Main/src/GameplaySettingsDialog.cpp:92
+msgid ""
+"Enter name for profile\n"
+"(This will copy your current profile)"
+msgstr ""
+"프로필 이름을 입력하세요\n"
+"(현재 프로필에서 복사됨)"
+
+#: Main/src/GameplaySettingsDialog.cpp:148
+msgid "Manage Profiles"
+msgstr "프로필 관리"
+
+#: Main/src/GameplaySettingsDialog.cpp:172
+#: Main/src/GameplaySettingsDialog.cpp:173
+msgid "Song Offset"
+msgstr "곡 오프셋"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:6
+msgid "Downloaded"
+msgstr "다운로드 완료"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:7
+msgid "Downloading..."
+msgstr "다운로드 중..."
+
+#: bin/skins/Default/scripts/downloadscreen.lua:8
+msgid "Playing"
+msgstr "재생 중"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:128
+#, lua-format
+msgid "%d Effected by %s"
+msgstr "%d 이펙터: %s"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:185
+msgid "LOADING..."
+msgstr "로딩 중..."
+
+#: bin/skins/Default/scripts/downloadscreen.lua:199
+msgid "FX-R: Sorting"
+msgstr "FX-R: 정렬"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:201
+msgid "FX-L: Levels"
+msgstr "FX-L: 레벨"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:394
+msgid "Level filters:"
+msgstr "레벨 필터:"
+
+#: bin/skins/Default/scripts/downloadscreen.lua:420
+msgid "Sorting method:"
+msgstr "정렬 방식:"
+
+#: bin/skins/Default/scripts/gamesettingsdialog.lua:77
+msgid "Press both FXs to open/close. Use the Start button to press buttons."
+msgstr ""
+"두 FX 버튼을 동시에 눌러 여닫을 수 있습니다. 시작 버튼을 이용해 버튼을 누를 "
+"수 있습니다."
+
+#: bin/skins/Default/scripts/gamesettingsdialog.lua:78
+msgid ""
+"Use FX keys to navigate tabs. Use arrow keys to navigate and modify settings."
+msgstr ""
+"FX 버튼을 사용해 탭을 선택할 수 있습니다. 키보드 방향키로 설정 선택 및 조작"
+"을 할 수 있습니다."
+
+#: bin/skins/Default/scripts/result.lua:143
+#, lua-format
+msgid "%dm %02d.%01ds"
+msgstr "%d분 %02d.%01d초"
+
+#: bin/skins/Default/scripts/result.lua:250
+#, lua-format
+msgid "x%.2f play"
+msgstr "%.2f배속 플레이"
+
+#: bin/skins/Default/scripts/result.lua:251
+#, lua-format
+msgid "%s (x%.2f play)"
+msgstr "%s (%.2f배속 플레이)"
+
+#: bin/skins/Default/scripts/result.lua:258
+#, lua-format
+msgid "By %s"
+msgstr "플레이어: %s"
+
+#: bin/skins/Default/scripts/result.lua:292
+#, lua-format
+msgid "%02dms CRIT"
+msgstr "크리티컬 %02dms"
+
+#: bin/skins/Default/scripts/result.lua:293
+#, lua-format
+msgid "%02dms NEAR"
+msgstr "니어 %02dms"
+
+#: bin/skins/Default/scripts/result.lua:326
+msgid "Screenshot saved to:"
+msgstr "스크린샷 저장 경로:"
+
+#: bin/skins/Default/scripts/result.lua:384
+msgid "IR (BT-D: High Scores)"
+msgstr "인터넷 랭킹 (BT-D: 최고 기록)"
+
+#: bin/skins/Default/scripts/result.lua:389
+msgid "Loading... please wait."
+msgstr "로딩 중..."
+
+#: bin/skins/Default/scripts/result.lua:448
+msgid "Now"
+msgstr "지금"
+
+#: bin/skins/Default/scripts/result.lua:465
+msgid "High Scores"
+msgstr "최고 기록"
+
+#: bin/skins/Default/scripts/result.lua:467
+msgid "High Scores (BT-D: IR)"
+msgstr "최고 기록 (BT-D: 인터넷 랭킹)"
+
+#: bin/skins/Default/scripts/result.lua:638
+#, lua-format
+msgid "Duration: %s"
+msgstr "재생 시간: %s"
+
+#: bin/skins/Default/scripts/result.lua:659
+#, lua-format
+msgid "BPM: %s"
+msgstr "BPM: %s"
+
+#: bin/skins/Default/scripts/result.lua:692
+#, lua-format
+msgid "Mean: %.1f ms, Median: %d ms"
+msgstr "평균: %.1f ms, 중간값: %d ms"
+
+#: bin/skins/Default/scripts/result.lua:698
+#, lua-format
+msgid "Mean deviation: %.1fms"
+msgstr "편차 중간값: %1fms"
+
+#: bin/skins/Default/scripts/result.lua:791
+#, lua-format
+msgid "Mean: %.1f ms"
+msgstr "평균: %.1f ms"
+
+#: bin/skins/Default/scripts/result.lua:801
+#, lua-format
+msgid "Median: %d ms"
+msgstr "중간값: %d ms"
+
+#: bin/skins/Default/scripts/result.lua:808
+#, lua-format
+msgid "Earliest: %d ms"
+msgstr "가장 이름: %d ms"
+
+#: bin/skins/Default/scripts/result.lua:812
+#, lua-format
+msgid "Latest: %d ms"
+msgstr "가장 늦음: %d ms"
+
+#: bin/skins/Default/scripts/result.lua:982
+msgid "No Image"
+msgstr "이미지 없음"
+
+#: bin/skins/Default/scripts/result.lua:1003
+#, lua-format
+msgid "  by %s"
+msgstr " 이펙터: %s"
+
+#: bin/skins/Default/scripts/result.lua:1057
+msgid "Effected by"
+msgstr "이펙터"
+
+#: bin/skins/Default/scripts/result.lua:1066
+msgid "Illustrated by"
+msgstr "일러스트레이터"
+
+#: bin/skins/Default/scripts/result.lua:1178
+#, lua-format
+msgid "Mission: %s"
+msgstr "미션: %s"
+
+#: bin/skins/Default/scripts/result.lua:1195
+msgid "FX-L: more info"
+msgstr "FX-L: 추가 정보"
+
+#: bin/skins/Default/scripts/result.lua:1197
+msgid "FX-L: simple view"
+msgstr "FX-L: 요약 보기"
+
+#: bin/skins/Default/scripts/result.lua:1200
+msgid "FX-R: toggle hiscore"
+msgstr "FX-R: 최고 기록 표시 토글"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:26
+msgid "DIFFICULTY SELECT"
+msgstr "난이도 선택"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:26
+msgid ""
+"DIFFICULTY\n"
+"SELECT"
+msgstr "난이도 선택"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:27
+msgid "MUSIC SELECT"
+msgstr "음악 선택"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:27
+msgid ""
+"MUSIC\n"
+"SELECT"
+msgstr "음악 선택"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:28
+msgid "FILTER MUSIC"
+msgstr "음악 필터 설정"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:28
+msgid ""
+"FILTER\n"
+"MUSIC"
+msgstr "음악 필터 설정"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:29
+msgid "SORT MUSIC"
+msgstr "정렬 방식 설정"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:29
+msgid ""
+"SORT\n"
+"MUSIC"
+msgstr "정렬 방식 설정"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:30
+msgid "PLAY MODS"
+msgstr "플레이 설정"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:30
+msgid ""
+"PLAY\n"
+"MODS"
+msgstr "플레이 설정"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:31
+msgid "PLAY"
+msgstr "플레이 시작"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:160
+msgid "Loading..."
+msgstr "로딩 중..."
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:203
+#: bin/skins/Default/scripts/songselect/songwheel.lua:303
+msgid "HIGH SCORE"
+msgstr "최고 기록"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:204
+msgid "IR RECORD"
+msgstr "인터넷 랭킹 기록"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:488
+#: bin/skins/Default/scripts/songselect/songwheel.lua:498
+#, lua-format
+msgid "Effector: %s"
+msgstr "이펙터: %s"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:593
+#, lua-format
+msgid "Search: %s"
+msgstr "검색: %s"
+
+#: bin/skins/Default/scripts/songselect/songwheel.lua:660
+#, lua-format
+msgid "Force: %.2f"
+msgstr "포스: %.2f"
 
 #: bin/skins/Default/scripts/titlescreen.lua:75
 msgid "Start"
@@ -43,7 +494,7 @@ msgstr "종료"
 
 #: bin/skins/Default/scripts/titlescreen.lua:187
 msgid "unnamed_sdvx_clone"
-msgstr "이름 없는 사볼 구동기"
+msgstr "unnamed_sdvx_clone"
 
 #: bin/skins/Default/scripts/titlescreen.lua:196
 #, lua-format
@@ -57,3 +508,19 @@ msgstr "보기"
 #: bin/skins/Default/scripts/titlescreen.lua:198
 msgid "Update"
 msgstr "업데이트"
+
+#~ msgid "MUSIC MODS"
+#~ msgstr "플레이 설정"
+
+#~ msgid ""
+#~ "MUSIC\n"
+#~ "MODS"
+#~ msgstr "플레이 설정"
+
+#, lua-format
+#~ msgid "%s %02d"
+#~ msgstr "%s %02d"
+
+#, lua-format
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"


### PR DESCRIPTION
- [X] Read and use PO files to translate text
    - `libintl` was quite unfriendly to use, so I created a simple PO file parser instead.
- [X] Added `Language` game settings for language selection
- [X] Added CPP and Lua functions for translation
    - `_("foo")`: translates 'foo'
    - `_("foo", "bar)`: translates 'foo' with context 'bar'
- [X] Added Korean translations for game-related parts, for testing
- [ ] Added Korean translations for settings
    - Currently, nuklear can't render CJK for unknown reason.

Non-goals for this PR:
- Provide full translations for other languages (current translations are more 'testy' than 'complety')
- Determine which string is translatable and which is not