### PR TITLE
Allow BUTTON_BCK use in multiplayer and dl screens

### DIFF
--- a/bin/skins/Default/scripts/downloadscreen.lua
+++ b/bin/skins/Default/scripts/downloadscreen.lua
@@ -350,24 +350,12 @@ function button_pressed(button)
         end
 
     elseif button == game.BUTTON_BCK then
-        -- Identical to pressing escape
-        handle_exit()
+        dlcache = io.open(cachepath, "w")
+        dlcache:write(json.encode(downloaded))
+        dlcache:close()
+        dlScreen.Exit() 
     end
 end
-
-function key_pressed(key)
-    if key == 27 then --escape pressed
-        handle_exit()
-    end
-end
-
-function handle_exit()
-    dlcache = io.open(cachepath, "w")
-    dlcache:write(json.encode(downloaded))
-    dlcache:close()
-    dlScreen.Exit() 
-end
-
 
 function advance_selection(steps)
     if screenState == 0 and #songs > 0 then

--- a/bin/skins/Default/scripts/downloadscreen.lua
+++ b/bin/skins/Default/scripts/downloadscreen.lua
@@ -348,16 +348,24 @@ function button_pressed(button)
          else
             screenState = 0
         end
+
+    elseif button == game.BUTTON_BCK then
+        -- Identical to pressing escape
+        handle_exit()
     end
 end
 
 function key_pressed(key)
     if key == 27 then --escape pressed
-        dlcache = io.open(cachepath, "w")
-        dlcache:write(json.encode(downloaded))
-        dlcache:close()
-        dlScreen.Exit() 
+        handle_exit()
     end
+end
+
+function handle_exit()
+    dlcache = io.open(cachepath, "w")
+    dlcache:write(json.encode(downloaded))
+    dlcache:close()
+    dlScreen.Exit() 
 end
 
 

--- a/bin/skins/Default/scripts/multiplayerscreen.lua
+++ b/bin/skins/Default/scripts/multiplayerscreen.lua
@@ -873,26 +873,33 @@ button_pressed = function(button)
     if button == game.BUTTON_FXR then
         toggle_mirror();
     end
+    if button == game.BUTTON_BCK then
+        -- Same behaviour as escape being pressed
+        handle_exit()
+    end
 end
 
 -- Handle the escape key around the UI
 function key_pressed(key)
     if key == 27 then --escape pressed
-        if screenState == "roomList" then
-            did_exit = true;
-            mpScreen.Exit();
-            return
-        end
-
-        -- Reset room data
-        screenState = "roomList" -- have to update here
-        selected_room = nil;
-        rooms = {};
-        selected_song = nil
-        selected_song_index = 1;
-        jacket = 0;
+        handle_exit()
     end
+end
 
+function handle_exit()
+    if screenState == "roomList" then
+        did_exit = true;
+        mpScreen.Exit();
+        return
+    end
+    
+    -- Reset room data
+    screenState = "roomList" -- have to update here
+    selected_room = nil;
+    rooms = {};
+    selected_song = nil
+    selected_song_index = 1;
+    jacket = 0;
 end
 
 -- Handle mouse clicks in the UI

--- a/bin/skins/Default/scripts/multiplayerscreen.lua
+++ b/bin/skins/Default/scripts/multiplayerscreen.lua
@@ -874,32 +874,21 @@ button_pressed = function(button)
         toggle_mirror();
     end
     if button == game.BUTTON_BCK then
-        -- Same behaviour as escape being pressed
-        handle_exit()
-    end
-end
+        -- Handle the Back key around the UI
+        if screenState == "roomList" then
+            did_exit = true;
+            mpScreen.Exit();
+            return
+        end
 
--- Handle the escape key around the UI
-function key_pressed(key)
-    if key == 27 then --escape pressed
-        handle_exit()
+        -- Reset room data
+        screenState = "roomList" -- have to update here
+        selected_room = nil;
+        rooms = {};
+        selected_song = nil
+        selected_song_index = 1;
+        jacket = 0;
     end
-end
-
-function handle_exit()
-    if screenState == "roomList" then
-        did_exit = true;
-        mpScreen.Exit();
-        return
-    end
-    
-    -- Reset room data
-    screenState = "roomList" -- have to update here
-    selected_room = nil;
-    rooms = {};
-    selected_song = nil
-    selected_song_index = 1;
-    jacket = 0;
 end
 
 -- Handle mouse clicks in the UI


### PR DESCRIPTION
Currently, pressing BUTTON_BCK does not do anything when in the multiplayer or song download screens. I found this to be a bit unusual.

This pull request makes it so that BUTTON_BCK is bound to perform the same behavior as pressing escape on the keyboard. 

A consequence of this is that with the default bindings, pressing Escape from the multiplayer / song download screens will exit the game. I believe this is because by default, Button_BCK is bound to Escape, so two "exit" routines are queued to be performed. 

This could be resolved by not binding Escape to BUTTON_BCK by default.

Thank you for working on this project in your free time. 