### PR TITLE
Make AppImage executable using `chmod`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
     windows_build:
         name: Windows build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,15 @@ jobs:
               run: |
                 ./linuxdeploy-x86_64.AppImage --custom-apprun appimage/AppRun -d appimage/usc-game.desktop -i appimage/usc-game.png -e bin/usc-game --appdir usc-appdir --output appimage
                 mv usc-game*.AppImage bin/usc-game.AppImage
+                chmod +x bin/usc-game.AppImage
                 rm bin/usc-game bin/Tests.*
+            - name: Pack everything into .tar.gz archive
+              run: cd bin && tar -czvf ../Game_linux_AppImage.tar.gz bin
             - name: Upload artifact
               uses: actions/upload-artifact@master
               with:
                 name: Game_linux_AppImage
-                path: bin
+                path: Game_linux_AppImage.tar.gz
     macos_build:
         name: macOS build
         runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
                 chmod +x bin/usc-game.AppImage
                 rm bin/usc-game bin/Tests.*
             - name: Pack everything into .tar.gz archive
-              run: cd bin && tar -czvf ../Game_linux_AppImage.tar.gz bin
+              run: cd bin && tar -czvf ../Game_linux_AppImage.tar.gz *
             - name: Upload artifact
               uses: actions/upload-artifact@master
               with:


### PR DESCRIPTION
Also preserves the execute permission by packing the game into a `.tar.gz` before uploading it.

(Manual workflow trigger is for testing)