### PR TITLE
Set gameDir to $XDG_DATA_HOME and copy assets on initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Just run 'usc-game' or 'usc-game_Debug' from within the 'bin' folder.
 - `-autoskip` - Skips beginning of song to the first chart note
 - `-debug` - Used to show relevant debug info in game such as hit timings, and scoring debug info
 - `-test` - Runs test scene, for development purposes only
+- `-gamedir` - Sets the directory the game loads assets from. If unset, attempts reading from `$XDG_DATA_HOME/unnamed-sdvx-clone`. Finally, uses the executable directory if all else fails.
 
 ## How to build:
 


### PR DESCRIPTION
This is somewhat of a stopgap solution to the issue of the game failing to launch when `gameDir` is set to a directory without the necessary assets. USC is shipped with the assets needed to at least run, so it can handle this scenario by copying them over to `gameDir` when it is detected to be empty. For my nix package I wrapped the executable with a bash script that does this at runtime, but it makes sense to me for the game to do this.

A more elegant solution would be to separate the specification of asset paths (for example, implementing `-skinsdir`, `-fontsdir`, `-songsdir`, etc), as well as allowing these options to contain multiple paths to be searched, akin to the colon-separated list of directories in `$PATH`. In this scenario, the game could always search the executable path for necessary assets, while still allowing the user to specify additional ones.

Fixes #645