### PR TITLE
[db] Support duplicate charts in song database

### DIFF
--- a/Main/include/ScoreScreen.hpp
+++ b/Main/include/ScoreScreen.hpp
@@ -4,13 +4,14 @@
 #include "json.hpp"
 
 class MultiplayerScreen;
+class MapDatabase;
 
 class ScoreScreen : public IAsyncLoadableApplicationTickable
 {
 public:
 	virtual ~ScoreScreen() = default;
-	static ScoreScreen* Create(class Game* game);
-	static ScoreScreen* Create(class Game* game, class ChallengeManager*);
+	static ScoreScreen* Create(class Game* game, MapDatabase*);
+	static ScoreScreen* Create(class Game* game, class ChallengeManager*, MapDatabase*);
 	static ScoreScreen* Create(class Game* game, String uid,
-            Vector<nlohmann::json> const*, MultiplayerScreen*);
+            Vector<nlohmann::json> const*, MultiplayerScreen*, MapDatabase*);
 };

--- a/Main/src/ChallengeSelect.cpp
+++ b/Main/src/ChallengeSelect.cpp
@@ -1692,6 +1692,7 @@ bool ChallengeManager::m_setupNextChart()
 		Log("Failed to start game", Logger::Severity::Error);
 		return false;
 	}
+	game->SetSongDB(m_challengeSelect->GetMapDatabase());
 
 	if (m_currentOptions.gauge_carry_over.Get(false) && m_lastGauges.size() > 0)
 	{

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -1470,21 +1470,25 @@ public:
 		}
 		else
 		{
+			assert(m_db != nullptr);
 			// Transition to score screen
 			if (IsMultiplayerGame())
 			{
-				g_transition->TransitionTo(ScoreScreen::Create(
+				ScoreScreen* scoreScreen = ScoreScreen::Create(
 					this, m_multiplayer->GetUserId(),
-					m_multiplayer->GetFinalStats(), m_multiplayer));
+					m_multiplayer->GetFinalStats(), m_multiplayer, m_db);
+				g_transition->TransitionTo(scoreScreen);
 			}
 			else if (m_challengeManager != nullptr)
 			{
-				g_transition->TransitionTo(ScoreScreen::Create(
-					this, m_challengeManager));
+				ScoreScreen* scoreScreen = ScoreScreen::Create(
+					this, m_challengeManager, m_db);
+				g_transition->TransitionTo(scoreScreen);
 			}
 			else
 			{
-				g_transition->TransitionTo(ScoreScreen::Create(this));
+				ScoreScreen* scoreScreen = ScoreScreen::Create(this, m_db);
+				g_transition->TransitionTo(scoreScreen);
 			}
 			m_transitioning = true;
 		}

--- a/Main/src/MultiplayerScreen.cpp
+++ b/Main/src/MultiplayerScreen.cpp
@@ -392,6 +392,8 @@ bool MultiplayerScreen::m_handleStartPacket(nlohmann::json& packet)
 		return 0;
 	}
 
+	game->SetSongDB(m_mapDatabase);
+
 	m_suspended = true;
 
 	// Switch to the new tickable

--- a/Main/src/SongSelect.cpp
+++ b/Main/src/SongSelect.cpp
@@ -1287,6 +1287,7 @@ public:
 					Log("Failed to start game", Logger::Severity::Error);
 					return;
 				}
+				game->SetSongDB(m_mapDatabase);
 				game->GetScoring().autoplayInfo.autoplay = autoplay;
 
 				// Transition to game


### PR DESCRIPTION
This change fixes issues that happen when you have multiple charts with the same hash in the database. To do this we now keep a list of duplicates (if there are any) for a given hash. Then when we add scores, we can add them to all duplicates rather than just the one found in chartsByHash.

We also need to pass an initialized map database into ScoreScreen so we can update duplicates as well.

Since this is refactoring some score saving code, wanted to sanity check it