### PR TITLE
Add support for playback speeds higher than x1.0

### DIFF
--- a/Main/include/Audio/AudioPlayback.hpp
+++ b/Main/include/Audio/AudioPlayback.hpp
@@ -14,7 +14,7 @@ public:
 	GameAudioEffect(const AudioEffect &other);
 
 	// Creates a DSP matching this effect
-	DSP *CreateDSP(const TimingPoint &tp, float filterInput, uint32 sampleRate);
+	DSP *CreateDSP(const TimingPoint &tp, float filterInput, uint32 sampleRate, float playbackSpeed);
 	// Applies the given parameters overriding some settings for this effect (depending on the effect)
 	void SetParams(DSP *dsp, AudioPlayback &playback, HoldObjectState *object);
 };

--- a/Main/include/GameConfig.hpp
+++ b/Main/include/GameConfig.hpp
@@ -192,6 +192,9 @@ DefineEnum(GameConfigKeys,
 		   DefaultFailConditionMissNear,
 		   DefaultFailConditionGauge,
 
+		   AdjustHiSpeedForLowerPlaybackSpeed,
+		   AdjustHiSpeedForHigherPlaybackSpeed,
+
 		   // Multiplayer
 		   MultiplayerHost,
 		   MultiplayerPassword,

--- a/Main/src/Audio/AudioPlayback.cpp
+++ b/Main/src/Audio/AudioPlayback.cpp
@@ -200,7 +200,8 @@ void AudioPlayback::SetEffect(uint32 index, HoldObjectState *object, class Beatm
 
 	dsp = m_buttonEffects[index].CreateDSP(m_playback->GetCurrentTimingPoint(),
 										   GetLaserFilterInput(),
-										   audioTrack->GetAudioSampleRate());
+										   audioTrack->GetAudioSampleRate(),
+										   GetPlaybackSpeed());
 	if (!dsp)
 		return;
 
@@ -286,7 +287,8 @@ void AudioPlayback::SetLaserFilterInput(float input, bool active)
 
 			m_laserDSP = m_laserEffect.CreateDSP(m_playback->GetCurrentTimingPoint(),
 												 GetLaserFilterInput(),
-												 audioTrack->GetAudioSampleRate());
+												 audioTrack->GetAudioSampleRate(),
+												 GetPlaybackSpeed());
 			if (!m_laserDSP)
 			{
 				Logf("Failed to create laser DSP with type %d", Logger::Severity::Warning, m_laserEffect.type);
@@ -532,7 +534,8 @@ void AudioPlayback::m_PreRenderDSPTrack()
 				GameAudioEffect effect = m_beatmap->GetEffect(holdObj->effectType);
 				DSP *dsp = effect.CreateDSP(*m_playback->GetTimingPointAt(chartObj->time),
 											1.0f,
-											m_fxtrack->GetSampleRate());
+											m_fxtrack->GetSampleRate(),
+											1.0f);
 				if (dsp != nullptr)
 				{
 					effect.SetParams(dsp, *this, holdObj);

--- a/Main/src/Audio/GameAudioEffects.cpp
+++ b/Main/src/Audio/GameAudioEffects.cpp
@@ -4,14 +4,15 @@
 #include <Audio/DSP.hpp>
 #include <Audio/Audio.hpp>
 
-DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32 sampleRate)
+DSP *GameAudioEffect::CreateDSP(const TimingPoint &tp, float filterInput, uint32 sampleRate, float playbackSpeed)
 {
 	DSP *ret = nullptr;
 
 	double noteDuration = tp.GetWholeNoteLength();
+	if (playbackSpeed > 0) noteDuration /= playbackSpeed;
 
-	uint32 actualLength = duration.Sample(filterInput).Absolute(noteDuration);
-	uint32 maxLength = Math::Max(duration.Sample(0.f).Absolute(noteDuration), duration.Sample(1.f).Absolute(noteDuration));
+	const uint32 actualLength = duration.Sample(filterInput).Absolute(noteDuration);
+	const uint32 maxLength = Math::Max(duration.Sample(0.f).Absolute(noteDuration), duration.Sample(1.f).Absolute(noteDuration));
 
 	switch (type)
 	{

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -863,15 +863,29 @@ public:
 	{
 		if (m_ended && IsSuspended()) return;
 
+		// Adjust factor for the hi-speed, based on the playback speed
+		float hiSpeedAdjustFactor = 1.0;
+
+		if (g_gameConfig.GetBool(GameConfigKeys::AdjustHiSpeedForLowerPlaybackSpeed)
+			&& 0 < m_playOptions.playbackSpeed && m_playOptions.playbackSpeed < 1.0)
+		{
+			hiSpeedAdjustFactor = m_playOptions.playbackSpeed;
+		}
+		else if (g_gameConfig.GetBool(GameConfigKeys::AdjustHiSpeedForHigherPlaybackSpeed)
+			&& 1.0 < m_playOptions.playbackSpeed)
+		{
+			hiSpeedAdjustFactor = m_playOptions.playbackSpeed;
+		}
+
 		// 8 beats (2 measures) in view at 1x hi-speed
 		if (m_speedMod == SpeedMods::CMod)
 		{
-			m_track->SetViewRange(1.0 / m_playback.cModSpeed);
+			m_track->SetViewRange(hiSpeedAdjustFactor / m_playback.cModSpeed);
             m_track->scrollSpeed = m_playback.cModSpeed;
 		}
 		else
 		{
-			m_track->SetViewRange(8.0f / m_hispeed);
+			m_track->SetViewRange(8 * (hiSpeedAdjustFactor / m_hispeed));
             m_track->scrollSpeed = m_hispeed * m_playback.GetCurrentTimingPoint().GetBPM();
 		}
 

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -1656,9 +1656,20 @@ public:
 		{
 			m_loopStreak = 0;
 
+			const bool mayIncreaseOver100 = m_playOptions.playbackSpeed > 1.0f;
+
 			int speedPercentage = Math::RoundToInt(100 * (m_playOptions.playbackSpeed + m_playOptions.incSpeedAmount));
 
-			m_playOptions.playbackSpeed = speedPercentage >= 100 ? 1.0f : speedPercentage / 100.0f;
+			if (!mayIncreaseOver100 && speedPercentage > 100) speedPercentage = 100;
+
+			if (speedPercentage == 100)
+			{
+				m_playOptions.playbackSpeed = 1.0f;
+			}
+			else
+			{
+				m_playOptions.playbackSpeed = speedPercentage / 100.0f;
+			}
 		}
 		
 		if (m_playOptions.decSpeedOnFail && !success)

--- a/Main/src/Game.cpp
+++ b/Main/src/Game.cpp
@@ -2825,6 +2825,7 @@ public:
 			else m_audioPlayback.Pause();
 
 			m_paused = m_audioPlayback.IsPaused();
+			if (!m_paused) m_triggerPause = false;
 		});
 		m_practiceSetupDialog->onSettingChange.AddLambda([this]() {
 			int oldAudioOffset = GetAudioOffset();

--- a/Main/src/GameConfig.cpp
+++ b/Main/src/GameConfig.cpp
@@ -132,6 +132,9 @@ void GameConfig::InitDefaults()
 	Set(GameConfigKeys::DefaultFailConditionMissNear, 0);
 	Set(GameConfigKeys::DefaultFailConditionGauge, 0);
 
+	Set(GameConfigKeys::AdjustHiSpeedForLowerPlaybackSpeed, true);
+	Set(GameConfigKeys::AdjustHiSpeedForHigherPlaybackSpeed, true);
+
 	SetEnum<Logger::Enum_Severity>(GameConfigKeys::LogLevel, Logger::Severity::Normal);
 
 	SetEnum<Enum_SpeedMods>(GameConfigKeys::SpeedMod, SpeedMods::MMod);

--- a/Main/src/PracticeModeSettingsDialog.cpp
+++ b/Main/src/PracticeModeSettingsDialog.cpp
@@ -61,7 +61,7 @@ PracticeModeSettingsDialog::Tab PracticeModeSettingsDialog::m_CreateMainSettingT
 
     Setting speedSetting = std::make_unique<SettingData>("Playback speed (%)", SettingType::Integer);
     speedSetting->intSetting.min = 25;
-    speedSetting->intSetting.max = 100;
+    speedSetting->intSetting.max = 400;
     speedSetting->intSetting.val = Math::RoundToInt(m_playOptions.playbackSpeed * 100);
     speedSetting->setter.AddLambda([this](const SettingData& data) { onSpeedChange.Call(data.intSetting.val == 100 ? 1.0f : data.intSetting.val / 100.0f); });
     speedSetting->getter.AddLambda([this](SettingData& data) { data.intSetting.val = Math::RoundToInt(m_playOptions.playbackSpeed * 100); });
@@ -110,6 +110,11 @@ PracticeModeSettingsDialog::Tab PracticeModeSettingsDialog::m_CreateLoopingTab()
             });
         loopingTab->settings.emplace_back(std::move(loopBeginButton));
 
+        Setting loopStartClearButton = CreateButton("Clear the start point", [this](const auto&) {
+            m_SetStartTime(0);
+            });
+        loopingTab->settings.emplace_back(std::move(loopStartClearButton));
+
         Setting loopBeginMeasureSetting = CreateIntSetting("- in measure no.", m_startMeasure, {1, m_TimeToMeasure(m_endTime)});
         loopBeginMeasureSetting->setter.AddLambda([this](const SettingData& data) {
             m_SetStartTime(m_MeasureToTime(data.intSetting.val), data.intSetting.val);
@@ -132,6 +137,12 @@ PracticeModeSettingsDialog::Tab PracticeModeSettingsDialog::m_CreateLoopingTab()
             });
         loopingTab->settings.emplace_back(std::move(loopEndButton));
 
+
+        Setting loopEndClearButton = CreateButton("Clear the end point", [this](const auto&) {
+            m_SetEndTime(0);
+            });
+        loopingTab->settings.emplace_back(std::move(loopEndClearButton));
+
         Setting loopEndMeasureSetting = CreateIntSetting("- in measure no.", m_endMeasure, {1, m_TimeToMeasure(m_endTime)});
         loopEndMeasureSetting->setter.AddLambda([this](const SettingData& data) {
             m_SetEndTime(m_MeasureToTime(data.intSetting.val), data.intSetting.val);
@@ -143,19 +154,6 @@ PracticeModeSettingsDialog::Tab PracticeModeSettingsDialog::m_CreateLoopingTab()
             m_SetEndTime(data.intSetting.val);
         });
         loopingTab->settings.emplace_back(std::move(loopEndMSSetting));
-    }
-    
-    // Clearing
-    {   
-        Setting loopStartClearButton = CreateButton("Clear the start point", [this](const auto&) {
-            m_SetStartTime(0);
-        });
-        loopingTab->settings.emplace_back(std::move(loopStartClearButton));
-        
-        Setting loopEndClearButton = CreateButton("Clear the end point", [this](const auto&) {
-            m_SetEndTime(0);
-        });
-        loopingTab->settings.emplace_back(std::move(loopEndClearButton));
     }
 
     return loopingTab;
@@ -373,6 +371,22 @@ PracticeModeSettingsDialog::Tab PracticeModeSettingsDialog::m_CreateGameSettingT
         onSettingChange.Call();
     });
     gameSettingTab->settings.emplace_back(std::move(revertToSetupSetting));
+
+    Setting adjustHSforLowerPSSetting = CreateBoolSetting(GameConfigKeys::AdjustHiSpeedForLowerPlaybackSpeed, "Adjust HiSpeed for playback speeds lower than x1.0");
+    adjustHSforLowerPSSetting->setter.Clear();
+    adjustHSforLowerPSSetting->setter.AddLambda([this](const SettingData& data) {
+        g_gameConfig.Set(GameConfigKeys::AdjustHiSpeedForLowerPlaybackSpeed, data.boolSetting.val);
+        onSettingChange.Call();
+    });
+    gameSettingTab->settings.emplace_back(std::move(adjustHSforLowerPSSetting));
+
+    Setting adjustHSforHigherPSSetting = CreateBoolSetting(GameConfigKeys::AdjustHiSpeedForHigherPlaybackSpeed, "Adjust HiSpeed for playback speeds higher than x1.0");
+    adjustHSforHigherPSSetting->setter.Clear();
+    adjustHSforHigherPSSetting->setter.AddLambda([this](const SettingData& data) {
+        g_gameConfig.Set(GameConfigKeys::AdjustHiSpeedForHigherPlaybackSpeed, data.boolSetting.val);
+        onSettingChange.Call();
+    });
+    gameSettingTab->settings.emplace_back(std::move(adjustHSforHigherPSSetting));
 
     return gameSettingTab;
 }

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -929,7 +929,7 @@ protected:
 		ToggleSetting(GameConfigKeys::DisplayPracticeInfoInGame, "Show practice-mode info during gameplay");
 
 		SectionHeader("Defaults for Playback and Loop Control");
-		IntSetting(GameConfigKeys::DefaultPlaybackSpeed, "Playback speed (%)", 25, 100);
+		IntSetting(GameConfigKeys::DefaultPlaybackSpeed, "Playback speed (%)", 25, 400);
 
 		Separator();
 

--- a/Main/src/SettingsScreen.cpp
+++ b/Main/src/SettingsScreen.cpp
@@ -928,6 +928,10 @@ protected:
 		ToggleSetting(GameConfigKeys::RevertToSetupAfterScoreScreen, "Revert to the setup after the result is shown");
 		ToggleSetting(GameConfigKeys::DisplayPracticeInfoInGame, "Show practice-mode info during gameplay");
 
+		ToggleSetting(GameConfigKeys::AdjustHiSpeedForLowerPlaybackSpeed, "Adjust HiSpeed for playback speeds lower than x1.0");
+		ToggleSetting(GameConfigKeys::AdjustHiSpeedForHigherPlaybackSpeed, "Adjust HiSpeed for playback speeds higher than x1.0");
+
+
 		SectionHeader("Defaults for Playback and Loop Control");
 		IntSetting(GameConfigKeys::DefaultPlaybackSpeed, "Playback speed (%)", 25, 400);
 


### PR DESCRIPTION
- [x] Support playback speed higher than x1.0
    - It can get higher, but the current upper bound of x4.0 seems to be more than enough
- [x] Add option for auto-adjusting HS depending on playback speed, as suggested in #440 
    - Two settings: one for speeds higher than x1.0 and one for speeds lower than x1.0
    - Default setting for both are `true`
- [ ] Make DSPs respect playback speed
    - Well, currently it almost works in this PR but it doesn't work for retrigger effects because of how it works :(
    - Pre-rendering effects will make it work correctly, so I think that this is not a big problem now.
 
I think that this is enough to close #440, with pre-rendered effects.