### PR TITLE
Prevent crash when XDG_DATA_DIRS is unset

### DIFF
--- a/Main/src/Application.cpp
+++ b/Main/src/Application.cpp
@@ -999,16 +999,20 @@ bool Application::m_Init()
 			String gameDir = Utility::Sprintf("%s%c%s", xdgDataDir, Path::sep, "unnamed-sdvx-clone");
 
 			auto gameDataSourceDir = Path::RemoveLast(Path::GetExecutablePath());
-			String xdgDataDirs(std::getenv("XDG_DATA_DIRS"));
-			// iterate over XDG_DATA_DIRS and look for a folder with the correct name
-			// if it exists, overwrite gameDataSourceDir with it and break
-			std::stringstream ss (xdgDataDirs);
-			String dir;
-			while (getline (ss, dir, ':')) {
-				String fullDir = Utility::Sprintf("%s%c%s", dir, Path::sep, "unnamed-sdvx-clone");
-				if (Path::IsDirectory(fullDir)) {
-					gameDataSourceDir = fullDir;
-					break;
+			if (const char *xdgDataDirs = std::getenv("XDG_DATA_DIRS")) {
+				String xdgDataDirsStr(xdgDataDirs);
+				// iterate over XDG_DATA_DIRS and look for a folder with the correct name
+				// if it exists, overwrite gameDataSourceDir with it and break
+				if (!xdgDataDirsStr.empty()) {
+					std::stringstream ss (xdgDataDirsStr);
+					String dir;
+					while (getline (ss, dir, ':')) {
+						String fullDir = Utility::Sprintf("%s%c%s", dir, Path::sep, "unnamed-sdvx-clone");
+						if (Path::IsDirectory(fullDir)) {
+							gameDataSourceDir = fullDir;
+							break;
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
When attempting to construct xdgDataDirs, if `XDG_DATA_DIRS` is unset, then `std::getenv` returns NULL, and the string construction fails with:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
[1]    1662356 IOT instruction (core dumped)  ./bin/usc-game
```