### PR TITLE
Fix crash by adding virtual destructor to SettingsPage base class

### DIFF
--- a/Main/include/SettingsPage.hpp
+++ b/Main/include/SettingsPage.hpp
@@ -3,6 +3,8 @@
 
 class SettingsPage
 {
+public:
+	virtual ~SettingsPage() = default;
 protected:
 	SettingsPage(nk_context* nctx, const std::string_view& name) : m_nctx(nctx), m_name(name) {}
 


### PR DESCRIPTION
- Fixes #539
- Fixes #491