### PR TITLE
Clean up IApplicationTickable function overrides

### DIFF
--- a/Main/src/ChallengeResult.cpp
+++ b/Main/src/ChallengeResult.cpp
@@ -307,7 +307,7 @@ public:
 		m_scroll += steps;
 	}
 
-	virtual void OnKeyPressed(SDL_Scancode code, int32 delta) override
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		if(code == SDL_SCANCODE_RETURN && !m_removed)
 		{
@@ -341,10 +341,10 @@ public:
 			m_scroll -= 1;
 		}
 	}
-	virtual void OnKeyReleased(SDL_Scancode code, int32 delta) override
+	void OnKeyReleased(SDL_Scancode code, int32 delta) override
 	{
 	}
-	virtual void Render(float deltaTime) override
+	void Render(float deltaTime) override
 	{
 		lua_getglobal(m_lua, "render");
 		lua_pushnumber(m_lua, deltaTime);
@@ -358,7 +358,7 @@ public:
 		}
 		m_hasRendered = true;
 	}
-	virtual void Tick(float deltaTime) override
+	void Tick(float deltaTime) override
 	{
 		if (!m_hasScreenshot && m_hasRendered && !IsSuspended())
 		{

--- a/Main/src/ChallengeSelect.cpp
+++ b/Main/src/ChallengeSelect.cpp
@@ -1011,7 +1011,7 @@ public:
 		}
 	}
 
-	virtual void OnKeyPressed(SDL_Scancode code, int32 delta)
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		//if (m_multiplayer && m_multiplayer->GetChatOverlay()->OnKeyPressedConsume(code))
 
@@ -1110,11 +1110,11 @@ public:
 		}
 	}
 
-	virtual void OnKeyReleased(SDL_Scancode code, int32 delta)
+	void OnKeyReleased(SDL_Scancode code, int32 delta) override
 	{
 	}
 
-	virtual void Tick(float deltaTime) override
+	void Tick(float deltaTime) override
 	{
 		if (m_dbUpdateTimer.Milliseconds() > 500)
 		{
@@ -1134,7 +1134,7 @@ public:
 		//	m_multiplayer->GetChatOverlay()->Tick(deltaTime);
 	}
 
-	virtual void Render(float deltaTime)
+	void Render(float deltaTime) override
 	{
 		if (m_suspended && m_hasRestored) return;
 
@@ -1232,7 +1232,7 @@ public:
 		m_advanceChal -= advanceChalActual;
 	}
 
-	virtual void OnSuspend()
+	void OnSuspend() override
 	{
 		m_lastChalIndex = m_selectionWheel->GetCurrentItemIndex();
 
@@ -1243,7 +1243,7 @@ public:
 			m_lockMouse.reset();
 	}
 
-	virtual void OnRestore()
+	void OnRestore() override
 	{
 		// NOTE: we can't trigger the next chart here bc you can't add tickables on restore
 		g_application->DiscordPresenceMenu("Challenge Select");

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -760,7 +760,7 @@ public:
 		m_hiddenObjects.clear();
 	}
 
-	virtual void Tick(float deltaTime) override
+	void Tick(float deltaTime) override
 	{
 		if (m_ended && IsSuspended()) return;
 
@@ -894,7 +894,7 @@ public:
 		}
 	}
 
-	virtual void Render(float deltaTime) override
+	void Render(float deltaTime) override
 	{
 		if (m_ended && IsSuspended()) return;
 
@@ -1256,11 +1256,11 @@ public:
 		m_permanentlyHiddenObjects.insert(obj);
 	}
 
-	virtual void OnSuspend() override
+	void OnSuspend() override
 	{
 	}
 
-	virtual void OnRestore() override
+	void OnRestore() override
 	{
 		if (m_ended && m_isPracticeMode)
 		{

--- a/Main/src/ScoreScreen.cpp
+++ b/Main/src/ScoreScreen.cpp
@@ -900,7 +900,7 @@ public:
 	}
 
 
-	virtual void OnKeyPressed(SDL_Scancode code, int32 delta) override
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		if (m_multiplayer &&
 				m_multiplayer->GetChatOverlay()->OnKeyPressedConsume(code))
@@ -933,10 +933,10 @@ public:
 			lua_settop(m_lua, 0);
 		}
 	}
-	virtual void OnKeyReleased(SDL_Scancode code, int32 delta) override
+	void OnKeyReleased(SDL_Scancode code, int32 delta) override
 	{
 	}
-	virtual void Render(float deltaTime) override
+	void Render(float deltaTime) override
 	{
 		lua_getglobal(m_lua, "render");
 		lua_pushnumber(m_lua, deltaTime);
@@ -956,7 +956,7 @@ public:
 		if (m_multiplayer)
 			m_multiplayer->GetChatOverlay()->Render(deltaTime);
 	}
-	virtual void Tick(float deltaTime) override
+	void Tick(float deltaTime) override
 	{
 		if (!m_hasScreenshot && m_hasRendered && !IsSuspended())
 		{

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -1213,7 +1213,7 @@ public:
 		}
 	}
 
-	bool Init()
+	bool Init() override
 	{
 		if (m_isGamepad)
 		{
@@ -1245,7 +1245,7 @@ public:
 		return true;
 	}
 
-	void Tick(float deltatime)
+	void Tick(float deltatime) override
 	{
 		if (m_knobs && m_isGamepad)
 		{
@@ -1276,7 +1276,7 @@ public:
 
 	}
 
-	void Render(float deltatime)
+	void Render(float deltatime) override
 	{
 		String prompt = "Press the key";
 
@@ -1317,7 +1317,7 @@ public:
 		}
 	}
 
-	virtual void OnKeyPressed(SDL_Scancode code)
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		if (!m_isGamepad && !m_knobs)
 		{
@@ -1365,11 +1365,11 @@ public:
 		}
 	}
 
-	virtual void OnSuspend()
+	void OnSuspend() override
 	{
 		//g_rootCanvas->Remove(m_canvas.As<GUIElementBase>());
 	}
-	virtual void OnRestore()
+	void OnRestore() override
 	{
 		//Canvas::Slot* slot = g_rootCanvas->Add(m_canvas.As<GUIElementBase>());
 		//slot->anchor = Anchors::Full;
@@ -1403,7 +1403,7 @@ public:
 		g_input.OnButtonPressed.RemoveAll(this);
 	}
 
-	bool Init()
+	bool Init() override
 	{
 		g_input.GetInputLaserDir(0); //poll because there might be something idk
 
@@ -1421,13 +1421,13 @@ public:
 		return true;
 	}
 
-	void Tick(float deltatime)
+	void Tick(float deltatime) override
 	{
 		m_delta += g_input.GetAbsoluteInputLaserDir(0);
 
 	}
 
-	void Render(float deltatime)
+	void Render(float deltatime) override
 	{
 		const Vector2 center = { static_cast<float>(g_resolution.x / 2), static_cast<float>(g_resolution.y / 2) };
 
@@ -1485,17 +1485,17 @@ public:
 		}
 	}
 
-	virtual void OnKeyPressed(SDL_Scancode code)
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		if (code == SDL_SCANCODE_ESCAPE)
 			g_application->RemoveTickable(this);
 	}
 
-	virtual void OnSuspend()
+	void OnSuspend() override
 	{
 		//g_rootCanvas->Remove(m_canvas.As<GUIElementBase>());
 	}
-	virtual void OnRestore()
+	void OnRestore() override
 	{
 		//Canvas::Slot* slot = g_rootCanvas->Add(m_canvas.As<GUIElementBase>());
 		//slot->anchor = Anchors::Full;

--- a/Main/src/Test.cpp
+++ b/Main/src/Test.cpp
@@ -38,20 +38,20 @@ public:
 	~Test_Impl()
 	{
 	}
-	virtual void OnKeyPressed(SDL_Scancode code, int32 delta) override
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		if(code == SDL_SCANCODE_TAB)
 		{
 			//m_settings->SetShow(!m_settings->IsShown());
 		}
 	}
-	virtual void OnKeyReleased(SDL_Scancode code, int32 delta) override
+	void OnKeyReleased(SDL_Scancode code, int32 delta) override
 	{
 	}
-	virtual void Render(float deltaTime) override
+	void Render(float deltaTime) override
 	{
 	}
-	virtual void Tick(float deltaTime) override
+	void Tick(float deltaTime) override
 	{
 	}
 };

--- a/Main/src/TitleScreen.cpp
+++ b/Main/src/TitleScreen.cpp
@@ -128,7 +128,7 @@ private:
 	}
 
 public:
-	bool Init()
+	bool Init() override
 	{
 		m_lua = g_application->LoadScript("titlescreen");
 		if (m_lua == nullptr)
@@ -174,7 +174,7 @@ public:
 		}
 	}
 
-	virtual void Render(float deltaTime)
+	void Render(float deltaTime) override
 	{
 		if (IsSuspended())
 			return;
@@ -189,10 +189,10 @@ public:
 			}
 		}
 	}
-	virtual void OnSuspend()
+	void OnSuspend() override
 	{
 	}
-	virtual void OnRestore()
+	void OnRestore() override
 	{
 		g_gameWindow->SetCursorVisible(true);
 		g_application->DiscordPresenceMenu("Title Screen");

--- a/Main/src/TransitionScreen.cpp
+++ b/Main/src/TransitionScreen.cpp
@@ -74,16 +74,16 @@ public:
 			nvgDeleteImage(g_application->GetVGContext(), m_jacketImg);
 	}
 
-	virtual void RemoveAllOnComplete(void *handle)
+	void RemoveAllOnComplete(void *handle) override
 	{
 		m_handlesToRemove.Add(handle);
 	}
-	virtual void RemoveOnComplete(DelegateHandle handle)
+	void RemoveOnComplete(DelegateHandle handle) override
 	{
 		m_lamdasToRemove.Add(handle);
 	}
 
-	virtual void Tick(float deltaTime)
+	void Tick(float deltaTime) override
 	{
 		m_transitionTimer += deltaTime;
 
@@ -106,7 +106,7 @@ public:
 		}
 		m_lastComplete = m_loadComplete;
 	}
-	virtual void OnSuspend()
+	void OnSuspend() override
 	{
 		if (m_tickableToLoad && m_transition == End)
 		{
@@ -115,7 +115,7 @@ public:
 		}
 	}
 
-	virtual bool Init()
+	bool Init() override
 	{
 		if (m_initialized)
 			return true;
@@ -153,7 +153,7 @@ public:
 		return true;
 	}
 
-	virtual void TransitionTo(IAsyncLoadableApplicationTickable *next, bool noCancel, IApplicationTickable* before)
+	void TransitionTo(IAsyncLoadableApplicationTickable *next, bool noCancel, IApplicationTickable* before) override
 	{
 		m_isGame = false;
 		m_InitTransition(next);
@@ -181,7 +181,7 @@ public:
 		g_application->AddTickable(this, before);
 	}
 
-	virtual void TransitionTo(Game* next, IApplicationTickable* before)
+	void TransitionTo(Game* next, IApplicationTickable* before) override
 	{
 		m_isGame = true;
 		m_canCancel = true;
@@ -261,7 +261,7 @@ public:
 		g_application->AddTickable(this, before);
 	}
 
-	void Render(float deltaTime)
+	void Render(float deltaTime) override
 	{
 		lua_State *lua = m_lua;
 		if (m_isGame)
@@ -411,7 +411,7 @@ public:
 		return true;
 	}
 
-	void OnKeyPressed(SDL_Scancode code)
+	void OnKeyPressed(SDL_Scancode code, int32 delta) override
 	{
 		if (code == SDL_SCANCODE_ESCAPE && !m_stopped && m_canCancel)
 		{


### PR DESCRIPTION
This fixes ButtonBindingScreen, LaserSensCalibrationScreen and TransitionScreen's OnKeyPressed() override not actually overriding their base function. Also properly mark a bunch of IApplicationTickable overrides to prevent this from happening again.