### PR TITLE
Fix LiqidWave 1.5.0 crash when trying to load `commonShared` module

### DIFF
--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -1787,7 +1787,9 @@ void Application::SetScriptPath(lua_State *s)
 {
 	//Set path for 'require' (https://stackoverflow.com/questions/4125971/setting-the-global-lua-path-variable-from-c-c?lq=1)
 	String lua_path = Path::Normalize(
-		Path::Absolute("./skins/" + m_skin + "/scripts/?.lua;") + Path::Absolute("./skins/" + m_skin + "/scripts/?"));
+		Path::Absolute("./skins/" + m_skin + "/scripts/?.lua;") + Path::Absolute("./skins/" + m_skin + "/scripts/?;")) + Path::Absolute("./skins/" + m_skin + "/textures/_shared/scripts/?.lua;") + Path::Absolute("./skins/" + m_skin + "/textures/_shared/scripts/?");
+
+	Logf("Lua path: %s", Logger::Severity::Warning, *lua_path);
 
 	lua_getglobal(s, "package");
 	lua_getfield(s, -1, "path");				// get field "path" from table at top of stack (-1)


### PR DESCRIPTION
No idea why they're attempting to load a script in the textures directory of all places, but whatever.

Fixes #652 