### PR TITLE
fix: add error check to Path::Normalize() and explicitely skip normalization in that case

### DIFF
--- a/Shared/src/Unix/Path.cpp
+++ b/Shared/src/Unix/Path.cpp
@@ -136,7 +136,7 @@ String Path::Normalize(const String& path)
 
     char *ret = realpath(*path, out);
     if (ret == 0) { // error occurred
-		Logf("Path::Normalize: realpath failed for path: %s", Logger::Severity::Warning, *path);
+		Logf("Path::Normalize: realpath failed for path %s: %s", Logger::Severity::Warning, *path, std::strerror(errno));
         return path;
     }
 

--- a/Shared/src/Unix/Path.cpp
+++ b/Shared/src/Unix/Path.cpp
@@ -137,7 +137,7 @@ String Path::Normalize(const String& path)
     char *ret = realpath(*path, out);
     if (ret == 0) { // error occurred
 		Logf("Path::Normalize: realpath failed for path %s: %s", Logger::Severity::Warning, *path, std::strerror(errno));
-        return path;
+        return path; // skip normalization
     }
 
 	for(uint32 i = 0; i < MAX_PATH; i++)

--- a/Shared/src/Unix/Path.cpp
+++ b/Shared/src/Unix/Path.cpp
@@ -133,14 +133,20 @@ bool Path::FileExists(const String& path)
 String Path::Normalize(const String& path)
 {
 	char out[MAX_PATH];
-	realpath(*path, out);
+
+    char *ret = realpath(*path, out);
+    if (ret == 0) { // error occurred
+		Logf("Path::Normalize: realpath failed for path: %s", Logger::Severity::Warning, *path);
+        return path;
+    }
+
 	for(uint32 i = 0; i < MAX_PATH; i++)
 	{
 		if(out[i] == '\\')
 			out[i] = sep;
-		if (out[i] == '\0')
-			return out;
+		if (out[i] == '\0') break;
 	}
+
 	return out;
 }
 bool Path::IsAbsolute(const String& path)

--- a/Shared/src/Unix/Path.cpp
+++ b/Shared/src/Unix/Path.cpp
@@ -17,6 +17,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <filesystem>
 // Convenience
 #define MAX_PATH PATH_MAX
 
@@ -132,13 +133,8 @@ bool Path::FileExists(const String& path)
 }
 String Path::Normalize(const String& path)
 {
-	char out[MAX_PATH];
-
-    char *ret = realpath(*path, out);
-    if (ret == 0) { // error occurred
-		Logf("Path::Normalize: realpath failed for path %s: %s", Logger::Severity::Warning, *path, std::strerror(errno));
-        return path; // skip normalization
-    }
+    auto s = std::filesystem::weakly_canonical(*path).string();
+	char *out = s.data();
 
 	for(uint32 i = 0; i < MAX_PATH; i++)
 	{


### PR DESCRIPTION
According to the [man](https://www.man7.org/linux/man-pages/man3/realpath.3.html), `realpath()` needs to be given an existing folder/file path, or it will fail with `ENOENT`, and the value `resolved_path` is undefined by the standard.

It seems like in these cases, regular C++ implementations set `resolved_path` to the input argument (and thus skip any normalization). However, this is not always the case, and emscripten for example will set `resolved_path` to garbage data.

This PR clarifies the behaviour of the function, and make it work with the emscripten toolchain

Note: the problematic instance is the normalization of menu_click, which is done without an extension, and thus with a non-existent filepath