### PR TITLE
Update to CPR 1.10.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,7 @@
 [submodule "third_party/cpr"]
 	path = third_party/cpr
 	url = https://github.com/whoshuu/cpr.git
+	branch = 1.10.x
 [submodule "third_party/miniaudio"]
 	path = third_party/miniaudio
 	url = https://github.com/dr-soft/miniaudio.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Root CMake file
 cmake_minimum_required(VERSION 3.12)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "v")
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 #set(VCPKG_CRT_LINKAGE static)
 #set(VCPKG_LIBRARY_LINKAGE static)
 #set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg target triplet (ex. x86-windows)")
@@ -14,6 +16,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build libraries as shared libraries" OFF)
 option(USC_GNU_WERROR "Set Werror for gcc." OFF)
+option(USE_SYSTEM_CPR "Use system CPR" OFF)
 
 project(USC VERSION 0.5.0)
 if(WIN32 AND ${CMAKE_VERSION} VERSION_GREATER "3.12")

--- a/Main/include/LuaRequests.hpp
+++ b/Main/include/LuaRequests.hpp
@@ -5,6 +5,11 @@ struct AsyncRequest
 	struct lua_State* L;
 	cpr::AsyncResponse r;
 	int callback;
+
+	AsyncRequest(struct lua_State* luaState, cpr::AsyncResponse asyncResponse, int callback)
+		: L(luaState), r(std::move(asyncResponse)), callback(callback)
+	{
+	}
 };
 
 struct CompleteRequest

--- a/Main/src/SkinHttp.cpp
+++ b/Main/src/SkinHttp.cpp
@@ -119,10 +119,7 @@ int SkinHttp::lGetAsync(lua_State * L)
 	String url = luaL_checkstring(L, 2);
 	cpr::Header header = HeaderFromLuaTable(L, 3);
 	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
-	AsyncRequest* r = new AsyncRequest();
-	r->r = cpr::GetAsync(cpr::Url{ url }, header);
-	r->callback = callback;
-	r->L = L;
+	AsyncRequest* r = new AsyncRequest(L, cpr::GetAsync(cpr::Url{ url }, header), callback);
 	m_mutex.lock();
 	m_requests.push(r);
 	m_mutex.unlock();
@@ -135,10 +132,7 @@ int SkinHttp::lPostAsync(lua_State * L)
 	String payload = luaL_checkstring(L, 3);
 	cpr::Header header = HeaderFromLuaTable(L, 4);
 	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
-	AsyncRequest* r = new AsyncRequest();
-	r->r = cpr::PostAsync(cpr::Url{ url }, cpr::Body{ *payload }, header);
-	r->callback = callback;
-	r->L = L;
+	AsyncRequest* r = new AsyncRequest(L, cpr::PostAsync(cpr::Url{ url }, cpr::Body{ *payload }, header), callback);
 	m_mutex.lock();
 	m_requests.push(r);
 	m_mutex.unlock();

--- a/Main/src/SkinIR.cpp
+++ b/Main/src/SkinIR.cpp
@@ -141,10 +141,7 @@ SkinIR::~SkinIR()
 int SkinIR::lHeartbeat(struct lua_State* L)
 {
     int callback = luaL_ref(L, LUA_REGISTRYINDEX);
-    AsyncRequest* r = new AsyncRequest();
-    r->r = IR::Heartbeat();
-    r->callback = callback;
-    r->L = L;
+    AsyncRequest* r = new AsyncRequest(L, IR::Heartbeat(), callback);
     m_mutex.lock();
     m_requests.push(r);
     m_mutex.unlock();
@@ -155,10 +152,7 @@ int SkinIR::lChartTracked(struct lua_State* L)
 {
     String hash = luaL_checkstring(L, 2);
 	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
-	AsyncRequest* r = new AsyncRequest();
-	r->r = IR::ChartTracked(hash);
-	r->callback = callback;
-	r->L = L;
+	AsyncRequest* r = new AsyncRequest(L, IR::ChartTracked(hash), callback);
 	m_mutex.lock();
 	m_requests.push(r);
 	m_mutex.unlock();
@@ -169,10 +163,7 @@ int SkinIR::lRecord(struct lua_State* L)
 {
     String hash = luaL_checkstring(L, 2);
 	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
-	AsyncRequest* r = new AsyncRequest();
-	r->r = IR::Record(hash);
-	r->callback = callback;
-	r->L = L;
+	AsyncRequest* r = new AsyncRequest(L, IR::Record(hash), callback);
 	m_mutex.lock();
 	m_requests.push(r);
 	m_mutex.unlock();
@@ -185,10 +176,7 @@ int SkinIR::lLeaderboard(struct lua_State* L)
     String mode = luaL_checkstring(L, 3);
     int n = luaL_checkinteger(L, 4);
 	int callback = luaL_ref(L, LUA_REGISTRYINDEX);
-	AsyncRequest* r = new AsyncRequest();
-	r->r = IR::Leaderboard(hash, mode, n);
-	r->callback = callback;
-	r->L = L;
+	AsyncRequest* r = new AsyncRequest(L, IR::Leaderboard(hash, mode, n), callback);
 	m_mutex.lock();
 	m_requests.push(r);
 	m_mutex.unlock();

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -1,6 +1,7 @@
 /* Main and precompiled header file for Main project*/
 #pragma once
 
+#include "cpr/cpr.h"
 // OpenGL headers
 #include <Graphics/GL.hpp>
 
@@ -57,7 +58,6 @@ using namespace Graphics;
 
 #include "archive.h"
 #include "archive_entry.h"
-#include "cpr/cpr.h"
 #include "discord_rpc.h"
 #include "json.hpp"
 #include "lua.hpp"

--- a/cmake/Modules/FindCPR.cmake
+++ b/cmake/Modules/FindCPR.cmake
@@ -1,0 +1,26 @@
+# - C++ Requests, Curl for People
+# This module is a libcurl wrapper written in modern C++.
+# It provides an easy, intuitive, and efficient interface to
+# a host of networking methods.
+#
+# Finding this module will define the following variables:
+#  CPR_FOUND - True if the core library has been found
+#  CPR_LIBRARIES - Path to the core library archive
+#  CPR_INCLUDE_DIRS - Path to the include directories. Gives access
+#                     to cpr.h, which must be included in every
+#                     file that uses this interface
+
+find_path(CPR_INCLUDE_DIR
+          NAMES cpr.h)
+
+find_library(CPR_LIBRARY
+             NAMES cpr
+             HINTS ${CPR_LIBRARY_ROOT})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CPR REQUIRED_VARS CPR_LIBRARY CPR_INCLUDE_DIR)
+
+if(CPR_FOUND)
+    set(CPR_LIBRARIES ${CPR_LIBRARY})
+    set(CPR_INCLUDE_DIRS ${CPR_INCLUDE_DIR})
+endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,8 +8,12 @@ set(CPR_ENABLE_SSL ON)
 #if(MSVC)
 #    set(CPR_FORCE_USE_SYSTEM_CURL ON) #curl should be available through vcpkg
 #endif(MSVC)
-add_subdirectory(cpr)
-target_include_directories(cpr PUBLIC ${CPR_INCLUDE_DIRS})
+if(USE_SYSTEM_CPR)
+    find_package(cpr REQUIRED)
+else()
+    add_subdirectory(cpr)
+    target_include_directories(cpr PUBLIC ${CPR_INCLUDE_DIRS})
+endif(USE_SYSTEM_CPR)
 
 #discord example program
 option(BUILD_EXAMPLES "Build example apps" OFF)


### PR DESCRIPTION
This PR updates CPR to 1.10.5, as well as adds a CMake option to use the system's CPR instead of the one in submodules. The update allows the game to be compiled with a more recent version of CURL, and the latter is mostly just for convenience when packaging the game for Nix in the near future.