### PR TITLE
Add rapidjson target to fix MSVC build

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -44,6 +44,10 @@ add_library(sqlite3
 )
 target_include_directories(sqlite3 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sqlite3)
 
+#rapidjson -- add as interface library to prevent building it
+add_library(rapidjson INTERFACE)
+target_include_directories(rapidjson INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rapidjson)
+
 #minimp3
 add_library(minimp3
     minimp3/minimp3.c


### PR DESCRIPTION
This PR is a followup to PR #699 where rapidjson was added as a new submodule, but not declared as a target in the third party CMakeLists file.

This did not cause any issues on Linux, but with MSVC the call to `set_target_properties` fails since `rapidjson` is not a target.

This PR adds `rapidjson` as a target to fix that issue. Since we do not need to build rapidjson itself, it has been added as an interface library.

This has not been tested on a Windows setup, since I do not have one.