### PR TITLE
Fixed volume loading as default value

### DIFF
--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -192,8 +192,10 @@ int32 Application::Run()
 				AddTickable(ss);
 			}
 			else // Start regular game, goto title screen
+			{
 				g_audio->SetGlobalVolume(g_gameConfig.GetFloat(GameConfigKeys::MasterVolume));
 				AddTickable(TitleScreen::Create());
+			}
 		}
 	}
 

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -192,6 +192,7 @@ int32 Application::Run()
 				AddTickable(ss);
 			}
 			else // Start regular game, goto title screen
+				g_audio->SetGlobalVolume(g_gameConfig.GetFloat(GameConfigKeys::MasterVolume));
 				AddTickable(TitleScreen::Create());
 		}
 	}


### PR DESCRIPTION
Fixed bug #646 where volume will revert to default value instead of user set value when loading into title screen for the first time.