### PR TITLE
Clamp laser FX parameters, fix FX parameters being parsed incorrectly

### DIFF
--- a/Audio/include/Audio/DSP.hpp
+++ b/Audio/include/Audio/DSP.hpp
@@ -44,9 +44,9 @@ private:
 	// Delayed samples
 	static const uint32 order = 2;
 	// FIR Delay buffers
-	float zb[2][order];
+	float zb[2][order]{};
 	// IIR Delay buffers
-	float za[2][order];
+	float za[2][order]{};
 };
 
 // Combinded Low/High-pass and Peaking filter
@@ -117,7 +117,7 @@ private:
 	uint32 m_length = 0;
 	uint32 m_fadeIn = 0;  // Fade In mark
 	uint32 m_fadeOut = 0; // Fade Out mark
-	uint32 m_halfway;	  // Halfway mark
+	uint32 m_halfway{};	  // Halfway mark
 	uint32 m_currentSample = 0;
 };
 
@@ -177,7 +177,7 @@ public:
 	virtual const char *GetName() const { return "WobbleDSP"; }
 
 private:
-	uint32 m_length;
+	uint32 m_length{};
 	uint32 m_currentSample = 0;
 };
 
@@ -269,7 +269,7 @@ public:
 	// Volume multiplier for the sidechaing
 	float amount = 0.25f;
 
-	Interpolation::CubicBezier curve;
+	Interpolation::CubicBezier curve{};
 
 	virtual void Process(float *out, uint32 numSamples);
 	virtual const char *GetName() const { return "SidechainDSP"; }

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -2,7 +2,6 @@
 #include "DSP.hpp"
 #include "AudioOutput.hpp"
 #include "Audio_Impl.hpp"
-#include <Shared/Interpolation.hpp>
 
 void PanDSP::Process(float *out, uint32 numSamples)
 {
@@ -677,12 +676,8 @@ private:
 	Vector<float> m_receiveBuffer;
 
 public:
-	PitchShiftDSP_Impl()
-	{
-	}
-	~PitchShiftDSP_Impl()
-	{
-	}
+	PitchShiftDSP_Impl() = default;
+	~PitchShiftDSP_Impl() = default;
 	void Init(uint32 sampleRate)
 	{
 		m_soundtouch.setChannels(2);

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -217,6 +217,7 @@ void GateDSP::SetLength(double length)
 }
 void GateDSP::SetGating(float gating)
 {
+	gating = Math::Clamp(gating, 0.f, 1.f);
 	float flength = (float)m_length;
 	m_gating = gating;
 	m_halfway = (uint32)(flength * gating);
@@ -335,6 +336,7 @@ void RetriggerDSP::SetResetDuration(uint32 resetDuration)
 }
 void RetriggerDSP::SetGating(float gating)
 {
+	gating = Math::Clamp(gating, 0.f, 1.f);
 	m_gating = gating;
 	m_gateLength = (uint32)((float)m_length * gating);
 }

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -198,14 +198,7 @@ struct MultiParamRange
 static MultiParam ParseParam(const String &in)
 {
 	MultiParam ret;
-	if (in.find("%") != -1)
-	{
-		ret.type = MultiParam::Float;
-		int percentage = 0;
-		sscanf(*in, "%i", &percentage);
-		ret.fval = percentage / 100.0;
-	}
-	else if (in.find('/') != -1)
+	if (in.find('/') != -1)
 	{
 		ret.type = MultiParam::Float;
 		String a, b;
@@ -216,6 +209,13 @@ static MultiParam ParseParam(const String &in)
 	{
 		ret.type = MultiParam::Samples;
 		sscanf(*in, "%i", &ret.ival);
+	}
+	else if (in.find("%") != -1)
+	{
+		ret.type = MultiParam::Float;
+		int percentage = 0;
+		sscanf(*in, "%i", &percentage);
+		ret.fval = percentage / 100.0;
 	}
 	else if (in.find('.') != -1)
 	{

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -198,10 +198,12 @@ struct MultiParamRange
 static MultiParam ParseParam(const String &in)
 {
 	MultiParam ret;
-	if (in.find('.') != -1)
+	if (in.find("%") != -1)
 	{
 		ret.type = MultiParam::Float;
-		sscanf(*in, "%f", &ret.fval);
+		int percentage = 0;
+		sscanf(*in, "%i", &percentage);
+		ret.fval = percentage / 100.0;
 	}
 	else if (in.find('/') != -1)
 	{
@@ -215,12 +217,10 @@ static MultiParam ParseParam(const String &in)
 		ret.type = MultiParam::Samples;
 		sscanf(*in, "%i", &ret.ival);
 	}
-	else if (in.find("%") != -1)
+	else if (in.find('.') != -1)
 	{
 		ret.type = MultiParam::Float;
-		int percentage = 0;
-		sscanf(*in, "%i", &percentage);
-		ret.fval = percentage / 100.0;
+		sscanf(*in, "%f", &ret.fval);
 	}
 	else
 	{
@@ -236,7 +236,7 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 	bool typeSet = false;
 
 	Map<String, MultiParamRange> params;
-	for (auto s : def.parameters)
+	for (const auto& s : def.parameters)
 	{
 		// This one is easy
 		if (s.first == "type")

--- a/Main/include/Audio/AudioPlayback.hpp
+++ b/Main/include/Audio/AudioPlayback.hpp
@@ -122,4 +122,6 @@ private:
 	class DSP *m_buttonDSPs[2] = {nullptr};
 	HoldObjectState *m_currentHoldEffects[2] = {nullptr};
 	float m_effectMix[2] = {0.0f};
+
+	bool m_SkipEffectIfInputIsZero();
 };

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -498,14 +498,14 @@ void AudioPlayback::m_SetLaserEffectParameter(float input)
 	}
 	case EffectType::Gate:
 	{
-		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
+		m_laserDSP->mix = 1; // TODO: This should get the mix value from custom fx parameters
 		GateDSP *gd = (GateDSP *)m_laserDSP;
 		// gd->SetLength(actualLength);
 		break;
 	}
 	case EffectType::Retrigger:
 	{
-		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
+		m_laserDSP->mix = 1; // TODO: This should get the mix value from custom fx parameters
 		RetriggerDSP *rt = (RetriggerDSP *)m_laserDSP;
 		rt->SetLength(actualLength);
 		break;

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -498,14 +498,14 @@ void AudioPlayback::m_SetLaserEffectParameter(float input)
 	}
 	case EffectType::Gate:
 	{
-		m_laserDSP->mix = 1; // TODO: This should get the mix value from custom fx parameters
+		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
 		GateDSP *gd = (GateDSP *)m_laserDSP;
 		// gd->SetLength(actualLength);
 		break;
 	}
 	case EffectType::Retrigger:
 	{
-		m_laserDSP->mix = 1; // TODO: This should get the mix value from custom fx parameters
+		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
 		RetriggerDSP *rt = (RetriggerDSP *)m_laserDSP;
 		rt->SetLength(actualLength);
 		break;

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -251,9 +251,15 @@ void AudioPlayback::SetLaserEffect(EffectType type)
 		m_laserEffect = m_beatmap->GetFilter(type);
 	}
 }
+bool AudioPlayback::m_SkipEffectIfInputIsZero()
+{
+	return m_laserEffect.type == EffectType::PeakingFilter || m_laserEffect.type == EffectType::HighPassFilter
+		|| m_laserEffect.type == EffectType::LowPassFilter || m_laserEffect.type == EffectType::PitchShift
+		|| m_laserEffect.type == EffectType::Bitcrush;
+}
 void AudioPlayback::SetLaserFilterInput(float input, bool active)
 {
-	if (m_laserEffect.type != EffectType::None && active)
+	if (m_laserEffect.type != EffectType::None && (active && (input != 0.0f || !m_SkipEffectIfInputIsZero())))
 	{
 		if (m_laserEffect.type == EffectType::SwitchAudio)
 		{

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -436,9 +436,6 @@ void AudioPlayback::m_CleanupDSP(DSP *&ptr)
 }
 void AudioPlayback::m_SetLaserEffectParameter(float input)
 {
-	if (!m_laserDSP)
-		return;
-
 	assert(input >= 0.0f && input <= 1.0f);
 
 	// Mix float biquad filters, these are applied manualy by changing the filter parameters (gain,q,freq,etc.)
@@ -454,14 +451,14 @@ void AudioPlayback::m_SetLaserEffectParameter(float input)
 	case EffectType::Bitcrush:
 	{
 		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
-		BitCrusherDSP *bcDSP = (BitCrusherDSP *)m_laserDSP;
+		auto *bcDSP = (BitCrusherDSP *)m_laserDSP;
 		bcDSP->SetPeriod((float)m_laserEffect.bitcrusher.reduction.Sample(input));
 		break;
 	}
 	case EffectType::Echo:
 	{
 		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
-		EchoDSP *echoDSP = (EchoDSP *)m_laserDSP;
+		auto *echoDSP = (EchoDSP *)m_laserDSP;
 		echoDSP->feedback = m_laserEffect.echo.feedback.Sample(input);
 		break;
 	}
@@ -471,48 +468,48 @@ void AudioPlayback::m_SetLaserEffectParameter(float input)
 		if (input > 0.8f)
 			mix *= 1.0f - (input - 0.8f) / 0.2f;
 
-		BQFDSP *bqfDSP = (BQFDSP *)m_laserDSP;
+		auto *bqfDSP = (BQFDSP *)m_laserDSP;
 		bqfDSP->SetPeaking(m_laserEffect.peaking.q.Sample(input), m_laserEffect.peaking.freq.Sample(input), m_laserEffect.peaking.gain.Sample(input) * mix);
 		break;
 	}
 	case EffectType::LowPassFilter:
 	{
 		m_laserDSP->mix = m_laserEffectMix;
-		BQFDSP *bqfDSP = (BQFDSP *)m_laserDSP;
+		auto *bqfDSP = (BQFDSP *)m_laserDSP;
 		bqfDSP->SetLowPass(m_laserEffect.lpf.q.Sample(input) * mix + 0.1f, m_laserEffect.lpf.freq.Sample(input));
 		break;
 	}
 	case EffectType::HighPassFilter:
 	{
 		m_laserDSP->mix = m_laserEffectMix;
-		BQFDSP *bqfDSP = (BQFDSP *)m_laserDSP;
+		auto *bqfDSP = (BQFDSP *)m_laserDSP;
 		bqfDSP->SetHighPass(m_laserEffect.hpf.q.Sample(input) * mix + 0.1f, m_laserEffect.hpf.freq.Sample(input));
 		break;
 	}
 	case EffectType::PitchShift:
 	{
 		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
-		PitchShiftDSP *ps = (PitchShiftDSP *)m_laserDSP;
+		auto *ps = (PitchShiftDSP *)m_laserDSP;
 		ps->amount = m_laserEffect.pitchshift.amount.Sample(input);
 		break;
 	}
 	case EffectType::Gate:
 	{
 		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
-		GateDSP *gd = (GateDSP *)m_laserDSP;
-		// gd->SetLength(actualLength);
 		break;
 	}
 	case EffectType::Retrigger:
 	{
 		m_laserDSP->mix = m_laserEffect.mix.Sample(input);
-		RetriggerDSP *rt = (RetriggerDSP *)m_laserDSP;
+		auto *rt = (RetriggerDSP *)m_laserDSP;
 		rt->SetLength(actualLength);
 		break;
 	}
 	default:
 		break;
 	}
+
+	m_laserDSP->mix = Math::Clamp(m_laserDSP->mix, 0.f, 1.f);
 }
 
 void AudioPlayback::m_PreRenderDSPTrack()

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -253,7 +253,7 @@ void AudioPlayback::SetLaserEffect(EffectType type)
 }
 void AudioPlayback::SetLaserFilterInput(float input, bool active)
 {
-	if (m_laserEffect.type != EffectType::None && (active || (input != 0.0f)))
+	if (m_laserEffect.type != EffectType::None && active)
 	{
 		if (m_laserEffect.type == EffectType::SwitchAudio)
 		{
@@ -292,6 +292,7 @@ void AudioPlayback::SetLaserFilterInput(float input, bool active)
 
 		// Set params
 		m_SetLaserEffectParameter(input);
+		m_laserDSP->mix = Math::Clamp(m_laserDSP->mix, 0.f, 1.f);
 		m_laserInput = input;
 	}
 	else
@@ -508,8 +509,6 @@ void AudioPlayback::m_SetLaserEffectParameter(float input)
 	default:
 		break;
 	}
-
-	m_laserDSP->mix = Math::Clamp(m_laserDSP->mix, 0.f, 1.f);
 }
 
 void AudioPlayback::m_PreRenderDSPTrack()

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -428,7 +428,10 @@ bool Scoring::IsLaserHeld(uint32 laserIndex, bool includeSlams) const
 	if (m_holdObjects[laserIndex + 6])
 	{
 		// Check for slams
-		return (((LaserObjectState*)m_holdObjects[laserIndex + 6])->flags & LaserObjectState::flag_Instant) == 0;
+		auto obj = (LaserObjectState*)m_holdObjects[laserIndex + 6];
+		if ((obj->flags & LaserObjectState::flag_Instant) && obj->next)
+			return true;
+		return !(obj->flags & LaserObjectState::flag_Instant);
 	}
 	return false;
 }


### PR DESCRIPTION
Laser FX mix values are now clamped to [0, 1], preventing dangerously loud audio FX. An issue with how FX parameters were parsed was also fixed, where a parameter with a decimal point and a percent sign was being interpreted as a whole number rather than a percentage.