### PR TITLE
Add option to save nuklear font texture between BasicNuklearGui instances

### DIFF
--- a/Main/include/Application.hpp
+++ b/Main/include/Application.hpp
@@ -136,6 +136,7 @@ private:
 	Map<String, CachedJacketImage*> m_jacketImages;
 	String m_lastMapPath;
 	Thread m_updateThread;
+	Thread m_fontBakeThread;
 	class Beatmap* m_currentMap = nullptr;
 	SkinHttp m_skinHttp;
 	SkinIR m_skinIR;

--- a/Main/include/ChatOverlay.hpp
+++ b/Main/include/ChatOverlay.hpp
@@ -4,20 +4,21 @@
 #include "Application.hpp"
 #include "Input.hpp"
 #include "GameConfig.hpp"
+#include "GuiUtils.hpp"
 
 class MultiplayerScreen;
 
 // TODO(itszn) inherit BasicNuklearGui to reduce duplciated code
-class ChatOverlay: public IApplicationTickable
+class ChatOverlay: public BasicNuklearGui
 {
 public:
-	ChatOverlay(MultiplayerScreen* m) : m_multi(m), m_nctx(), m_eventQueue() {};
+	ChatOverlay(MultiplayerScreen* m) : m_multi(m) {};
 	~ChatOverlay();
 	
 	bool Init() override;
 	void Tick(float deltaTime) override;
 	void Render(float deltaTime) override;
-	void NKRender();
+
 	void UpdateNuklearInput(SDL_Event evt);
 	void SendChatMessage(const String& message);
 	void AddMessage(const String& message);
@@ -25,8 +26,6 @@ public:
 	bool OnKeyPressedConsume(SDL_Scancode key);
 	void OpenChat();
 	void CloseChat();
-    void ShutdownNuklear();
-    void InitNuklearIfNeeded();
 	bool IsOpen() {
 		return m_isOpen;
 	}
@@ -43,11 +42,7 @@ private:
 	void m_drawWindow();
 	void m_drawChatAlert();
 
-    bool m_nuklearRunning = false;
-
 	MultiplayerScreen* m_multi = NULL;
-	struct nk_context* m_nctx = NULL;
-	std::queue<SDL_Event> m_eventQueue;
 
 	char m_chatDraft[512] = {0};
 	bool m_isOpen = false;

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -179,6 +179,8 @@ DefineEnum(GameConfigKeys,
 		   SettingsLastTab,
 		   TransferScoresOnChartUpdate,
 
+		   KeepFontTexture,
+
 		   CurrentProfileName,
 
 		   // Gameplay options

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -2,6 +2,7 @@
 #include "ApplicationTickable.hpp"
 #include "GameConfig.hpp"
 #include "Input.hpp"
+#include "Shared/Thread.hpp"
 
 class BasicNuklearGui : public IApplicationTickable
 {
@@ -17,6 +18,9 @@ public:
     void InitNuklearIfNeeded();
 	virtual bool OnKeyPressedConsume(SDL_Scancode code) { return m_isOpen; };
 
+	static void StartFontInit();
+	static void BakeFontWithLock();
+
 protected:
 	bool m_nuklearRunning = false;
 	struct nk_context* m_nctx = NULL;
@@ -29,8 +33,16 @@ protected:
 	Mesh m_bgMesh;
 
 private:
+	static Mutex s_mutex;
+	static nk_font_atlas* s_atlas;
+	static nk_font* s_font;
+	static GLuint s_fontTexture;
+	static bool s_hasFontTexture;
+	static int s_fontImageWidth;
+	static int s_fontImageHeight;
 	void InitNuklearFontAtlas();
-	void InitNuklearFontAtlasFallback(struct nk_font_atlas* atlas, float fontSize);
+	static void BakeFont();
+	static void InitNuklearFontAtlasFallback(struct nk_font_atlas* atlas, float fontSize);
 };
 
 class BasicWindow : public BasicNuklearGui

--- a/Main/include/GuiUtils.hpp
+++ b/Main/include/GuiUtils.hpp
@@ -20,6 +20,7 @@ public:
 
 	static void StartFontInit();
 	static void BakeFontWithLock();
+	static void DestroyFont();
 
 protected:
 	bool m_nuklearRunning = false;

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1013,8 +1013,10 @@ bool Application::m_Init()
 		g_transition = TransitionScreen::Create();
 	}
 
-	BasicNuklearGui::StartFontInit();
-	m_fontBakeThread = Thread(BasicNuklearGui::BakeFontWithLock);
+	if (g_gameConfig.GetBool(GameConfigKeys::KeepFontTexture)) {
+		BasicNuklearGui::StartFontInit();
+		m_fontBakeThread = Thread(BasicNuklearGui::BakeFontWithLock);
+	}
 
 	///TODO: check if directory exists already?
 	Path::CreateDir(Path::Absolute("screenshots"));

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -9,6 +9,7 @@
 #include <Graphics/ResourceManagers.hpp>
 #include <Shared/Profiling.hpp>
 #include "GameConfig.hpp"
+#include "GuiUtils.hpp"
 #include "Input.hpp"
 #include "TransitionScreen.hpp"
 #include "SkinConfig.hpp"
@@ -1012,6 +1013,9 @@ bool Application::m_Init()
 		g_transition = TransitionScreen::Create();
 	}
 
+	BasicNuklearGui::StartFontInit();
+	m_fontBakeThread = Thread(BasicNuklearGui::BakeFontWithLock);
+
 	///TODO: check if directory exists already?
 	Path::CreateDir(Path::Absolute("screenshots"));
 	Path::CreateDir(Path::Absolute("songs"));
@@ -1312,6 +1316,9 @@ void Application::m_Cleanup()
 	Graphics::FontRes::FreeLibrary();
 	if (m_updateThread.joinable())
 		m_updateThread.join();
+
+	if (m_fontBakeThread.joinable())
+		m_fontBakeThread.join();
 
 	// Finally, save config
 	m_SaveConfig();

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -230,6 +230,12 @@ void GameConfig::InitDefaults()
 
 	Set(GameConfigKeys::CurrentProfileName, "Main");
 	Set(GameConfigKeys::UpdateChannel, "master");
+
+#ifndef EMBEDDED
+	Set(GameConfigKeys::KeepFontTexture, true);
+#else
+	Set(GameConfigKeys::KeepFontTexture, false);
+#endif
 }
 
 void GameConfig::UpdateVersion()

--- a/Main/src/GuiUtils.cpp
+++ b/Main/src/GuiUtils.cpp
@@ -123,7 +123,7 @@ void BasicNuklearGui::InitNuklearFontAtlas()
 	if (!s_hasFontTexture && s_atlas->pixel == nullptr)
 	{
 		// Our thread didn't work
-		Logf("Failed to bake font in thread, trying again on main thread", Logger::Severity::Warning);
+		Log("Failed to bake font in thread, trying again on main thread", Logger::Severity::Warning);
 		BakeFont();
 	}
 

--- a/Main/src/GuiUtils.cpp
+++ b/Main/src/GuiUtils.cpp
@@ -111,23 +111,26 @@ void BasicNuklearGui::BakeFont()
 	usc_nk_bake_atlas(s_atlas, s_fontImageWidth, s_fontImageHeight);
 }
 
+void BasicNuklearGui::DestroyFont()
+{
+    glDeleteTextures(1, &s_fontTexture);
+}
+
 void BasicNuklearGui::InitNuklearFontAtlas()
 {
 	BasicNuklearGui::s_mutex.lock();
 	if (s_atlas == nullptr)
 	{
 		StartFontInit();
-		assert(s_atlas);
 	}
 
+	assert(s_atlas);
 	if (!s_hasFontTexture && s_atlas->pixel == nullptr)
 	{
 		// Our thread didn't work
 		Log("Failed to bake font in thread, trying again on main thread", Logger::Severity::Warning);
 		BakeFont();
 	}
-
-	assert(s_atlas);
 
 	if (!s_hasFontTexture)
 	{

--- a/Main/src/GuiUtils.cpp
+++ b/Main/src/GuiUtils.cpp
@@ -20,7 +20,7 @@ void BasicNuklearGui::ShutdownNuklear()
         return;
 
     g_gameWindow->OnAnyEvent.RemoveAll(this);
-    nk_sdl_shutdown();
+    nk_sdl_shutdown_keep_font();
 
     m_nuklearRunning = false;
 }
@@ -70,26 +70,79 @@ static void ExtendFontAtlas(struct nk_font_atlas* atlas, const std::string_view&
 	nk_font_atlas_add_from_file(atlas, fontPath.data(), pixelHeight, &cfg);
 }
 
-void BasicNuklearGui::InitNuklearFontAtlas()
+Mutex BasicNuklearGui::s_mutex;
+nk_font_atlas* BasicNuklearGui::s_atlas = nullptr;
+nk_font* BasicNuklearGui::s_font = nullptr;
+GLuint BasicNuklearGui::s_fontTexture = 0;
+bool BasicNuklearGui::s_hasFontTexture = false;
+
+void BasicNuklearGui::StartFontInit()
 {
 	// This font should cover latin and cyrillic fonts.
 	const String defaultFontPath = Path::Normalize(Path::Absolute("fonts/settings/NotoSans-Regular.ttf"));
 	const float fontSize = 24.f;
 
-	struct nk_font_atlas* atlas;
-	nk_sdl_font_stash_begin(&atlas);
+	s_atlas = new nk_font_atlas();
+	nk_atlas_font_stash_begin(s_atlas);
 
-	struct nk_font* font = nk_font_atlas_add_from_file(atlas, defaultFontPath.data(), fontSize, 0);
+	struct nk_font* font = nk_font_atlas_add_from_file(s_atlas, defaultFontPath.data(), fontSize, 0);
 
 	if (!g_gameConfig.GetBool(GameConfigKeys::LimitSettingsFont))
 	{
-		InitNuklearFontAtlasFallback(atlas, fontSize);
+		InitNuklearFontAtlasFallback(s_atlas, fontSize);
+	}
+	s_font = font;
+}
+
+int BasicNuklearGui::s_fontImageWidth = 0;
+int BasicNuklearGui::s_fontImageHeight = 0;
+
+void BasicNuklearGui::BakeFontWithLock()
+{
+	BasicNuklearGui::s_mutex.lock();
+	BakeFont();
+	BasicNuklearGui::s_mutex.unlock();
+}
+
+void BasicNuklearGui::BakeFont()
+{
+	if (s_atlas->pixel || s_hasFontTexture)
+		return;
+	usc_nk_bake_atlas(s_atlas, s_fontImageWidth, s_fontImageHeight);
+}
+
+void BasicNuklearGui::InitNuklearFontAtlas()
+{
+	BasicNuklearGui::s_mutex.lock();
+	if (s_atlas == nullptr)
+	{
+		StartFontInit();
+		assert(s_atlas);
 	}
 
-	usc_nk_sdl_font_stash_end();
-	nk_font_atlas_cleanup(atlas);
+	if (!s_hasFontTexture && s_atlas->pixel == nullptr)
+	{
+		// Our thread didn't work
+		Logf("Failed to bake font in thread, trying again on main thread", Logger::Severity::Warning);
+		BakeFont();
+	}
 
-	nk_style_set_font(m_nctx, &font->handle);
+	assert(s_atlas);
+
+	if (!s_hasFontTexture)
+	{
+		// Also assigns the atlas to the current sdl
+		s_fontTexture = usc_nk_sdl_generate_texture(s_atlas, s_atlas->pixel, s_fontImageWidth, s_fontImageHeight);
+		s_hasFontTexture = true;
+	} 
+	else
+	{
+		usc_nk_sdl_use_atlas(s_atlas, s_fontTexture);
+	}
+	BasicNuklearGui::s_mutex.unlock();
+
+	assert(s_font);
+	nk_style_set_font(m_nctx, &s_font->handle);
 }
 
 void BasicNuklearGui::InitNuklearFontAtlasFallback(struct nk_font_atlas* atlas, float fontSize)

--- a/Main/src/GuiUtils.cpp
+++ b/Main/src/GuiUtils.cpp
@@ -22,6 +22,12 @@ void BasicNuklearGui::ShutdownNuklear()
     g_gameWindow->OnAnyEvent.RemoveAll(this);
     nk_sdl_shutdown_keep_font();
 
+	if (!g_gameConfig.GetBool(GameConfigKeys::KeepFontTexture)) {
+		glDeleteTextures(1, &s_fontTexture);
+		s_fontTexture = 0;
+		s_hasFontTexture = false;
+	}
+
     m_nuklearRunning = false;
 }
 
@@ -113,7 +119,18 @@ void BasicNuklearGui::BakeFont()
 
 void BasicNuklearGui::DestroyFont()
 {
-    glDeleteTextures(1, &s_fontTexture);
+	if (s_hasFontTexture)
+	{
+		glDeleteTextures(1, &s_fontTexture);
+		s_hasFontTexture = false;
+	}
+	if (s_atlas)
+	{
+		nk_font_atlas_clear(s_atlas);
+		delete s_atlas;
+		s_atlas = nullptr;
+		s_font = nullptr;
+	}
 }
 
 void BasicNuklearGui::InitNuklearFontAtlas()
@@ -128,7 +145,7 @@ void BasicNuklearGui::InitNuklearFontAtlas()
 	if (!s_hasFontTexture && s_atlas->pixel == nullptr)
 	{
 		// Our thread didn't work
-		Log("Failed to bake font in thread, trying again on main thread", Logger::Severity::Warning);
+		Log("Baking nuklear font on main thread", Logger::Severity::Warning);
 		BakeFont();
 	}
 

--- a/Main/src/MultiplayerScreen.cpp
+++ b/Main/src/MultiplayerScreen.cpp
@@ -1211,7 +1211,9 @@ void MultiplayerScreen::m_OnButtonPressed(Input::Button buttonCode)
 			if (g_gameConfig.GetEnum<Enum_InputDevice>(GameConfigKeys::ButtonInputDevice) == InputDevice::Keyboard)
 			{
 				// In this case we want them to hit escape so we don't exit on text inputs
-				break;
+				int backScancode = g_gameConfig.GetInt(GameConfigKeys::Key_Back);
+				if (backScancode != SDL_SCANCODE_ESCAPE)
+					break;
 			}
 			// Otherwise fall though
             [[fallthrough]];

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -708,6 +708,7 @@ protected:
 		SelectionSetting(GameConfigKeys::AntiAliasing, m_aaModes, "Anti-aliasing (requires restart):");
 		SetApply(ToggleSetting(GameConfigKeys::VSync, "VSync"));
 		SetApply(ToggleSetting(GameConfigKeys::ShowFps, "Show FPS"));
+		SetApply(ToggleSetting(GameConfigKeys::KeepFontTexture, "Save font texture (settings load faster but uses more memory)"));
 
 		SectionHeader("Update");
 

--- a/Main/stdafx.cpp
+++ b/Main/stdafx.cpp
@@ -284,3 +284,111 @@ void usc_nk_sdl_font_stash_end(void)
     if (sdl.atlas.default_font)
         nk_style_set_font(&sdl.ctx, &sdl.atlas.default_font->handle);
 }
+
+const void* usc_nk_bake_atlas(nk_font_atlas* atlas, int& w, int& h)
+{
+    const void* image;
+    image = usc_nk_font_atlas_bake(atlas, &w, &h, NK_FONT_ATLAS_RGBA32);
+    return image;
+}
+
+NK_API void
+nk_font_atlas_end_keep_atlas(struct nk_font_atlas *atlas, nk_handle texture,
+    struct nk_draw_null_texture *null)
+{
+    int i = 0;
+    struct nk_font *font_iter;
+    NK_ASSERT(atlas);
+    if (!atlas) {
+        if (!null) return;
+        null->texture = texture;
+        null->uv = nk_vec2(0.5f,0.5f);
+    }
+    if (null) {
+        null->texture = texture;
+        null->uv.x = (atlas->custom.x + 0.5f)/(float)atlas->tex_width;
+        null->uv.y = (atlas->custom.y + 0.5f)/(float)atlas->tex_height;
+    }
+    for (font_iter = atlas->fonts; font_iter; font_iter = font_iter->next) {
+        font_iter->texture = texture;
+#ifdef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+        font_iter->handle.texture = texture;
+#endif
+    }
+    for (i = 0; i < NK_CURSOR_COUNT; ++i)
+        atlas->cursors[i].img.handle = texture;
+
+    /*
+    atlas->temporary.free(atlas->temporary.userdata, atlas->pixel);
+    atlas->pixel = 0;
+    atlas->tex_width = 0;
+    atlas->tex_height = 0;
+    atlas->custom.x = 0;
+    atlas->custom.y = 0;
+    atlas->custom.w = 0;
+    atlas->custom.h = 0;
+    */
+}
+
+GLuint usc_nk_sdl_generate_texture(nk_font_atlas* atlas, const void* image, int w, int h)
+{
+    nk_sdl_device_upload_atlas(image, w, h);
+    nk_font_atlas_end_keep_atlas(atlas, nk_handle_id((int)sdl.ogl.font_tex), &sdl.ogl.null);
+    if (atlas->default_font)
+        nk_style_set_font(&sdl.ctx, &atlas->default_font->handle);
+    sdl.atlas = *atlas;
+    return sdl.ogl.font_tex;
+}
+
+void usc_nk_sdl_use_atlas(nk_font_atlas* atlas, GLuint texture)
+{
+    NK_ASSERT(atlas);
+    sdl.atlas = *atlas;
+    sdl.ogl.font_tex = texture;
+
+    nk_draw_null_texture* null = &sdl.ogl.null;
+	null->texture = nk_handle_id((int)texture);
+	null->uv.x = (sdl.atlas.custom.x + 0.5f)/(float)sdl.atlas.tex_width;
+	null->uv.y = (sdl.atlas.custom.y + 0.5f)/(float)sdl.atlas.tex_height;
+    if (sdl.atlas.default_font)
+        nk_style_set_font(&sdl.ctx, &sdl.atlas.default_font->handle);
+}
+
+NK_INTERN void
+nk_sdl_device_upload_pregenerated_atlas(GLuint texture, const void* image, int width, int height)
+{
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)width, (GLsizei)height, 0,
+                GL_RGBA, GL_UNSIGNED_BYTE, image);
+}
+
+NK_API void
+nk_sdl_device_destroy_keep_font(void)
+{
+    struct nk_sdl_device *dev = &sdl.ogl;
+    glDetachShader(dev->prog, dev->vert_shdr);
+    glDetachShader(dev->prog, dev->frag_shdr);
+    glDeleteShader(dev->vert_shdr);
+    glDeleteShader(dev->frag_shdr);
+    glDeleteProgram(dev->prog);
+    glDeleteBuffers(1, &dev->vbo);
+    glDeleteBuffers(1, &dev->ebo);
+    nk_buffer_free(&dev->cmds);
+}
+
+NK_API
+void nk_sdl_shutdown_keep_font(void)
+{
+    nk_free(&sdl.ctx);
+    nk_sdl_device_destroy_keep_font();
+    memset(&sdl, 0, sizeof(sdl));
+}
+
+NK_API void
+nk_atlas_font_stash_begin(struct nk_font_atlas *atlas)
+{
+    nk_font_atlas_init_default(atlas);
+    nk_font_atlas_begin(atlas);
+}

--- a/Main/stdafx.cpp
+++ b/Main/stdafx.cpp
@@ -354,7 +354,7 @@ void usc_nk_sdl_use_atlas(nk_font_atlas* atlas, GLuint texture)
         nk_style_set_font(&sdl.ctx, &sdl.atlas.default_font->handle);
 }
 
-NK_INTERN void
+NK_API void
 nk_sdl_device_upload_pregenerated_atlas(GLuint texture, const void* image, int width, int height)
 {
     glBindTexture(GL_TEXTURE_2D, texture);

--- a/Main/stdafx.cpp
+++ b/Main/stdafx.cpp
@@ -338,6 +338,7 @@ usc_nk_sdl_device_upload_atlas(const void *image, int width, int height)
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)width, (GLsizei)height, 0,
                 GL_RGBA, GL_UNSIGNED_BYTE, 0);
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    glDeleteBuffers(1, &pdo);
 #else
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)width, (GLsizei)height, 0,
                 GL_RGBA, GL_UNSIGNED_BYTE, image);
@@ -348,6 +349,8 @@ GLuint usc_nk_sdl_generate_texture(nk_font_atlas* atlas, const void* image, int 
 {
     usc_nk_sdl_device_upload_atlas(image, w, h);
     nk_font_atlas_end_keep_atlas(atlas, nk_handle_id((int)sdl.ogl.font_tex), &sdl.ogl.null);
+    atlas->temporary.free(atlas->temporary.userdata, atlas->pixel);
+    atlas->pixel = nullptr;
     if (atlas->default_font)
         nk_style_set_font(&sdl.ctx, &atlas->default_font->handle);
     sdl.atlas = *atlas;

--- a/Main/stdafx.cpp
+++ b/Main/stdafx.cpp
@@ -372,16 +372,6 @@ void usc_nk_sdl_use_atlas(nk_font_atlas* atlas, GLuint texture)
 }
 
 NK_API void
-nk_sdl_device_upload_pregenerated_atlas(GLuint texture, const void* image, int width, int height)
-{
-    glBindTexture(GL_TEXTURE_2D, texture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)width, (GLsizei)height, 0,
-                GL_RGBA, GL_UNSIGNED_BYTE, image);
-}
-
-NK_API void
 nk_sdl_device_destroy_keep_font(void)
 {
     struct nk_sdl_device *dev = &sdl.ogl;

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -99,7 +99,6 @@ void usc_nk_sdl_font_stash_end();
 const void* usc_nk_bake_atlas(nk_font_atlas * atlas, int& w, int& h);
 GLuint usc_nk_sdl_generate_texture(nk_font_atlas * atlas, const void* image, int w, int h);
 void usc_nk_sdl_use_atlas(nk_font_atlas * atlas, GLuint texture);
-void nk_sdl_device_upload_pregenerated_atlas(GLuint texture, const void* image, int width, int height);
 void nk_sdl_device_destroy_keep_font(void);
 void nk_sdl_shutdown_keep_font(void);
 void nk_atlas_font_stash_begin(struct nk_font_atlas* atlas);

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -96,3 +96,10 @@ constexpr int FULL_FONT_TEXTURE_HEIGHT = 8192; //needed to load all CJK glyphs
 
 /// nk_sdl_font_stash_end but uses a better bake function to reduce baked font texture dimension
 void usc_nk_sdl_font_stash_end();
+const void* usc_nk_bake_atlas(nk_font_atlas * atlas, int& w, int& h);
+GLuint usc_nk_sdl_generate_texture(nk_font_atlas * atlas, const void* image, int w, int h);
+void usc_nk_sdl_use_atlas(nk_font_atlas * atlas, GLuint texture);
+void nk_sdl_device_upload_pregenerated_atlas(GLuint texture, const void* image, int width, int height);
+void nk_sdl_device_destroy_keep_font(void);
+void nk_sdl_shutdown_keep_font(void);
+void nk_atlas_font_stash_begin(struct nk_font_atlas* atlas);


### PR DESCRIPTION
This option has BasicNuklearGui instances share the same font atlas and font texture. Additionally there are two changes which improve the time it takes to initialize the nuklear font texture:
- Font baking is done in a background thread at startup if the option is enabled
- A pixel buffer is used to asynchronously upload a font texture (on non embedded builds)

From testing the font texture is about 250mb currently so this option is disabled by default on embedded