### PR TITLE
Fix out of bounds access on back button input

### DIFF
--- a/Main/src/Input.cpp
+++ b/Main/src/Input.cpp
@@ -400,7 +400,7 @@ void Input::m_OnButtonInput(Button b, bool pressed)
 	}
 
 	static Timer t;
-	if(b >= Button::LS_0Neg)
+	if(b >= Button::LS_0Neg && b <= Button::LS_1Pos)
 	{
 		int32 btnIdx = (int32)b - (int32)Button::LS_0Neg;
 		int32 laserIdx = btnIdx / 2;


### PR DESCRIPTION
This code was incorrectly treating a back button input as a laser input.
This resulted in an out of bounds array access, causing random left
laser inputs when hitting the back button.