### PR TITLE
Fix mouse input in offset calibration screen

### DIFF
--- a/Main/include/CalibrationScreen.hpp
+++ b/Main/include/CalibrationScreen.hpp
@@ -38,8 +38,10 @@ private:
 	int32 m_hitcount = 0;
 	bool m_autoCalibrate = false;
 	bool m_hasRenderedOnce = false;
+	std::queue<SDL_Event> m_eventQueue;
 
 	void m_OnButtonPressed(Input::Button buttonCode, int32 delta);
 	void m_OnButtonReleased(Input::Button buttonCode, int32 delta);
+	void m_OnSDLEvent(SDL_Event evt);
 	float m_average(const Vector<int>& values);
 };

--- a/Main/src/CalibrationScreen.cpp
+++ b/Main/src/CalibrationScreen.cpp
@@ -15,6 +15,7 @@ CalibrationScreen::~CalibrationScreen()
 {
 	g_input.OnButtonPressed.RemoveAll(this);
 	g_input.OnButtonReleased.RemoveAll(this);
+	g_gameWindow->OnAnyEvent.RemoveAll(this);
 }
 
 bool CalibrationScreen::AsyncLoad()
@@ -60,6 +61,11 @@ bool CalibrationScreen::AsyncFinalize()
 
 	g_input.OnButtonPressed.Add(this, &CalibrationScreen::m_OnButtonPressed);
 	g_input.OnButtonReleased.Add(this, &CalibrationScreen::m_OnButtonReleased);
+
+	// The settings screen that owns m_ctx is suspended while this screen is
+	// active, so its nuklear input pump is not running and this screen has to
+	// feed the mouse/keyboard events to nuklear itself.
+	g_gameWindow->OnAnyEvent.Add(this, &CalibrationScreen::m_OnSDLEvent);
 
 	return m_track.AsyncFinalize();
 }
@@ -218,6 +224,14 @@ void CalibrationScreen::Render(float deltaTime)
 
 void CalibrationScreen::Tick(float deltaTime)
 {
+	nk_input_begin(m_ctx);
+	while (!m_eventQueue.empty())
+	{
+		nk_sdl_handle_event(&m_eventQueue.front());
+		m_eventQueue.pop();
+	}
+	nk_input_end(m_ctx);
+
 	m_lastTime = 2000 + (m_timer.Milliseconds() % 2000);
 	m_lastTime -= m_audioOffset;
 
@@ -274,6 +288,11 @@ void CalibrationScreen::m_OnButtonPressed(Input::Button buttonCode, int32 delta)
 		}
 
 	}
+}
+
+void CalibrationScreen::m_OnSDLEvent(SDL_Event evt)
+{
+	m_eventQueue.push(evt);
 }
 
 void CalibrationScreen::m_OnButtonReleased(Input::Button buttonCode, int32 delta)

--- a/Main/src/GuiUtils.cpp
+++ b/Main/src/GuiUtils.cpp
@@ -12,7 +12,9 @@ BasicNuklearGui::~BasicNuklearGui()
 
 void BasicNuklearGui::UpdateNuklearInput(SDL_Event evt)
 {
-	if (!m_isOpen)
+	// While suspended Tick doesn't drain the queue, so queueing here would
+	// replay every buffered event into nuklear on restore.
+	if (!m_isOpen || (m_canSuspend && IsSuspended()))
 		return;
 	m_eventQueue.push(evt);
 }


### PR DESCRIPTION
Fixes #617

The offset calibration screen draws its nuklear windows with the settings screen's nk_context, but the only place SDL events are pumped into nuklear is BasicNuklearGui::Tick, which returns early while suspended. Since the settings screen is suspended while the calibration screen is on top, no mouse or keyboard events ever reached nuklear there, so the calibration GUI ignored all mouse clicks. Before the tabbed settings refactor the old settings screen pumped its event queue unconditionally, which is why this used to work.

This PR makes CalibrationScreen queue window events and pump them into nuklear in its own Tick, mirroring what BasicNuklearGui does.

It also stops a suspended BasicNuklearGui from buffering events while its Tick is not draining the queue. Without this, every click made during calibration piles up in the suspended settings screen's queue and replays into the settings GUI the moment you return to it. ChatOverlay is unaffected since it sets m_canSuspend = false.