### PR TITLE
Update dead links in build.linux

### DIFF
--- a/build.linux
+++ b/build.linux
@@ -2,11 +2,11 @@ Building on linux
 
 Download/install the following libraries/tools:
 - Install CMake (>= 3.4, binary or source from https://cmake.org/download/)
-- Install FreeType(2.6.5, http://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.gz)
+- Install FreeType (2.11.1, https://download.savannah.gnu.org/releases/freetype/freetype-2.11.1.tar.gz)
 - Install libogg (from package manager or http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz )
 - Install libvorbis (from package manager or http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz )
 - Install SDL2 (2.0.9, https://www.libsdl.org/release/SDL2-2.0.9.tar.gz )
-- Install zlib (from package manager or http://zlib.net/zlib-1.2.8.tar.gz )
+- Install zlib (from package manager or https://www.zlib.net/fossils/zlib-1.2.11.tar.gz )
 - Install libPNG (1.6, http://download.sourceforge.net/libpng/libpng-1.6.24.tar.gz )
 - Install libjpeg (9b, http://ijg.org/files/jpegsrc.v9b.tar.gz )
 - Install libarchive (3.3.3, https://www.libarchive.org/downloads/libarchive-3.3.3.tar.gz )


### PR DESCRIPTION
Fixes #557.

I tested both FreeType and zlib with their latest versions and confirmed that both worked, so I bumped both of their versions.  
zlib has a download archive with all versions so I linked to the archive download so that the link won't break with the next update.