### PR TITLE
Extend custom phasers

### DIFF
--- a/Audio/include/Audio/DSP.hpp
+++ b/Audio/include/Audio/DSP.hpp
@@ -5,6 +5,31 @@
 #include "AudioBase.hpp"
 #include <Shared/Interpolation.hpp>
 
+// Biquad Filter
+// Thanks to https://www.youtube.com/watch?v=FnpkBE4kJ6Q&list=WL&index=8 for the explanation
+// Also http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt for the coefficient formulas
+class BQF
+{
+public:
+	float b0 = 1.0f;
+	float b1 = 0.0f;
+	float b2 = 0.0f;
+	float a0 = 1.0f;
+	float a1 = 0.0f;
+	float a2 = 0.0f;
+
+	void SetPeaking(float q, float freq, float gain, float sampleRate);
+	void SetLowPass(float q, float freq, float sampleRate);
+	void SetHighPass(float q, float freq, float sampleRate);
+	void SetAllPass(float q, float freq, float sampleRate);
+	float Update(float in);
+private:
+	// FIR Delay buffers
+	float zb[2]{};
+	// IIR Delay buffers
+	float za[2]{};
+};
+
 class PanDSP : public DSP
 {
 public:
@@ -14,19 +39,10 @@ public:
 	virtual const char *GetName() const { return "PanDSP"; }
 };
 
-// Biquad Filter
-// Thanks to https://www.youtube.com/watch?v=FnpkBE4kJ6Q&list=WL&index=8 for the explanation
-// Also http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt for the coefficient formulas
 class BQFDSP : public DSP
 {
 public:
 	BQFDSP(uint32 sampleRate);
-	float b0 = 1.0f;
-	float b1 = 0.0f;
-	float b2 = 0.0f;
-	float a0 = 1.0f;
-	float a1 = 0.0f;
-	float a2 = 0.0f;
 
 	virtual void Process(float *out, uint32 numSamples);
 	virtual const char *GetName() const { return "BQFDSP"; }
@@ -36,17 +52,8 @@ public:
 	void SetLowPass(float q, float freq);
 	void SetHighPass(float q, float freq);
 
-	void SetPeaking(float q, float freq, float gain, float sampleRate);
-	void SetLowPass(float q, float freq, float sampleRate);
-	void SetHighPass(float q, float freq, float sampleRate);
-
 private:
-	// Delayed samples
-	static const uint32 order = 2;
-	// FIR Delay buffers
-	float zb[2][order]{};
-	// IIR Delay buffers
-	float za[2][order]{};
+	BQF m_filters[2];
 };
 
 // Combinded Low/High-pass and Peaking filter
@@ -161,7 +168,7 @@ private:
 	bool m_bufferReserved = false;
 };
 
-class WobbleDSP : public BQFDSP
+class WobbleDSP : public DSP
 {
 public:
 	WobbleDSP(uint32 sampleRate);
@@ -177,42 +184,35 @@ public:
 	virtual const char *GetName() const { return "WobbleDSP"; }
 
 private:
+	BQF m_filters[2];
 	uint32 m_length{};
 	uint32 m_currentSample = 0;
 };
 
-// Referenced http://www.musicdsp.org/files/phaser.cpp
 class PhaserDSP : public DSP
 {
 public:
 	PhaserDSP(uint32 sampleRate);
 
-	uint32 time = 0;
-
 	// Frequency range
-	float dmin = 1000.0f;
-	float dmax = 4000.0f;
-	float fb = 0.2f;	//feedback
-	float lmix = 0.33f; //local mix
+	float fmin = 1500.0f;
+	float fmax = 20000.0f;
+	float q = 0.707f;
+	float feedback = 0.35f;
+	float stereoWidth = 0.0f;
 
 	void SetLength(double length);
+	void SetStage(uint32 stage);
 
 	virtual void Process(float *out, uint32 numSamples);
 	virtual const char *GetName() const { return "PhaserDSP"; }
 
 private:
 	uint32 m_length = 0;
-
-	// All pass filter
-	struct APF
-	{
-		float Update(float in);
-		float a1 = 0.0f;
-		float za = 0.0f;
-	};
-
-	APF filters[2][6];
+	uint32 m_stage = 6;
+	BQF m_apf[12][2];
 	float za[2] = {0.0f};
+	uint32 m_currentSample = 0;
 };
 
 class FlangerDSP : public DSP

--- a/Audio/include/Audio/DSP.hpp
+++ b/Audio/include/Audio/DSP.hpp
@@ -18,10 +18,11 @@ public:
 	float a1 = 0.0f;
 	float a2 = 0.0f;
 
-	void SetPeaking(float q, float freq, float gain, float sampleRate);
 	void SetLowPass(float q, float freq, float sampleRate);
 	void SetHighPass(float q, float freq, float sampleRate);
 	void SetAllPass(float q, float freq, float sampleRate);
+	void SetPeaking(float q, float freq, float gain, float sampleRate);
+	void SetHighShelf(float q, float freq, float gain, float sampleRate);
 	float Update(float in);
 private:
 	// FIR Delay buffers
@@ -200,6 +201,7 @@ public:
 	float q = 0.707f;
 	float feedback = 0.35f;
 	float stereoWidth = 0.0f;
+	float hiCutGain = -8.0f;
 
 	void SetLength(double length);
 	void SetStage(uint32 stage);
@@ -211,6 +213,7 @@ private:
 	uint32 m_length = 0;
 	uint32 m_stage = 6;
 	BQF m_apf[12][2];
+	BQF m_hiShelf[2];
 	float za[2] = {0.0f};
 	uint32 m_currentSample = 0;
 };

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -731,7 +731,7 @@ PitchShiftDSP::~PitchShiftDSP()
 }
 void PitchShiftDSP::Process(float *out, uint32 numSamples)
 {
-	m_impl->pitch = Math::Clamp(amount, -12.0f, 12.0f);
+	m_impl->pitch = Math::Clamp(amount, -48.0f, 48.0f);
 	if (!m_impl->init)
 		m_impl->Init(m_sampleRate);
 	m_impl->Process(out, numSamples);

--- a/Audio/src/DSP.cpp
+++ b/Audio/src/DSP.cpp
@@ -3,59 +3,7 @@
 #include "AudioOutput.hpp"
 #include "Audio_Impl.hpp"
 
-void PanDSP::Process(float *out, uint32 numSamples)
-{
-	for (uint32 i = 0; i < numSamples; i++)
-	{
-		if (panning > 0)
-			out[i * 2 + 0] = (out[i * 2 + 0] * (1.0f - panning)) * mix + out[i * 2 + 0] * (1 - mix);
-		if (panning < 0)
-			out[i * 2 + 1] = (out[i * 2 + 1] * (1.0f + panning)) * mix + out[i * 2 + 1] * (1 - mix);
-	}
-}
-
-BQFDSP::BQFDSP(uint32 sampleRate) : DSP()
-{
-	SetSampleRate(sampleRate);
-
-	for (size_t i = 0; i < 2; i++)
-	{
-		for (size_t j = 0; j < order; j++)
-		{
-			za[i][j] = 0.f;
-			zb[i][j] = 0.f;
-		}
-	}
-}
-void BQFDSP::Process(float *out, uint32 numSamples)
-{
-	for (uint32 c = 0; c < 2; c++)
-	{
-		for (uint32 i = 0; i < numSamples; i++)
-		{
-			float &sample = out[i * 2 + c];
-			float src = sample;
-
-			float filtered =
-				(b0 / a0) * src +
-				(b1 / a0) * zb[c][0] +
-				(b2 / a0) * zb[c][1] -
-				(a1 / a0) * za[c][0] -
-				(a2 / a0) * za[c][1];
-
-			// Shift delay buffers
-			zb[c][1] = zb[c][0];
-			zb[c][0] = src;
-
-			// Feedback the calculated value into the IIR delay buffers
-			za[c][1] = za[c][0];
-			za[c][0] = filtered;
-
-			sample = filtered;
-		}
-	}
-}
-void BQFDSP::SetLowPass(float q, float freq, float sampleRate)
+void BQF::SetLowPass(float q, float freq, float sampleRate)
 {
 	// Limit q
 	q = Math::Max(q, 0.01f);
@@ -72,11 +20,7 @@ void BQFDSP::SetLowPass(float q, float freq, float sampleRate)
 	a1 = (float)(-2 * cw0);
 	a2 = 1 - alpha;
 }
-void BQFDSP::SetLowPass(float q, float freq)
-{
-	SetLowPass(q, freq, (float)m_sampleRate);
-}
-void BQFDSP::SetHighPass(float q, float freq, float sampleRate)
+void BQF::SetHighPass(float q, float freq, float sampleRate)
 {
 	// Limit q
 	q = Math::Max(q, 0.01f);
@@ -93,11 +37,23 @@ void BQFDSP::SetHighPass(float q, float freq, float sampleRate)
 	a1 = (float)(-2 * cw0);
 	a2 = 1 - alpha;
 }
-void BQFDSP::SetHighPass(float q, float freq)
+void BQF::SetAllPass(float q, float freq, float sampleRate)
 {
-	SetHighPass(q, freq, (float)m_sampleRate);
+	// Limit q
+	q = Math::Max(q, 0.01f);
+
+	double w0 = (2 * Math::pi * freq) / sampleRate;
+	double cw0 = cos(w0);
+	float alpha = (float)(sin(w0) / (2 * q));
+
+	b0 = 1 - alpha;
+	b1 = (float)(-2 * cw0);
+	b2 = 1 + alpha;
+	a0 = 1 + alpha;
+	a1 = (float)(-2 * cw0);
+	a2 = 1 - alpha;
 }
-void BQFDSP::SetPeaking(float q, float freq, float gain, float sampleRate)
+void BQF::SetPeaking(float q, float freq, float gain, float sampleRate)
 {
 	// Limit q
 	q = Math::Max(q, 0.01f);
@@ -114,9 +70,71 @@ void BQFDSP::SetPeaking(float q, float freq, float gain, float sampleRate)
 	a1 = -2 * (float)cw0;
 	a2 = 1 - (float)(alpha / A);
 }
+float BQF::Update(float in)
+{
+	float filtered =
+		(b0 / a0) * in +
+		(b1 / a0) * zb[0] +
+		(b2 / a0) * zb[1] -
+		(a1 / a0) * za[0] -
+		(a2 / a0) * za[1];
+
+	// Shift delay buffers
+	zb[1] = zb[0];
+	zb[0] = in;
+
+	// Feedback the calculated value into the IIR delay buffers
+	za[1] = za[0];
+	za[0] = filtered;
+
+	return filtered;
+}
+
+void PanDSP::Process(float *out, uint32 numSamples)
+{
+	for (uint32 i = 0; i < numSamples; i++)
+	{
+		if (panning > 0)
+			out[i * 2 + 0] = (out[i * 2 + 0] * (1.0f - panning)) * mix + out[i * 2 + 0] * (1 - mix);
+		if (panning < 0)
+			out[i * 2 + 1] = (out[i * 2 + 1] * (1.0f + panning)) * mix + out[i * 2 + 1] * (1 - mix);
+	}
+}
+
+BQFDSP::BQFDSP(uint32 sampleRate) : DSP()
+{
+	SetSampleRate(sampleRate);
+}
+void BQFDSP::Process(float *out, uint32 numSamples)
+{
+	for (uint32 c = 0; c < 2; c++)
+	{
+		for (uint32 i = 0; i < numSamples; i++)
+		{
+			out[i * 2 + c] = m_filters[c].Update(out[i * 2 + c]);
+		}
+	}
+}
+void BQFDSP::SetLowPass(float q, float freq)
+{
+	for (uint32 c = 0; c < 2; c++)
+	{
+		m_filters[c].SetLowPass(q, freq, (float)m_sampleRate);
+	}
+}
+void BQFDSP::SetHighPass(float q, float freq)
+{
+	for (uint32 c = 0; c < 2; c++)
+	{
+		m_filters[c].SetHighPass(q, freq, (float)m_sampleRate);
+	}
+}
 void BQFDSP::SetPeaking(float q, float freq, float gain)
 {
-	SetPeaking(q, freq, gain, (float)m_sampleRate);
+	for (uint32 c = 0; c < 2; c++)
+	{
+		m_filters[c].SetPeaking(q, freq, gain, (float)m_sampleRate);
+	}
 }
 
 CombinedFilterDSP::CombinedFilterDSP(uint32 sampleRate) : DSP(), a(sampleRate), peak(sampleRate)
@@ -397,8 +415,9 @@ void RetriggerDSP::Process(float *out, uint32 numSamples)
 	}
 }
 
-WobbleDSP::WobbleDSP(uint32 sampleRate) : BQFDSP(sampleRate)
+WobbleDSP::WobbleDSP(uint32 sampleRate) : DSP()
 {
+	SetSampleRate(sampleRate);
 }
 void WobbleDSP::SetLength(double length)
 {
@@ -423,14 +442,11 @@ void WobbleDSP::Process(float *out, uint32 numSamples)
 		float f = abs(2.0f * ((float)m_currentSample / (float)m_length) - 1.0f);
 		f = easing.Sample(f);
 		float freq = fmin + (fmax - fmin) * f;
-		SetLowPass(q, freq);
 
-		float s[2] = {out[i * 2], out[i * 2 + 1]};
-
-		BQFDSP::Process(&out[i * 2], 1);
-
-		out[i * 2 + 0] = out[i * 2 + 0] * mix + s[0] * (1.0f - mix);
-		out[i * 2 + 1] = out[i * 2 + 1] * mix + s[1] * (1.0f - mix);
+		for (uint32 c = 0; c < 2; c++) {
+			m_filters[c].SetLowPass(q, freq, (float)m_sampleRate);
+			out[i * 2 + c] = m_filters[c].Update(out[i * 2 + c]) * mix + out[i * 2 + c] * (1.0f - mix);
+		}
 
 		m_currentSample++;
 		m_currentSample %= m_length;
@@ -446,6 +462,11 @@ void PhaserDSP::SetLength(double length)
 	double flength = length / 1000.0 * m_sampleRate;
 	m_length = (uint32)flength;
 }
+void PhaserDSP::SetStage(uint32 stage)
+{
+	stage = Math::Clamp(stage, 0u, 12u);
+	m_stage = (stage / 2) * 2;
+}
 void PhaserDSP::Process(float *out, uint32 numSamples)
 {
 	if (m_length == 0)
@@ -460,46 +481,25 @@ void PhaserDSP::Process(float *out, uint32 numSamples)
 		{
 			continue;
 		}
-		//float f = ((float)time / (float)m_length) * Math::pi * 2.0f;
-		float f = abs(2.0f * ((float)time / (float)m_length) - 1.0f);
 
-		//calculate and update phaser sweep lfo...
-		//float d = dmin + (dmax - dmin) * ((sin(f) + 1.0f) / 2.0f);
-		float d = dmin + (dmax - dmin) * f;
-		d /= (float)m_sampleRate;
-
-		//calculate output per channel
-		for (uint32 c = 0; c < 2; c++)
-		{
-			APF *filters1 = filters[c];
-
-			//update filter coeffs
-			float a1 = (1.f - d) / (1.f + d);
-			for (int i = 0; i < 6; i++)
-				filters1[i].a1 = a1;
-
-			float filtered = filters1[0].Update(
-				filters1[1].Update(
-					filters1[2].Update(
-						filters1[3].Update(
-							filters1[4].Update(
-								filters1[5].Update(out[i * 2 + c] + za[c] * fb))))));
-			// Store filter feedback
-			za[c] = filtered;
-
-			// Final sample
-			out[i * 2 + c] = out[i * 2 + c] * (1.f - lmix) + filtered * mix * lmix;
+		float fLeft = abs(2.0f * ((float)m_currentSample / (float)m_length) - 1.0f);
+		float fRight = abs(2.0f * fmodf((float)m_currentSample / (float)m_length + stereoWidth, 1.0f) - 1.0f);
+		float f[2] = {fLeft, fRight};
+		for (uint32 c = 0; c < 2; c++) {
+			// logarithmic interpolation
+			float freq = pow(fmin, 1-f[c]) * pow(fmax, f[c]);
+			float output = feedback * za[c] + out[i * 2 + c];
+			for (uint32 j = 0; j < m_stage; j++) {
+				m_apf[j][c].SetAllPass(q, freq, (float)m_sampleRate);
+				output = m_apf[j][c].Update(output);
+			}
+			// effect strongest when mix = 0.5
+			out[i * 2 + c] = (mix/2) * output + (1-mix/2) * out[i * 2 + c];
+			za[c] = output;
 		}
-
-		time++;
-		time %= m_length;
+		m_currentSample++;
+		m_currentSample %= m_length;
 	}
-}
-float PhaserDSP::APF::Update(float in)
-{
-	float y = in * -a1 + za;
-	za = y * a1 + in;
-	return y;
 }
 
 FlangerDSP::FlangerDSP(uint32 sampleRate) : DSP()

--- a/Beatmap/include/Beatmap/AudioEffects.hpp
+++ b/Beatmap/include/Beatmap/AudioEffects.hpp
@@ -170,6 +170,8 @@ struct AudioEffect
 		} flanger;
 		struct
 		{
+			// Number of stages
+			EffectParam<int32> stage;
 			// Minimum frequency (Hz)
 			EffectParam<float> min;
 			// Maximum frequency (Hz)
@@ -180,6 +182,8 @@ struct AudioEffect
 			EffectParam<float> feedback;
 			// Stereo width (0-1)
 			EffectParam<float> stereoWidth;
+			// High cut gain (dB)
+			EffectParam<float> hiCutGain;
 		} phaser;
 		struct
 		{

--- a/Beatmap/include/Beatmap/AudioEffects.hpp
+++ b/Beatmap/include/Beatmap/AudioEffects.hpp
@@ -174,10 +174,12 @@ struct AudioEffect
 			EffectParam<float> min;
 			// Maximum frequency (Hz)
 			EffectParam<float> max;
-			// Depth of the effect (>=0)
-			EffectParam<float> depth;
+			// Q factor (0-1)
+			EffectParam<float> q;
 			// Feedback (0-1)
 			EffectParam<float> feedback;
+			// Stereo width (0-1)
+			EffectParam<float> stereoWidth;
 		} phaser;
 		struct
 		{

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -75,6 +75,7 @@ static AudioEffect CreateDefault(EffectType type)
 		ret.bitcrusher.reduction = IntRange(0, 45);
 		break;
 	case EffectType::Gate:
+		ret.mix = FloatRange(0.9f);
 		ret.gate.gate = 0.5f;
 		break;
 	case EffectType::Retrigger:
@@ -90,6 +91,7 @@ static AudioEffect CreateDefault(EffectType type)
 	case EffectType::TapeStop:
 		break;
 	case EffectType::Phaser:
+		ret.mix = FloatRange(0.5f);
 		ret.phaser.min = FloatRange(1500.0f);
 		ret.phaser.max = FloatRange(20000.0f);
 		ret.phaser.feedback = FloatRange(0.35f);
@@ -98,9 +100,10 @@ static AudioEffect CreateDefault(EffectType type)
 	case EffectType::Wobble:
 		// wobble is 1/12 by default
 		ret.duration = TimeRange(1.0f / 12.0f);
+		ret.mix = FloatRange(0.8f);
 		ret.wobble.max = FloatRange(20000.0f);
 		ret.wobble.min = FloatRange(500.0f);
-		ret.wobble.q = FloatRange(2.0f);
+		ret.wobble.q = FloatRange(1.414f);
 		break;
 	case EffectType::Flanger:
 		ret.duration = TimeRange(2.0f);

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -91,13 +91,15 @@ static AudioEffect CreateDefault(EffectType type)
 	case EffectType::TapeStop:
 		break;
 	case EffectType::Phaser:
+		ret.duration = TimeRange(0.5f);
 		ret.mix = FloatRange(0.5f);
+		ret.phaser.stage = IntRange(6);
 		ret.phaser.min = FloatRange(1500.0f);
 		ret.phaser.max = FloatRange(20000.0f);
 		ret.phaser.q = FloatRange(0.707f);
 		ret.phaser.feedback = FloatRange(0.35f);
 		ret.phaser.stereoWidth = FloatRange(0.0f);
-		ret.duration = TimeRange(0.5f);
+		ret.phaser.hiCutGain = FloatRange(-8.0f);
 		break;
 	case EffectType::Wobble:
 		// wobble is 1/12 by default

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -98,7 +98,7 @@ static AudioEffect CreateDefault(EffectType type)
 		ret.phaser.max = FloatRange(20000.0f);
 		ret.phaser.q = FloatRange(0.707f);
 		ret.phaser.feedback = FloatRange(0.35f);
-		ret.phaser.stereoWidth = FloatRange(0.0f);
+		ret.phaser.stereoWidth = FloatRange(0.75f);
 		ret.phaser.hiCutGain = FloatRange(-8.0f);
 		break;
 	case EffectType::Wobble:

--- a/Beatmap/src/AudioEffects.cpp
+++ b/Beatmap/src/AudioEffects.cpp
@@ -94,8 +94,10 @@ static AudioEffect CreateDefault(EffectType type)
 		ret.mix = FloatRange(0.5f);
 		ret.phaser.min = FloatRange(1500.0f);
 		ret.phaser.max = FloatRange(20000.0f);
+		ret.phaser.q = FloatRange(0.707f);
 		ret.phaser.feedback = FloatRange(0.35f);
-		ret.duration = TimeRange(1.f);
+		ret.phaser.stereoWidth = FloatRange(0.0f);
+		ret.duration = TimeRange(0.5f);
 		break;
 	case EffectType::Wobble:
 		// wobble is 1/12 by default

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -372,11 +372,13 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 		break;
 	case EffectType::Phaser:
 		AssignDurationIfSet(effect.duration, "period");
-		AssignFloatIfSet(effect.phaser.min, "feedback");
-		AssignFloatIfSet(effect.phaser.max, "feedback");
-		AssignFloatIfSet(effect.phaser.q, "feedback");
+		AssignIntIfSet(effect.phaser.stage, "stage");
+		AssignFloatIfSet(effect.phaser.min, "loFreq");
+		AssignFloatIfSet(effect.phaser.max, "hiFreq");
+		AssignFloatIfSet(effect.phaser.q, "Q");
 		AssignFloatIfSet(effect.phaser.feedback, "feedback");
 		AssignFloatIfSet(effect.phaser.stereoWidth, "stereoWidth");
+		AssignFloatIfSet(effect.phaser.hiCutGain, "hiCutGain");
 		break;
 	case EffectType::Flanger:
 		AssignDurationIfSet(effect.duration, "period");

--- a/Beatmap/src/BeatmapFromKSH.cpp
+++ b/Beatmap/src/BeatmapFromKSH.cpp
@@ -370,6 +370,14 @@ AudioEffect ParseCustomEffect(const KShootEffectDefinition &def, Vector<String> 
 		AssignDurationIfSet(effect.duration, "waveLength");
 		AssignFloatIfSet(effect.echo.feedback, "feedbackLevel");
 		break;
+	case EffectType::Phaser:
+		AssignDurationIfSet(effect.duration, "period");
+		AssignFloatIfSet(effect.phaser.min, "feedback");
+		AssignFloatIfSet(effect.phaser.max, "feedback");
+		AssignFloatIfSet(effect.phaser.q, "feedback");
+		AssignFloatIfSet(effect.phaser.feedback, "feedback");
+		AssignFloatIfSet(effect.phaser.stereoWidth, "stereoWidth");
+		break;
 	case EffectType::Flanger:
 		AssignDurationIfSet(effect.duration, "period");
 		AssignIntIfSet(effect.flanger.depth, "depth");

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -220,7 +220,7 @@ void AudioPlayback::SetEffect(uint32 index, HoldObjectState *object, class Beatm
 void AudioPlayback::SetEffectEnabled(uint32 index, bool enabled)
 {
 	assert(index <= 1);
-	m_effectMix[index] = enabled ? 1.0f : 0.0f;
+	m_effectMix[index] = enabled ? m_buttonEffects[index].mix.Sample() : 0.0f;
 
 	if (m_buttonEffects[index].type == EffectType::SwitchAudio)
 	{

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -80,7 +80,9 @@ DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32
 		phs->SetLength(actualLength);
 		phs->fmin = phaser.min.Sample(filterInput);
 		phs->fmax = phaser.max.Sample(filterInput);
+		phs->q = phaser.q.Sample(filterInput);
 		phs->feedback = phaser.feedback.Sample(filterInput);
+		phs->stereoWidth = phaser.stereoWidth.Sample(filterInput);
 		ret = phs;
 		break;
 	}

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -141,7 +141,6 @@ void GameAudioEffect::SetParams(DSP *dsp, AudioPlayback &playback, HoldObjectSta
 	{
 		GateDSP *gateDSP = (GateDSP *)dsp;
 		gateDSP->SetLength(noteDuration / object->effectParams[0]);
-		gateDSP->SetGating(0.5f);
 		break;
 	}
 	case EffectType::TapeStop:
@@ -154,7 +153,6 @@ void GameAudioEffect::SetParams(DSP *dsp, AudioPlayback &playback, HoldObjectSta
 	{
 		RetriggerDSP *retriggerDSP = (RetriggerDSP *)dsp;
 		retriggerDSP->SetLength(noteDuration / object->effectParams[0]);
-		retriggerDSP->SetGating(0.65f);
 		break;
 	}
 	case EffectType::Echo:

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -78,11 +78,13 @@ DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32
 	{
 		PhaserDSP *phs = new PhaserDSP(sampleRate);
 		phs->SetLength(actualLength);
+		phs->SetStage(phaser.stage.Sample(filterInput));
 		phs->fmin = phaser.min.Sample(filterInput);
 		phs->fmax = phaser.max.Sample(filterInput);
 		phs->q = phaser.q.Sample(filterInput);
 		phs->feedback = phaser.feedback.Sample(filterInput);
 		phs->stereoWidth = phaser.stereoWidth.Sample(filterInput);
+		phs->hiCutGain = phaser.hiCutGain.Sample(filterInput);
 		ret = phs;
 		break;
 	}
@@ -124,6 +126,7 @@ DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32
 		return nullptr;
 	}
 
+	ret->mix = mix.Sample(filterInput);
 	return ret;
 }
 void GameAudioEffect::SetParams(DSP *dsp, AudioPlayback &playback, HoldObjectState *object)

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -78,9 +78,9 @@ DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32
 	{
 		PhaserDSP *phs = new PhaserDSP(sampleRate);
 		phs->SetLength(actualLength);
-		phs->dmin = phaser.min.Sample(filterInput);
-		phs->dmax = phaser.max.Sample(filterInput);
-		phs->fb = phaser.feedback.Sample(filterInput);
+		phs->fmin = phaser.min.Sample(filterInput);
+		phs->fmax = phaser.max.Sample(filterInput);
+		phs->feedback = phaser.feedback.Sample(filterInput);
 		ret = phs;
 		break;
 	}
@@ -171,7 +171,6 @@ void GameAudioEffect::SetParams(DSP *dsp, AudioPlayback &playback, HoldObjectSta
 	case EffectType::Phaser:
 	{
 		PhaserDSP *phs = (PhaserDSP *)dsp;
-		phs->time = object->time;
 		break;
 	}
 	case EffectType::Flanger:

--- a/Tests.Game/src/TestAudio.cpp
+++ b/Tests.Game/src/TestAudio.cpp
@@ -56,9 +56,9 @@ Test("Audio.Music.Phaser")
 			TestMusicPlayer::Init(songPath, startOffset);
 
 			phaser = new PhaserDSP(song->GetAudioSampleRate());
-			phaser->dmin = 800.0f;
-			phaser->dmax = 1000.0f;
-			phaser->fb = 0.8f;
+			phaser->fmin = 800.0f;
+			phaser->fmax = 1000.0f;
+			phaser->feedback = 0.8f;
 			song->AddDSP(phaser);
 			phaser->SetLength(1000);
 		}


### PR DESCRIPTION
Add support for all custom phaser params: `period`, `stage`, `loFreq`, `hiFreq`, `Q`, `feedback`, `stereoWidth`, `hiCutGain`

Additional misc changes:
- sample `mix` for effects instead of always setting it to `1.0` when enabled
- fix default effect params
- factor out biquad filters from BQFDSP

Comparison of KSM, USC (new), USC (old) using `#define_fx testFx type=Phaser;period=1;stage=12;loFreq=5000Hz;hiFreq=15000Hz;Q=0.5;feedback=25%;stereoWidth=25%;hiCutGain=-20.0dB;mix=0%>75%`:
![phaser](https://user-images.githubusercontent.com/2906473/135934578-e1ac4617-6dae-497b-9698-bef4095a479e.png)
