### PR TITLE
Changes for easier Linux packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,3 +165,6 @@ if(MSVC)
     set_target_properties(Tests.Game PROPERTIES FOLDER "Tests")
 
 endif(MSVC)
+
+install(TARGETS usc-game RUNTIME)
+install(DIRECTORY bin/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unnamed-sdvx-clone)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,4 +167,7 @@ if(MSVC)
 endif(MSVC)
 
 install(TARGETS usc-game RUNTIME)
-install(DIRECTORY bin/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unnamed-sdvx-clone)
+install(DIRECTORY bin/audio DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unnamed-sdvx-clone/audio)
+install(DIRECTORY bin/fonts DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unnamed-sdvx-clone/fonts)
+install(DIRECTORY bin/LightPlugins DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unnamed-sdvx-clone/LightPlugins)
+install(DIRECTORY bin/skins DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unnamed-sdvx-clone/skins)

--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -997,7 +997,20 @@ bool Application::m_Init()
 
 		if (xdgDataDir) {
 			String gameDir = Utility::Sprintf("%s%c%s", xdgDataDir, Path::sep, "unnamed-sdvx-clone");
-			auto executableDir = Path::RemoveLast(Path::GetExecutablePath());
+
+			auto gameDataSourceDir = Path::RemoveLast(Path::GetExecutablePath());
+			String xdgDataDirs(std::getenv("XDG_DATA_DIRS"));
+			// iterate over XDG_DATA_DIRS and look for a folder with the correct name
+			// if it exists, overwrite gameDataSourceDir with it and break
+			std::stringstream ss (xdgDataDirs);
+			String dir;
+			while (getline (ss, dir, ':')) {
+				String fullDir = Utility::Sprintf("%s%c%s", dir, Path::sep, "unnamed-sdvx-clone");
+				if (Path::IsDirectory(fullDir)) {
+					gameDataSourceDir = fullDir;
+					break;
+				}
+			}
 
 			Path::gameDir = gameDir;
 
@@ -1014,7 +1027,7 @@ bool Application::m_Init()
 				std::list<String> requiredDirectories = { "skins", "fonts", "audio", "LightPlugins" };
 
 				for (String directory : requiredDirectories) {
-					auto sourceDir = Utility::Sprintf("%s%c%s", executableDir, Path::sep, directory);
+					auto sourceDir = Utility::Sprintf("%s%c%s", gameDataSourceDir, Path::sep, directory);
 					auto destDir = Path::Absolute(directory);
 
 					response = Path::CopyDir(sourceDir, destDir);
@@ -1026,7 +1039,7 @@ bool Application::m_Init()
 				}
 
 			} else {
-				Logf("Setting gamedir to $XDG_DATA_HOME (%s). If data is missing, you can either copy the game data in %s to that directory, unset the $XDG_DATA_HOME variable or run the game with -gamedir=%s", Logger::Severity::Warning, *gameDir, *executableDir, *executableDir);
+				Logf("Setting gamedir to $XDG_DATA_HOME (%s). If data is missing, you can either copy the game data in %s to that directory, unset the $XDG_DATA_HOME variable or run the game with -gamedir=%s", Logger::Severity::Warning, *gameDir, *gameDataSourceDir, *gameDataSourceDir);
 			}
 		}
 	}


### PR DESCRIPTION
Building on #645, I wanted to make things easier for packaging the application for things like flatpak.

- Add install targets to cmake file. This allows packaging tools to know where to put the compiled binary and game files. This shouldn't affect much since it should only perform operations when explicitly running `make install`.
- Added search against `XDG_DATA_DIRS` for assets. This is usually set by the distro or packaging system and defines where a package's assets should be located.

If you're okay with merging these changes,  I do have a flatpak manifest that is ready to go if you're interested in submitting to [flathub](https://flathub.org/)!

Let me know if you have any questions, or would like any changes. Thanks!