### PR TITLE
Fixing a few bugs related to the result screen and timing windows.

### DIFF
--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -379,7 +379,7 @@ public:
 		m_songOffset = 0;
 
 		// Compute chart offset
-		if (g_gameConfig.GetBool(GameConfigKeys::AutoComputeSongOffset) && m_scoreReplays.empty()) {
+		if (g_gameConfig.GetBool(GameConfigKeys::AutoComputeSongOffset) && m_scoreReplays.empty() && m_chartIndex->custom_offset == 0) {
 			if (OffsetComputer(m_audioPlayback).Compute(m_songOffset) && m_chartIndex)
 			{
 				Logf("Setting the chart offset of '%s' to %d (previously %d)", Logger::Severity::Info, m_chartIndex->title, m_songOffset, m_chartIndex->custom_offset);

--- a/Main/src/HitStat.cpp
+++ b/Main/src/HitStat.cpp
@@ -3,7 +3,9 @@
 #include "GameConfig.hpp"
 
 const HitWindow HitWindow::NORMAL = HitWindow(46, 150);
-const HitWindow HitWindow::HARD = HitWindow(23, 75);
+
+// The intention is that hard UC should be equivalent to normal PUC
+const HitWindow HitWindow::HARD = HitWindow(23, HitWindow::NORMAL.perfect);
 
 HitStat::HitStat(ObjectState* object) : object(object)
 {

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -46,8 +46,11 @@ local hitHistogram = {}
 local hitMinDelta = 0
 local hitMaxDelta = 0
 
-local hitWindowPerfect = 46
-local hitWindowGood = 92
+local NORMAL_HIT_WINDOW_PERFECT = 46
+local NORMAL_HIT_WINDOW_GOOD = 150
+
+local hitWindowPerfect = NORMAL_HIT_WINDOW_PERFECT
+local hitWindowGood = NORMAL_HIT_WINDOW_GOOD
 
 local clearTextBase = "" -- Used to determind the type of clear
 local clearText = ""
@@ -128,7 +131,6 @@ function getScoreBadgeDesc(s)
     elseif 2 <= s.badge and s.badge <= 4 and s.misses < 10 then
         return string.format("%d-%d", s.goods, s.misses)
     end
-    return ""
 end
 
 result_set = function()
@@ -279,8 +281,8 @@ result_set = function()
 
     hasHitStat = result.noteHitStats ~= nil and #result.noteHitStats > 0
 
-    hitWindowPerfect = 46
-    hitWindowGood = 92
+    hitWindowPerfect = NORMAL_HIT_WINDOW_PERFECT
+    hitWindowGood = NORMAL_HIT_WINDOW_GOOD
     critText = "CRIT"
     nearText = "NEAR"
 
@@ -288,7 +290,7 @@ result_set = function()
         hitWindowPerfect = result.hitWindow.perfect
         hitWindowGood = result.hitWindow.good
 
-        if hitWindowPerfect ~= 46 or hitWindowGood ~= 92 then
+        if hitWindowPerfect ~= NORMAL_HIT_WINDOW_PERFECT or hitWindowGood ~= NORMAL_HIT_WINDOW_GOOD then
             critText = string.format("%02dms CRIT", hitWindowPerfect)
             nearText = string.format("%02dms NEAR", hitWindowGood)
         end
@@ -439,7 +441,7 @@ draw_ir = function(full)
                 gfx.BeginPath()
                 gfx.FontSize(15)
                 gfx.TextAlign(gfx.TEXT_ALIGN_CENTER + gfx.TEXT_ALIGN_BOTTOM)
-                gfx.Text("todo", 55, 52)
+                gfx.Text(s.badgeDesc, 55, 52)
             end
         end
 

--- a/bin/skins/Default/scripts/result.lua
+++ b/bin/skins/Default/scripts/result.lua
@@ -131,6 +131,7 @@ function getScoreBadgeDesc(s)
     elseif 2 <= s.badge and s.badge <= 4 and s.misses < 10 then
         return string.format("%d-%d", s.goods, s.misses)
     end
+    return ""
 end
 
 result_set = function()


### PR DESCRIPTION
Fixed bugs:

* Badge desc displayed as 'TODO' on IR scores
* Timing window details were incorrectly shown for the default timing window
* UCing on HARD judgement was not equivalent to PUCing on NORMAL judgement

Also, "automatically set timing window" feature was modified a little bit so that it doesn't override manually-set timing offsets