### PR TITLE
Added indicators for delta time

### DIFF
--- a/bin/skins/Default/config-definitions.json
+++ b/bin/skins/Default/config-definitions.json
@@ -5,15 +5,32 @@
 		"type": "selection",
 		"label": "Early/Late display position",
 		"default": "bottom",
-		"values": ["bottom", "middle", "top", "off"]
+		"values": ["off", "bottom", "middle", "top"]
 	},
+	
+	"earlate_position_delta": {
+		"type": "int",
+		"label": "Offset for Early/Late display position",
+		"default": 0,
+		"max": 300,
+		"min": -300
+	},
+	
+	"earlate_show_delta_shape": {
+		"type": "bool",
+		"label": "Show delta time using shapes",
+		"default": true
+	},
+	
+	"separator_a" : {},
+	
 	"nick": {
 		"type" : "text",
 		"label" : "Display name",
 		"default" : "Guest"
 	},
 
-	"separator_a" : {},
+	"separator_b" : {},
 	"Song select:" : { "type" : "label" },
 	"show_guide": {
 		"label" : "Show control guide on song select",
@@ -21,7 +38,7 @@
 		"default": true
 	},
 
-	"separator_b" : {},
+	"separator_c" : {},
 	"Result:" : { "type" : "label" },
 	"show_result_hiscore": {
 		"label": "Show hiscore on result",
@@ -56,7 +73,7 @@
 		"default": false
 	},
 
-	"separator_c" : {},
+	"separator_test" : {},
 	"Test objects:" : { "type" : "label" },
 	"Testing with space" : {
 		"type": "float",
@@ -68,7 +85,7 @@
 
 	"Ineger_test" : {
 		"type": "int",
-		"label": "Ineger Test with range -100<->100",
+		"label": "Integer Test with range -100<->100",
 		"default": 50,
 		"max": 100,
 		"min": -100

--- a/bin/skins/Default/config-definitions.json
+++ b/bin/skins/Default/config-definitions.json
@@ -19,7 +19,7 @@
 	"earlate_show_delta_shape": {
 		"type": "bool",
 		"label": "Show delta time using shapes",
-		"default": true
+		"default": false
 	},
 	
 	"separator_a" : {},

--- a/bin/skins/Default/scripts/gameplay.lua
+++ b/bin/skins/Default/scripts/gameplay.lua
@@ -979,7 +979,10 @@ function draw_earlate(deltaTime)
         hitAlpha = mostRecentAlpha
     end
     
-    if earlate_force_show then hitAlpha = 255 end
+    if earlate_force_show then
+        hitAlpha = 255
+        mostRecentAlpha = 255
+    end
     
     -- Show early / late text
     if lingerNearType == -1 then


### PR DESCRIPTION
For default skin, an indicator that tells delta time is added.
A circle corresponds to ±10ms offset, and no more than 4 circles are drawn.

Originally tried adding ms display, but after experimenting with it I decided that this is a better way to show delta time.

Disabled by default; can be enabled via skin setting.

![image](https://user-images.githubusercontent.com/835369/115112459-9eb2fe80-9fc0-11eb-9ba7-b00fdf30df01.png)
