### PR TITLE
Fix bugs related to calibration mode and hid/sud

### DIFF
--- a/bin/skins/Default/shaders/button.fs
+++ b/bin/skins/Default/shaders/button.fs
@@ -37,22 +37,34 @@ void main()
 
 #else
 
+// The OpenGL standard leave the case when `edge0 >= edge1` undefined,
+// so this function was made to remove the ambiguity when `edge0 >= edge1`.
+// Note that the case when `edge0 > edge1` should be avoided.
+float smoothstep_fix(float edge0, float edge1, float x)
+{
+    if(edge0 >= edge1)
+    {
+        return x < edge0 ? 0.0 : x > edge1 ? 1.0 : 0.5;
+    }
+
+    return smoothstep(edge0, edge1, x);
+}
+
 float hide()
 {
     float off = trackPos + position.y * trackScale;
 
     if (hiddenCutoff > suddenCutoff) {
-        float sudden = smoothstep(suddenCutoff, suddenCutoff - suddenFadeWindow, off);
-        float hidden = smoothstep(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
+        float sudden = 1.0 - smoothstep_fix(suddenCutoff - suddenFadeWindow, suddenCutoff, off);
+        float hidden = smoothstep_fix(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
         return min(hidden + sudden, 1.0);
     }
 
-    float sudden = smoothstep(suddenCutoff + suddenFadeWindow, suddenCutoff, off);
-    float hidden = smoothstep(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
+    float sudden = 1.0 - smoothstep_fix(suddenCutoff, suddenCutoff + suddenFadeWindow, off);
+    float hidden = smoothstep_fix(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
 
     return hidden * sudden;
 }
-
 
 void main()
 {	

--- a/bin/skins/Default/shaders/holdbutton.fs
+++ b/bin/skins/Default/shaders/holdbutton.fs
@@ -29,20 +29,34 @@ void main()
 	target.xyz = target.xyz * (1.0 + objectGlow * 0.3);
     target.a = min(1.0, target.a + target.a * objectGlow * 0.9);
 }
+
 #else
+
+// The OpenGL standard leave the case when `edge0 >= edge1` undefined,
+// so this function was made to remove the ambiguity when `edge0 >= edge1`.
+// Note that the case when `edge0 > edge1` should be avoided.
+float smoothstep_fix(float edge0, float edge1, float x)
+{
+    if(edge0 >= edge1)
+    {
+        return x < edge0 ? 0.0 : x > edge1 ? 1.0 : 0.5;
+    }
+
+    return smoothstep(edge0, edge1, x);
+}
 
 float hide()
 {
     float off = trackPos + position.y * trackScale;
 
     if (hiddenCutoff > suddenCutoff) {
-        float sudden = smoothstep(suddenCutoff, suddenCutoff - suddenFadeWindow, off);
-        float hidden = smoothstep(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
+        float sudden = 1.0 - smoothstep_fix(suddenCutoff - suddenFadeWindow, suddenCutoff, off);
+        float hidden = smoothstep_fix(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
         return min(hidden + sudden, 1.0);
     }
 
-    float sudden = smoothstep(suddenCutoff + suddenFadeWindow, suddenCutoff, off);
-    float hidden = smoothstep(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
+    float sudden = 1.0 - smoothstep_fix(suddenCutoff, suddenCutoff + suddenFadeWindow, off);
+    float hidden = smoothstep_fix(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
 
     return hidden * sudden;
 }

--- a/bin/skins/Default/shaders/laser.fs
+++ b/bin/skins/Default/shaders/laser.fs
@@ -43,20 +43,34 @@ void main()
     target = mainColor * color;
     target.xyz = target.xyz * (0.0 + objectGlow * 1.2);
 }
+
 #else
+
+// The OpenGL standard leave the case when `edge0 >= edge1` undefined,
+// so this function was made to remove the ambiguity when `edge0 >= edge1`.
+// Note that the case when `edge0 > edge1` should be avoided.
+float smoothstep_fix(float edge0, float edge1, float x)
+{
+    if(edge0 >= edge1)
+    {
+        return x < edge0 ? 0.0 : x > edge1 ? 1.0 : 0.5;
+    }
+
+    return smoothstep(edge0, edge1, x);
+}
 
 float hide()
 {
     float off = trackPos + position.y * trackScale;
 
     if (hiddenCutoff > suddenCutoff) {
-        float sudden = smoothstep(suddenCutoff, suddenCutoff - suddenFadeWindow, off);
-        float hidden = smoothstep(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
+        float sudden = 1.0 - smoothstep_fix(suddenCutoff - suddenFadeWindow, suddenCutoff, off);
+        float hidden = smoothstep_fix(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
         return min(hidden + sudden, 1.0);
     }
 
-    float sudden = smoothstep(suddenCutoff + suddenFadeWindow, suddenCutoff, off);
-    float hidden = smoothstep(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
+    float sudden = 1.0 - smoothstep_fix(suddenCutoff, suddenCutoff + suddenFadeWindow, off);
+    float hidden = smoothstep_fix(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
 
     return hidden * sudden;
 }

--- a/bin/skins/Default/shaders/trackCover.fs
+++ b/bin/skins/Default/shaders/trackCover.fs
@@ -12,6 +12,19 @@ uniform float hiddenFadeWindow;
 uniform float suddenCutoff;
 uniform float suddenFadeWindow;
 
+// The OpenGL standard leave the case when `edge0 >= edge1` undefined,
+// so this function was made to remove the ambiguity when `edge0 >= edge1`.
+// Note that the case when `edge0 > edge1` should be avoided.
+float smoothstep_fix(float edge0, float edge1, float x)
+{
+    if(edge0 >= edge1)
+    {
+        return x < edge0 ? 0.0 : x > edge1 ? 1.0 : 0.5;
+    }
+
+    return smoothstep(edge0, edge1, x);
+}
+
 void main()
 {	
 	#ifdef EMBEDDED
@@ -21,13 +34,13 @@ void main()
 	
 	float off = 1.0 - (fsTex.y * 2.0);
     if (hiddenCutoff < suddenCutoff) {
-        float hidden = 1.0 - smoothstep(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
-        float sudden = 1.0 - smoothstep(suddenCutoff + suddenFadeWindow, suddenCutoff, off);
+        float hidden = 1.0 - smoothstep_fix(hiddenCutoff - hiddenFadeWindow, hiddenCutoff, off);
+        float sudden = smoothstep_fix(suddenCutoff, suddenCutoff + suddenFadeWindow, off);
         target.a = min(hidden + sudden, 1.0);
     }
     else {
-        float hidden = smoothstep(hiddenCutoff + hiddenFadeWindow, hiddenCutoff, off);
-        float sudden = smoothstep(suddenCutoff - suddenFadeWindow, suddenCutoff, off);
+        float hidden = 1.0 - smoothstep_fix(hiddenCutoff, hiddenCutoff + hiddenFadeWindow, off);
+        float sudden = smoothstep_fix(suddenCutoff - suddenFadeWindow, suddenCutoff, off);
         target.a = hidden * sudden;
     }
 	#endif


### PR DESCRIPTION
Fixed following bugs:

- Game crashes on entering calibration mode
- Hid/sud is not working correctly when fade window is set to 0
- Measure bar does not show for long charts or charts with scroll speed modifier