### PR TITLE
Override zoom parameters on-the-fly

### DIFF
--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -139,6 +139,7 @@ DefineEnum(GameConfigKeys,
 		   ExitPlayMethod,
 		   ExitPlayHoldDuration,
 		   DisableNonButtonInputsDuringPlay, // TODO: after enabling key customization for non-button commands, remove this.
+		   EnableVisualParamOverridesForNormalGameplay,
 
 		   LastSelected,
 		   LastSelectedChal,

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -2097,7 +2097,7 @@ public:
 
 		Vector2 center = Vector2(g_resolution / 2);
 
-		for (int8 i = 0; i < m_visualParamOverrides.size(); ++i)
+		for (int8 i = 0; i < static_cast<int8>(m_visualParamOverrides.size()); ++i)
 		{
 			String s = "";
 
@@ -2436,7 +2436,8 @@ public:
 		// Ctrl + S + arrow keys: adjusting visual params
 		if (g_gameWindow->IsKeyPressed(SDL_SCANCODE_LCTRL) && g_gameWindow->IsKeyPressed(SDL_SCANCODE_S))
 		{
-			if (!IsMultiplayerGame() && !IsChallenge() && (m_renderDebugHUD || m_isPracticeSetup || m_paused || g_gameConfig.GetBool(GameConfigKeys::EnableVisualParamOverridesForNormalGameplay)))
+			const bool enableVisualParamOverrides = m_renderDebugHUD || m_isPracticeSetup || m_scoring.autoplayInfo.IsAutoplayButtons() || m_paused;
+			if (!IsMultiplayerGame() && !IsChallenge() && (enableVisualParamOverrides || g_gameConfig.GetBool(GameConfigKeys::EnableVisualParamOverridesForNormalGameplay)))
 			{
 				int increment = (g_gameWindow->IsKeyPressed(SDL_SCANCODE_LSHIFT) ? 5 : 1) * (g_gameWindow->IsKeyPressed(SDL_SCANCODE_LALT) ? 1 : 10);
 
@@ -2466,7 +2467,7 @@ public:
 				{
 					m_currVisualParam = static_cast<int8>(m_visualParamOverrides.size()-1);
 				}
-				else if (m_currVisualParam >= m_visualParamOverrides.size())
+				else if (m_currVisualParam >= static_cast<int8>(m_visualParamOverrides.size()))
 				{
 					m_currVisualParam = -1;
 				}

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -2436,7 +2436,7 @@ public:
 		// Ctrl + S + arrow keys: adjusting visual params
 		if (g_gameWindow->IsKeyPressed(SDL_SCANCODE_LCTRL) && g_gameWindow->IsKeyPressed(SDL_SCANCODE_S))
 		{
-			if (m_renderDebugHUD || m_isPracticeSetup || m_paused)
+			if (!IsMultiplayerGame() && !IsChallenge() && (m_renderDebugHUD || m_isPracticeSetup || m_paused || g_gameConfig.GetBool(GameConfigKeys::EnableVisualParamOverridesForNormalGameplay)))
 			{
 				int increment = (g_gameWindow->IsKeyPressed(SDL_SCANCODE_LSHIFT) ? 5 : 1) * (g_gameWindow->IsKeyPressed(SDL_SCANCODE_LALT) ? 1 : 10);
 

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -181,6 +181,7 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::ExitPlayHoldDuration, 2000);
 
 	Set(GameConfigKeys::DisableNonButtonInputsDuringPlay, false);
+	Set(GameConfigKeys::EnableVisualParamOverridesForNormalGameplay, false);
 
 	Set(GameConfigKeys::LastSelected, 0);
 	Set(GameConfigKeys::LastSelectedChal, 0);

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -194,6 +194,7 @@ protected:
 
 		ToggleSetting(GameConfigKeys::DisableNonButtonInputsDuringPlay, "Disable non-buttons during gameplay");
 		ToggleSetting(GameConfigKeys::PracticeSetupNavEnabled, "Enable navigation inputs for the practice setup");
+		ToggleSetting(GameConfigKeys::EnableVisualParamOverridesForNormalGameplay, "Enable overriding visual(camera) parameters during normal gameplay");
 	}
 
 private:

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -28,9 +28,10 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
+#include <queue>
 #include <stack>
 #include <string>
-#include <queue>
 #include <unordered_set>
 
 #include <Shared/Shared.hpp>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,23 @@ If something breaks in the song database, delete "maps.db". **Please note this w
 - \[Start\] when selecting filters to toggle between level and folder filters
 - \[FX-L\] + \[FX-R\] to open up game settings (Hard gauge, Random, Mirror, etc.)
 - \[TAB\] to open the Search bar on the top to search for songs
-- \[BT-B + BT-C\] Add song to collection (such as favourites)
+- \[BT-B + BT-C\] to add the song to a collection (such as favourites)
+- \[~\] to enter the practice mode
+
+### During Gameplay:
+- These keys can be disabled with a setting (`DisableNonButtonInputsDuringPlay`).
+- \[F5\] to restart the game
+- \[F8\] to show/hide the debug HUD
+- \[F9\] to reload the skin
+- \[Enter\] to skip intro/outro
+- \[Pause\] to pause/unpause
+- \[PageUp\] to advance 5 seconds
+- \[Ctrl\]+\[S\]+\[Arrow Key\] to override visual track parameters (`zoom_top`, `zoom_bottom`, ...)
+	- This is only available during one of these situations:
+		- The debug HUD is being shown
+		- During practice setup
+		- The game is paused
+	- Using this will prevent the score of the play from being saved.
 
 ## How to run:
 Just run 'usc-game' or 'usc-game_Debug' from within the 'bin' folder.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ If something breaks in the song database, delete "maps.db". **Please note this w
 - \[Pause\] to pause/unpause
 - \[PageUp\] to advance 5 seconds
 - \[Ctrl\]+\[S\]+\[Arrow Key\] to override visual track parameters (`zoom_top`, `zoom_bottom`, ...)
-	- This is only available during one of these situations:
+	- Unless the setting `EnableVisualParamOverridesForNormalGameplay` is set, this is only available during one of these situations:
 		- The debug HUD is being shown
 		- During practice setup
 		- The game is paused
 	- Using this will prevent the score of the play from being saved.
+	- Use \[Shift\] or \[Alt\] for coarse/fine adjustments.
+	- Clear overrides with \[Ctrl\]+\[S\]+\[Backspace\].
 
 ## How to run:
 Just run 'usc-game' or 'usc-game_Debug' from within the 'bin' folder.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If something breaks in the song database, delete "maps.db". **Please note this w
 	- Unless the setting `EnableVisualParamOverridesForNormalGameplay` is set, this is only available during one of these situations:
 		- The debug HUD is being shown
 		- During practice setup
+		- During autoplay
 		- The game is paused
 	- Using this will prevent the score of the play from being saved.
 	- Use \[Shift\] or \[Alt\] for coarse/fine adjustments.

--- a/Shared/include/Shared/Math.hpp
+++ b/Shared/include/Shared/Math.hpp
@@ -76,7 +76,7 @@ namespace Math
 	template<typename T>
 	int RoundToInt(T t)
 	{
-		return static_cast<int>(t + 0.5);
+		return t >= 0 ? static_cast<int>(t + 0.5) : static_cast<int>(t - 0.5);
 	}
 	template<typename T>
 	T BeatInMS(T bpm)


### PR DESCRIPTION
- \[Ctrl\]+\[S\]+\[Arrow Key\] to override visual track parameters (`zoom_top`, `zoom_bottom`, ...)
	- Unless the setting `EnableVisualParamOverridesForNormalGameplay` is set, this is only available during one of these situations:
		- The debug HUD is being shown
		- During practice setup
		- During autoplay
		- The game is paused
	- Using this will prevent the score of the play from being saved.
	- Use \[Shift\] or \[Alt\] for coarse/fine adjustments.
	- Clear overrides with \[Ctrl\]+\[S\]+\[Backspace\].

https://user-images.githubusercontent.com/835369/137573534-1fc697f9-4777-4b98-b360-5ae22054b11c.mp4

