### PR TITLE
Always start fading key beam when a hold has passed

### DIFF
--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -481,8 +481,7 @@ public:
 		if (m_delayedHitEffects)
 		{
 			m_scoring.OnHoldEnter.Add(m_track, &Track::OnHoldEnter);
-			if (m_scoring.autoplayInfo.IsAutoplayButtons())
-				m_scoring.OnHoldLeave.Add(m_track, &Track::OnButtonReleased);
+			m_scoring.OnHoldLeave.Add(m_track, &Track::OnButtonReleased);
 		}
 
 		#ifdef EMBEDDED
@@ -2582,7 +2581,6 @@ public:
 		m_scoring.autoplayInfo.autoplay = true;
 
 		m_track->hitEffectAutoplay = true;
-		m_scoring.OnHoldLeave.Add(m_track, &Track::OnButtonReleased);
 
 		m_playOptions.range = { 0, 0 };
 		m_playOnDialogClose = true;
@@ -2621,7 +2619,6 @@ public:
 		m_scoring.autoplayInfo.autoplay = false;
 
 		m_track->hitEffectAutoplay = false;
-		m_scoring.OnHoldLeave.Remove(m_track, &Track::OnButtonReleased);
 
 		m_paused = false;
 		m_triggerPause = false;

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -736,7 +736,6 @@ void Scoring::m_UpdateTicks()
 						}
 					}
 					else if (tick->HasFlag(TickFlags::End))
-					    // Simulate releasing a held button on autoplay
 					    OnHoldLeave.Call(button);
 
 					processed = true;


### PR DESCRIPTION
This applies regardless if the key beam was spawned from a crit, near or idle state.