### PR TITLE
Update USC-IR support to v0.3.2-a

### DIFF
--- a/Main/include/IR.hpp
+++ b/Main/include/IR.hpp
@@ -17,6 +17,7 @@ namespace IR
         const static int Unused = 0;
         const static int Pending = 10;
         const static int Success = 20;
+        const static int Accepted = 22;
         const static int BadRequest = 40;
         const static int Unauthorized = 41;
         const static int ChartRefused = 42;
@@ -29,6 +30,7 @@ namespace IR
             {"Unused", IR::ResponseState::Unused},
             {"Pending", IR::ResponseState::Pending},
             {"Success", IR::ResponseState::Success},
+            {"Accepted", IR::ResponseState::Accepted},
             {"BadRequest", IR::ResponseState::BadRequest},
             {"Unauthorized", IR::ResponseState::Unauthorized},
             {"ChartRefused", IR::ResponseState::ChartRefused},

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -394,7 +394,7 @@ draw_ir = function(full)
         gfx.FontSize(15)
         gfx.FillColor(255, 255, 255)
         gfx.Text("Score accepted, IR says:", 510, 60)
-        gfx.Text(result.irDescription)
+        gfx.Text(result.irDescription, 510, 80)
         return
     elseif result.irState ~= IRData.States.Success then
         gfx.FontSize(15)

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -389,8 +389,14 @@ draw_ir = function(full)
         gfx.Text("Loading... please wait.", 510, 60)
         return
     end
-
-    if result.irState ~= IRData.States.Success then
+    
+    if result.irState == IRData.States.Accepted then
+        gfx.FontSize(15)
+        gfx.FillColor(255, 255, 255)
+        gfx.Text("Score accepted, IR says:", 510, 60)
+        gfx.Text(result.irDescription)
+        return
+    elseif result.irState ~= IRData.States.Success then
         gfx.FontSize(15)
         gfx.FillColor(255, 0, 0)
         gfx.Text("Error:", 510, 60)
@@ -919,6 +925,9 @@ draw_ir_icon = function(x, y, s)
     elseif result.irState == IRData.States.Success then
         gfx.FillColor(0, 255, 0)
         gfx.Text("OK", x + s/2, y + s*0.7)
+    elseif result.irState == IRData.States.Accepted then
+        gfx.FillColor(0, 255, 0)
+        gfx.Text("Q'D", x + s/2, y + s*0.7)
     else
         gfx.FillColor(255, 0, 0)
         gfx.Text("FAIL", x + s/2, y + s*0.7)


### PR DESCRIPTION
Adds the new 22 Accepted code to IR.hpp and updates the default skin to understand it.

Docs are [here](https://uscir.readthedocs.io/en/latest/) as always, but in summary, the purpose of the new code is for IRs that hold new charts in a queue until X unique players have played them to indicate that they have saved the submitted score but that it will not yet show up (as a record, or in the leaderboard, et cetera).