### PR TITLE
Improvements to appimage desktop + appstream data

### DIFF
--- a/appimage/me.drewol.Unnamed-SDVX-Clone.metainfo.xml
+++ b/appimage/me.drewol.Unnamed-SDVX-Clone.metainfo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>me.drewol.Unnamed-SDVX-Clone</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Unnamed SDVX Clone</name>
+  <summary>A game based on KShootMANIA &amp; SDVX</summary>
+  <description>
+    <p>
+        A game based on K-Shoot MANIA and Sound Voltex
+    </p>
+    <ul>
+      <li>Completely skinnable GUI</li>
+      <li>OGG/MP3 Audio streaming (with preloading for gameplay performance)</li>
+      <li>Uses KShoot charts (<code>*.ksh</code>) (1.6 supported)</li>
+      <li>Functional gameplay and scoring</li>
+      <li>Saving of local scores</li>
+      <li>Autoplay</li>
+      <li>Basic controller support</li>
+      <li>Changeable settings and key mapping</li>
+      <li>Supports new sound FX method (real-time sound FX) and old sound FX method (separate NOFX &amp; sound effected music files)</li>
+      <li>Song database cache for near-instant game startup (sqlite3)</li>
+      <li>Song database searching</li>
+      <li>Linux/Windows/macOS support</li>
+      <li>Song select UI/Controls to change HiSpeed and other game settings</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">me.drewol.Unnamed-SDVX-Clone.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://i3.ytimg.com/vi/1GCraT0ktrc/maxresdefault.jpg</image>
+      <caption>Gameplay screenshot showcasing default colors</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://i3.ytimg.com/vi/kP1tD6bkPa4/maxresdefault.jpg</image>
+      <caption>Gameplay screenshot showcasing a vertical resolution</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://i3.ytimg.com/vi/_g9Xv5RDwa0/maxresdefault.jpg</image>
+      <caption>Gameplay screenshot showcasing custom laser colors</caption>
+    </screenshot>
+  </screenshots>
+  <url type="bugtracker">https://github.com/Drewol/unnamed-sdvx-clone/issues</url>
+  <url type="homepage">https://github.com/Drewol/unnamed-sdvx-clone</url>
+  <developer id="me.drewol">
+    <name>Drewol</name>
+  </developer>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.5.0" date="2021-06-13">
+      <description>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.5.0</description>
+    </release>
+  </releases>
+</component>

--- a/appimage/usc-game.desktop
+++ b/appimage/usc-game.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
-Categories=Game;
 Type=Application
-Name=usc-game
+Name=Unnamed SDVX Clone
+Comment=A game based on K-Shoot MANIA and Sound Voltex
 Exec=usc-game
 Icon=usc-game
+Keywords=sdvx;sound voltex;k-shoot mania;kshootmania
+Categories=Game


### PR DESCRIPTION
Added some appstream metadata, as well as some improvements to the .desktop file to make it easier to search for.

I'm not sure how the appimage is currently built, but if you're interested in including the new metadata, you can find how to integrate it here: https://docs.appimage.org/packaging-guide/optional/appstream.html