### PR TITLE
Make lasers more lenient earlier

### DIFF
--- a/Main/include/HitStat.hpp
+++ b/Main/include/HitStat.hpp
@@ -46,7 +46,7 @@ struct HitWindow
 
 	void ToLuaTable(struct lua_State* L) const;
 
-	inline HitWindow& operator= (const HitWindow& that) noexcept { perfect = that.perfect; good = that.good; hold = that.hold; miss = that.miss; slam = that.slam; return *this; }
+	inline HitWindow& operator= (const HitWindow& that) noexcept = default;
 
 	constexpr bool operator== (const HitWindow& that) const noexcept { return perfect == that.perfect && good == that.good && hold == that.hold && miss == that.miss && slam == that.slam; }
 	constexpr bool operator<= (const HitWindow& that) const noexcept { return perfect <= that.perfect && good <= that.good && hold <= that.hold && miss <= that.miss && slam <= that.slam; }
@@ -73,7 +73,7 @@ struct HitWindow
 	MapTime good = 150;
 	MapTime hold = 150;
 	MapTime miss = 300;
-	MapTime slam = 84;
+	MapTime slam = 88;
 
 	static const HitWindow NORMAL;
 	static const HitWindow HARD;

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -81,7 +81,7 @@ public:
 	~Scoring();
 
 	static ClearMark CalculateBadge(const ScoreIndex& score);
-	static ClearMark CalculateBestBadge(Vector<ScoreIndex*> scores);
+	static ClearMark CalculateBestBadge(const Vector<ScoreIndex*>& scores);
 
 	// Needs to be set to find out which objects are active/hittable
 	void SetPlayback(BeatmapPlayback& playback);
@@ -106,9 +106,9 @@ public:
 	static float GetLaserPosition(uint32 index, float pos);
 	float GetLaserRollOutput(uint32 index);
 	// Check if any lasers are currently active
-	bool GetLaserActive();
-	bool GetFXActive();
-	float GetLaserOutput();
+	bool GetLaserActive() const;
+	bool GetFXActive() const;
+	float GetLaserOutput() const;
 
 	float GetMeanHitDelta(bool absolute = false);
 	int16 GetMedianHitDelta(bool absolute = false);
@@ -127,7 +127,7 @@ public:
 
 	bool IsFailOut() const;
 	class Gauge* GetTopGauge() const;
-	void SetAllGaugeValues(const Vector<float>, bool zeroRest=true);
+	void SetAllGaugeValues(const Vector<float>&, bool zeroRest=true);
 	void GetAllGaugeValues(Vector<float>& out) const;
 
 	// Calculates the maximum score of the current map
@@ -191,7 +191,7 @@ public:
 	HitWindow hitWindow = HitWindow::NORMAL;
 
 	// Map total infos
-	MapTotals mapTotals;
+	MapTotals mapTotals{};
 	// Maximum accumulated score of object that have been hit or missed
 	// used to calculate accuracy up to a give point
 	uint32 currentMaxScore = 0;
@@ -210,13 +210,13 @@ public:
 	uint32 timedHits[2] = { 0 };
 
 	// Current combo
-	uint32 currentComboCounter;
+	uint32 currentComboCounter{};
 
 	// Combo state (0 = regular, 1 = full combo, 2 = perfect)
 	uint8 comboState = 2;
 
 	// Highest combo in current run
-	uint32 maxComboCounter;
+	uint32 maxComboCounter{};
 
 	// The timings of hit objects, sorted by time hit
 	// these are used for debugging
@@ -225,13 +225,13 @@ public:
 	struct AutoplayInfo autoplayInfo;
 
 	// Actual positions of the laser
-	float laserPositions[2];
+	float laserPositions[2]{};
 	// Sampled target position of the lasers in the map
 	float laserTargetPositions[2] = { 0 };
 	// Current lasers are extended
 	bool lasersAreExtend[2] = { false, false };
 	// Time since laser has been used
-	float timeSinceLaserUsed[2];
+	float timeSinceLaserUsed[2]{};
 	constexpr static const float laserOutputInterpolationDuration = 0.1f;
 private:
 	// Calculates the number of ticks for a given TP
@@ -306,15 +306,12 @@ private:
 
 	// Input values for laser [-1,1]
 	float m_laserInput[2] = { 0.0f };
-	// Decides if the coming tick should be auto completed
+	// Decides if the laser segment should be auto-played
 	float m_autoLaserTime[2] = { 0.0f };
 	const double m_laserDistanceLeniency = 1 / 6.;
 	const float m_autoLaserDuration = 4 / 60.f;
 	const float m_autoLaserDurationWhileTurningInCorrectDirection = 5 / 60.f;
 	const float m_autoLaserDurationAfterSlam = 8 / 60.f;
-
-	//Ehhhh maybe
-	const MapTime m_offsetLaserConstant = 5;
 	
 	// Saves the time when a button was hit, used to decide if a button was held before a hold object was active
 	MapTime m_buttonHitTime[6] = { 0, 0, 0, 0, 0, 0 };
@@ -342,9 +339,9 @@ private:
 	Vector<ScoreTick*> m_ticks[8];
 
 	// Hold objects
-	ObjectState* m_holdObjects[8];
+	ObjectState* m_holdObjects[8]{};
 	Set<ObjectState*> m_heldObjects;
-	bool m_prevHoldHit[6];
+	bool m_prevHoldHit[6]{};
 
 	PlaybackOptions m_options;
 	MapTimeRange m_range;

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -308,8 +308,9 @@ private:
 	// Decides if the coming tick should be auto completed
 	float m_autoLaserTime[2] = { 0.0f };
 	const double m_laserDistanceLeniency = 1 / 6.;
-	const float m_autoLaserDuration = 4.5f / 60.f;
-	const float m_autoLaserDurationAfterSlam = 8.25f / 60.f;
+	const float m_autoLaserDuration = 4 / 60.f;
+	const float m_autoLaserDurationWhileTurningInCorrectDirection = 4.5f / 60.f;
+	const float m_autoLaserDurationAfterSlam = 8 / 60.f;
 
 	//Ehhhh maybe
 	const MapTime m_offsetLaserConstant = 5;

--- a/Main/include/Scoring.hpp
+++ b/Main/include/Scoring.hpp
@@ -103,7 +103,7 @@ public:
 	// Updates the list of objects that are possible to hit
 	void Tick(float deltaTime);
 
-	float GetLaserPosition(uint32 index, float pos);
+	static float GetLaserPosition(uint32 index, float pos);
 	float GetLaserRollOutput(uint32 index);
 	// Check if any lasers are currently active
 	bool GetLaserActive();
@@ -232,6 +232,7 @@ public:
 	bool lasersAreExtend[2] = { false, false };
 	// Time since laser has been used
 	float timeSinceLaserUsed[2];
+	constexpr static const float laserOutputInterpolationDuration = 0.1f;
 private:
 	// Calculates the number of ticks for a given TP
 	double m_CalculateTicks(const TimingPoint* tp) const;
@@ -309,7 +310,7 @@ private:
 	float m_autoLaserTime[2] = { 0.0f };
 	const double m_laserDistanceLeniency = 1 / 6.;
 	const float m_autoLaserDuration = 4 / 60.f;
-	const float m_autoLaserDurationWhileTurningInCorrectDirection = 4.5f / 60.f;
+	const float m_autoLaserDurationWhileTurningInCorrectDirection = 5 / 60.f;
 	const float m_autoLaserDurationAfterSlam = 8 / 60.f;
 
 	//Ehhhh maybe

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -1242,8 +1242,6 @@ public:
 			}
 		}
 
-
-
 		if (m_practiceSetupDialog)
 			m_practiceSetupDialog->Render(deltaTime);
 	}

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -468,20 +468,7 @@ bool Scoring::IsLaserIdle(uint32 index) const
 
 bool Scoring::IsFailOut() const
 {
-	// TODO: Replace with std::all_of()
-	if (m_gaugeStack.empty())
-		return true;
-
-	if (m_gaugeStack.size() == 1)
-		return m_gaugeStack.back()->FailOut();
-
-	for (auto g : m_gaugeStack)
-	{
-		// If there are any gauges left, then don't fail
-		if (!g->FailOut())
-			return false;
-	}
-	return true;
+	return std::all_of(m_gaugeStack.cbegin(), m_gaugeStack.cend(), [](Gauge *g) { return g->FailOut(); });
 }
 
 Gauge* Scoring::GetTopGauge() const

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1324,9 +1324,12 @@ void Scoring::m_UpdateLasers(float deltaTime)
 			if (incomingLaser)
 			{
 				laserPositions[i] = incomingLaser->points[0];
-				m_autoLaserTime[i] = inputDir == incomingLaser->GetDirection() || inputDir == 0
-									 ? m_autoLaserDuration
-									 : 0;
+				if (inputDir == incomingLaser->GetDirection())
+					m_autoLaserTime[i] = m_autoLaserDurationWhileTurningInCorrectDirection;
+				else if (inputDir == 0)
+					m_autoLaserTime[i] = m_autoLaserDuration;
+				else
+					m_autoLaserTime[i] = 0;
 			}
 		}
 

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1330,12 +1330,9 @@ void Scoring::m_UpdateLasers(float deltaTime)
 			if (incomingLaser)
 			{
 				laserPositions[i] = incomingLaser->points[0];
-				if (inputDir == 0)
-					m_autoLaserTime[i] = m_autoLaserDuration;
-				else if (inputDir == incomingLaser->GetDirection())
-					m_autoLaserTime[i] = m_autoLaserDurationWhileTurningInCorrectDirection;
-				else
-					m_autoLaserTime[i] = 0;
+				m_autoLaserTime[i] = inputDir == incomingLaser->GetDirection() || inputDir == 0
+									 ? m_autoLaserDuration
+									 : 0;
 			}
 		}
 

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1294,10 +1294,19 @@ void Scoring::m_UpdateLasers(float deltaTime)
 				}
 
 				positionDelta = laserTargetPositions[i] - laserPositions[i];
-				if ((inputDir == laserDir || laserDir == 0) && fabsf(positionDelta) <= m_laserDistanceLeniency)
-                    m_autoLaserTime[i] = m_autoLaserDuration;
+				if (fabsf(positionDelta) <= m_laserDistanceLeniency)
+				{
+					if (laserDir == 0)
+						m_autoLaserTime[i] = m_autoLaserDuration;
+					else if (inputDir == laserDir)
+						m_autoLaserTime[i] = m_autoLaserDurationWhileTurningInCorrectDirection;
+					else
+						m_autoLaserTime[i] -= deltaTime;
+				}
 				else
+				{
 					m_autoLaserTime[i] -= deltaTime;
+				}
 			}
 			// Lock lasers on straight parts
 			else if (laserDir == 0 && fabsf(positionDelta) <= m_laserDistanceLeniency)

--- a/Main/src/Scoring.cpp
+++ b/Main/src/Scoring.cpp
@@ -1206,7 +1206,6 @@ void Scoring::m_UpdateLasers(float deltaTime)
 				if (current->next && current->next->GetDirection() == 0 && current->flags & LaserObjectState::flag_Instant)
 					currentlySlamNextSegmentStraight[index] = true;
 
-				// Unused but might be useful for skin stuff?
 				auto prevDirection = prev ? prev->GetDirection() : 0;
 				auto currentDirection = current->GetDirection();
 				changeInDirection[index] = prevDirection != currentDirection;
@@ -1282,7 +1281,13 @@ void Scoring::m_UpdateLasers(float deltaTime)
 					else if (inputDir == laserDir)
 						m_autoLaserTime[i] = m_autoLaserDurationWhileTurningInCorrectDirection;
 					else
-						m_autoLaserTime[i] -= deltaTime;
+					{
+						float timeSinceDirectionChange = (currentSegment->time - mapTime) / 1000.f;
+						if (changeInDirection[i])
+							m_autoLaserTime[i] = Math::Min(m_autoLaserTime[i] - deltaTime, m_autoLaserDuration - timeSinceDirectionChange);
+						else
+							m_autoLaserTime[i] -= deltaTime;
+					}
 				}
 				else
 				{
@@ -1320,7 +1325,6 @@ void Scoring::m_UpdateLasers(float deltaTime)
 		if (autoplayInfo.autoplay || m_autoLaserTime[i] > 0)
 			laserPositions[i] = laserTargetPositions[i];
 
-		// Clamp cursor between 0 and 1
 		laserPositions[i] = Math::Clamp(laserPositions[i], 0.0f, 1.0f);
 		if (fabsf(laserPositions[i] - laserTargetPositions[i]) <= m_laserDistanceLeniency && currentSegment)
 			m_SetHoldObject(*currentSegment->GetRoot(), 6 + i);


### PR DESCRIPTION
Turns out it's +5 (or maybe +6? +6 sounds too high though)/-4 frames.

I think it makes sense to be more lenient for turning early since it's more catastrophic for the player to derail earlier than later.

Play tested a bit, I think it feels fine.