### PR TITLE
Fix and extend custom flangers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.lib
 *.exe
 *.a
+bin/usc-game
+bin/Tests.Game
+bin/Tests.Shared
 
 # Memory dump files
 *.dmp

--- a/Audio/include/Audio/DSP.hpp
+++ b/Audio/include/Audio/DSP.hpp
@@ -222,6 +222,9 @@ public:
 
 	void SetLength(double length);
 	void SetDelayRange(uint32 min, uint32 max);
+	void SetFeedback(float feedback);
+	void SetStereoWidth(float stereoWidth);
+	void SetVolume(float volume);
 
 	virtual void Process(float *out, uint32 numSamples);
 	virtual const char *GetName() const { return "FlangerDSP"; }
@@ -232,6 +235,10 @@ private:
 	// Delay range
 	uint32 m_min = 0;
 	uint32 m_max = 0;
+
+	float m_feedback = 0.f;
+	float m_stereoWidth = 0.f;
+	float m_volume = 0.f;
 
 	Vector<float> m_sampleBuffer;
 	uint32 m_time = 0;

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -554,9 +554,9 @@ void FlangerDSP::Process(float *out, uint32 numSamples)
 			continue;
 		}
 		// Determine where we want to sample past samples
-		float f = fmodf(((float)m_time / (float)m_length), 1.f);
+		float f = fmodf(((float)m_time / ((float)m_length * 2)), 1.f);
 		f = fabsf(f * 2 - 1);
-		uint32 dLeft = (uint32)(m_min + (depth * f));
+		uint32 dLeft = (uint32)(m_max - (depth * f));
 		uint32 dRight = dLeft + (uint32)(m_stereoWidth * depth);
 		// "fold" dRight to fit [m_min,m_max] range: matches KSM behavior
 		if (dRight > m_max) dRight = m_max - (dRight - m_max);

--- a/Beatmap/include/Beatmap/AudioEffects.hpp
+++ b/Beatmap/include/Beatmap/AudioEffects.hpp
@@ -161,6 +161,12 @@ struct AudioEffect
 			EffectParam<int32> offset;
 			// Depth of the effect (samples)
 			EffectParam<int32> depth;
+			// Feedback (0-1)
+			EffectParam<float> feedback;
+			// Stereo width (0-1)
+			EffectParam<float> stereoWidth;
+			// Volume of added source audio + delayed source audio (0-1)
+			EffectParam<float> volume;
 		} flanger;
 		struct
 		{

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -104,8 +104,12 @@ static AudioEffect CreateDefault(EffectType type)
 		break;
 	case EffectType::Flanger:
 		ret.duration = TimeRange(2000);
-		ret.flanger.offset = IntRange(10);
-		ret.flanger.depth = IntRange(40);
+		ret.mix = FloatRange(0.8f);
+		ret.flanger.offset = IntRange(30);
+		ret.flanger.depth = IntRange(45);
+		ret.flanger.feedback = FloatRange(0.6f);
+		ret.flanger.stereoWidth = FloatRange(0.0f);
+		ret.flanger.volume = FloatRange(0.75f);
 		break;
 	case EffectType::SwitchAudio:
 		ret.switchaudio.index = -1;

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -103,7 +103,7 @@ static AudioEffect CreateDefault(EffectType type)
 		ret.wobble.q = FloatRange(2.0f);
 		break;
 	case EffectType::Flanger:
-		ret.duration = TimeRange(2000);
+		ret.duration = TimeRange(2.0f);
 		ret.mix = FloatRange(0.8f);
 		ret.flanger.offset = IntRange(30);
 		ret.flanger.depth = IntRange(45);

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -137,6 +137,7 @@ struct MultiParam
 	{
 		Float,
 		Samples,
+		Milliseconds,
 		Int,
 	};
 	Type type;
@@ -164,22 +165,20 @@ struct MultiParamRange
 		r.isRange = isRange;
 		return r;
 	}
-	EffectParam<EffectDuration> ToDurationParam(bool isAbsolute) // TODO: revamp isAbsolute
+	EffectParam<EffectDuration> ToDurationParam()
 	{
 		EffectParam<EffectDuration> r;
-		if (isAbsolute)
+		if (params[0].type == MultiParam::Milliseconds)
 		{
-			if (params[0].type == MultiParam::Float)
-			{
-				r = EffectParam<EffectDuration>((int)(1000.f * params[0].fval), (int)(1000.f * params[1].fval));
-			}
-			else
-			{
-				r = EffectParam<EffectDuration>(1000 * params[0].ival, 1000 * params[1].ival);
-			}
+			r = EffectParam<EffectDuration>(params[0].ival, params[1].ival);
 		}
-		else {
-			r = params[0].type == MultiParam::Float ? EffectParam<EffectDuration>(params[0].fval, params[1].fval) : EffectParam<EffectDuration>(params[0].ival, params[1].ival);
+		else if (params[0].type == MultiParam::Float)
+		{
+			r = EffectParam<EffectDuration>(params[0].fval, params[1].fval);
+		}
+		else
+		{
+			r = EffectParam<EffectDuration>((float)params[0].ival, (float)params[1].ival);
 		}
 		r.isRange = isRange;
 		return r;
@@ -209,6 +208,18 @@ static MultiParam ParseParam(const String &in)
 	{
 		ret.type = MultiParam::Samples;
 		sscanf(*in, "%i", &ret.ival);
+	}
+	else if (in.find("ms") != -1)
+	{
+		ret.type = MultiParam::Milliseconds;
+		sscanf(*in, "%i", &ret.ival);
+	}
+	else if (in.find("s") != -1)
+	{
+		ret.type = MultiParam::Milliseconds;
+		float seconds = 0;
+		sscanf(*in, "%f", &seconds);
+		ret.ival = (int)(seconds * 1000.0);
 	}
 	else if (in.find("%") != -1)
 	{
@@ -319,11 +330,11 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 			target = param->ToFloatParam();
 		}
 	};
-	auto AssignDurationIfSet = [&](EffectParam<EffectDuration> &target, const String &name, bool absolute) {
+	auto AssignDurationIfSet = [&](EffectParam<EffectDuration> &target, const String &name) {
 		auto *param = params.Find(name);
 		if (param)
 		{
-			target = param->ToDurationParam(absolute);
+			target = param->ToDurationParam();
 		}
 	};
 	auto AssignSamplesIfSet = [&](EffectParam<int32> &target, const String &name) {
@@ -354,11 +365,11 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 		AssignSamplesIfSet(effect.bitcrusher.reduction, "amount");
 		break;
 	case EffectType::Echo:
-		AssignDurationIfSet(effect.duration, "waveLength", false);
+		AssignDurationIfSet(effect.duration, "waveLength");
 		AssignFloatIfSet(effect.echo.feedback, "feedbackLevel");
 		break;
 	case EffectType::Flanger:
-		AssignDurationIfSet(effect.duration, "period", true);
+		AssignDurationIfSet(effect.duration, "period");
 		AssignIntIfSet(effect.flanger.depth, "depth");
 		AssignIntIfSet(effect.flanger.offset, "delay");
 		AssignFloatIfSet(effect.flanger.feedback, "feedback");
@@ -366,22 +377,22 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 		AssignFloatIfSet(effect.flanger.volume, "volume");
 		break;
 	case EffectType::Gate:
-		AssignDurationIfSet(effect.duration, "waveLength", false);
+		AssignDurationIfSet(effect.duration, "waveLength");
 		AssignFloatIfSet(effect.gate.gate, "rate");
 		break;
 	case EffectType::Retrigger:
-		AssignDurationIfSet(effect.duration, "waveLength", false);
+		AssignDurationIfSet(effect.duration, "waveLength");
 		AssignFloatIfSet(effect.retrigger.gate, "rate");
-		AssignDurationIfSet(effect.retrigger.reset, "updatePeriod", false);
+		AssignDurationIfSet(effect.retrigger.reset, "updatePeriod");
 		break;
 	case EffectType::Wobble:
-		AssignDurationIfSet(effect.duration, "waveLength", false);
+		AssignDurationIfSet(effect.duration, "waveLength");
 		AssignFloatIfSet(effect.wobble.min, "loFreq");
 		AssignFloatIfSet(effect.wobble.max, "hiFreq");
 		AssignFloatIfSet(effect.wobble.q, "Q");
 		break;
 	case EffectType::TapeStop:
-		AssignDurationIfSet(effect.duration, "speed", false);
+		AssignDurationIfSet(effect.duration, "speed");
 		break;
 	case EffectType::SwitchAudio:
 		AssignIntIfSet(effect.switchaudio.index, "index");

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -164,7 +164,7 @@ struct MultiParamRange
 		r.isRange = isRange;
 		return r;
 	}
-	EffectParam<EffectDuration> ToDurationParam(bool isAbsolute)
+	EffectParam<EffectDuration> ToDurationParam(bool isAbsolute) // TODO: revamp isAbsolute
 	{
 		EffectParam<EffectDuration> r;
 		if (isAbsolute)
@@ -175,7 +175,7 @@ struct MultiParamRange
 			}
 			else
 			{
-				r = EffectParam<EffectDuration>(params[0].ival, params[1].ival);
+				r = EffectParam<EffectDuration>(1000 * params[0].ival, 1000 * params[1].ival);
 			}
 		}
 		else {

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -212,7 +212,9 @@ static MultiParam ParseParam(const String &in)
 	else if (in.find("ms") != -1)
 	{
 		ret.type = MultiParam::Milliseconds;
-		sscanf(*in, "%i", &ret.ival);
+		float milliseconds = 0;
+		sscanf(*in, "%f", &milliseconds);
+		ret.ival = (int)(milliseconds);
 	}
 	else if (in.find("s") != -1)
 	{

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -361,6 +361,9 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 		AssignDurationIfSet(effect.duration, "period", true);
 		AssignIntIfSet(effect.flanger.depth, "depth");
 		AssignIntIfSet(effect.flanger.offset, "delay");
+		AssignFloatIfSet(effect.flanger.feedback, "feedback");
+		AssignFloatIfSet(effect.flanger.stereoWidth, "stereoWidth");
+		AssignFloatIfSet(effect.flanger.volume, "volume");
 		break;
 	case EffectType::Gate:
 		AssignDurationIfSet(effect.duration, "waveLength", false);

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -90,6 +90,9 @@ DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32
 		fl->SetLength(actualLength);
 		fl->SetDelayRange(abs(flanger.offset.Sample(filterInput)),
 						  abs(flanger.depth.Sample(filterInput)));
+		fl->SetFeedback(flanger.feedback.Sample(filterInput));
+		fl->SetStereoWidth(flanger.stereoWidth.Sample(filterInput));
+		fl->SetVolume(flanger.volume.Sample(filterInput));
 		ret = fl;
 		break;
 	}
@@ -176,8 +179,6 @@ void GameAudioEffect::SetParams(DSP *dsp, AudioPlayback &playback, HoldObjectSta
 	case EffectType::Flanger:
 	{
 		FlangerDSP *fl = (FlangerDSP *)dsp;
-		double delay = (noteDuration) / 1000.0;
-		fl->SetDelayRange(10, 40);
 		break;
 	}
 	case EffectType::PitchShift:


### PR DESCRIPTION
Fix duration params so they support absolute (s, ms) and relative (float) lengths.
Support `feedback`, `stereoWidth`, and `volume` params for custom flangers.

Comparison between KSM, fixed USC, and original USC using `#define_fx testFlanger type=Flanger;period=2;stereoWidth=25%` on white noise:
![flanger](https://user-images.githubusercontent.com/2906473/133943988-55f699ef-d760-4409-98ae-a877fcc1c663.png)
- Note the "folding" due to `stereoWidth` in the right channels of `KSM` and `USC fixed`.
- `USC orig` interpreted `period=2` as 2 ms.