### PR TITLE
Fix missing libjpeg in ARM MacOS and set MacOS libraries in CMakeLists.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,12 +94,11 @@ jobs:
             - name: brew update
               run: brew update
             - name: Install packages
-              run: brew install freetype libvorbis sdl2 libpng jpeg libarchive
+              run: brew install freetype libvorbis sdl2 libpng jpeg-turbo libarchive
             - name: cmake
-              run: |
-                eval "$(brew shellenv)"
-                rm ./vcpkg.json
-                cmake . -DLibArchive_LIBRARY=$HOMEBREW_PREFIX/opt/libarchive/lib/libarchive.dylib -DLibArchive_INCLUDE_DIR=$HOMEBREW_PREFIX/opt/libarchive/include -DCMAKE_BUILD_TYPE=Release
+              env:
+                DCMAKE_BUILD_TYPE: Release
+              run: cmake .
             - name: make
               run: make
             - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,29 @@ endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
 
 set(CMAKE_MACOSX_RPATH 1)
 
+# Set library paths for MacOS
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+
+    # Set homebrew's include dir
+    execute_process(
+        COMMAND brew --prefix
+        OUTPUT_VARIABLE HOMEBREW_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    include_directories("${HOMEBREW_PREFIX}/include")
+
+    # Libarchive is shipped as a keg so we must get its path manually
+    execute_process(
+        COMMAND brew --prefix libarchive
+        OUTPUT_VARIABLE LIBARCHIVE_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    set(LibArchive_INCLUDE_DIR "${LIBARCHIVE_PREFIX}/include")
+endif()
+
 # Set folder where to find FindXXX.cmake and
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ To run from Visual Studio, go to Properties for Main > Debugging > Working Direc
 ### macOS:
 0. Clone the project using `git` and then run `git submodule update --init --recursive` to download the required submodules.
 1. Install dependencies
-	* [Homebrew](https://github.com/Homebrew/brew): `brew install cmake freetype libvorbis sdl2 libpng jpeg libarchive libiconv`
-2. Run `mac-cmake.sh` and then `make` from the root of the project.
+	* [Homebrew](https://github.com/Homebrew/brew): `brew install cmake freetype libvorbis sdl2 libpng jpeg-turbo libarchive libiconv`
+2. Run `cmake -DCMAKE_BUILD_TYPE=Release .` and then `make` from the root of the project.
 3. Run the executable made in the 'bin' folder.
 
 ### Embedded (Raspberry Pi):

--- a/mac-cmake.sh
+++ b/mac-cmake.sh
@@ -1,2 +1,0 @@
-eval "$(brew shellenv)"
-cmake . -DLibArchive_LIBRARY=$HOMEBREW_PREFIX/opt/libarchive/lib/libarchive.dylib -DLibArchive_INCLUDE_DIR=$HOMEBREW_PREFIX/opt/libarchive/include -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This PR simplifies the build process for MacOS by setting the library paths in the CMakeLists.txt file, essentially removing the need for `macos-cmake.sh` to exist.

It also fixes #471 and #654, which are related to `libjpeg` being shipped as a keg on ARM MacOS machines, making it so it's not symlinked to homebrew's prefix. This is due to it conflicting with `libjpeg-turbo`, which is (as far as I can tell) faster and ABI compatible, so I took the liberty of replacing it entirely. If this is undesirable, let me know and I can instead have cmake link with the correct path for `libjpeg` as I did with `libarchive`.